### PR TITLE
Fix `SyntaxError: invalid syntax`

### DIFF
--- a/src/chtools/monrun_checks/ch_tls.py
+++ b/src/chtools/monrun_checks/ch_tls.py
@@ -36,7 +36,7 @@ def tls_command(crit: int, warn: int, ports: Optional[str]) -> Result:
 
     for port in get_ports(ports):
         try:
-            addr: Tuple[str, int] = socket.getfqdn(), int(port)
+            addr: Tuple[str, int] = (socket.getfqdn(), int(port))
             cert: str = ssl.get_server_certificate(addr)
             certificate, days_to_expire = load_certificate_info(str.encode(cert))
         except Exception as e:


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/usr/bin/ch-monitoring", line 5, in <module>
    from chtools.monrun_checks.main import main
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/chtools/monrun_checks/main.py", line 30, in <module>
    from chtools.monrun_checks.ch_tls import tls_command  # noqa: E402
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/chtools/monrun_checks/ch_tls.py", line 39
    addr: Tuple[str, int] = socket.getfqdn(), int(port)
                                            ^
SyntaxError: invalid syntax
```