### PR TITLE
Add workflow to link startrek ticket

### DIFF
--- a/.github/workflows/link_startrek.yml
+++ b/.github/workflows/link_startrek.yml
@@ -1,0 +1,26 @@
+name: startrek link
+
+on:
+  pull_request: { branches: [main] }
+
+jobs:
+  link_with_startrek:    
+    runs-on: ubuntu-latest
+    steps:
+      - name: parse_branch_name
+        id: parse_branch_name
+        run: |
+          if [[ ${{ github.head_ref }} =~ ^([A-Za-z]+\-[0-9]+).*$ ]]; then
+              echo issue_number="${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT          
+          fi
+      - name: link_issue
+        if: steps.parse_branch_name.outputs.issue_number
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://st-api.yandex-team.ru/v2/issues/${{ steps.parse_branch_name.outputs.issue_number }}'
+          method: 'LINK'
+          customHeaders: >
+            {
+               "Link": "<${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}>; rel=\"relates\"",
+               "Authorization": "OAuth ${{ secrets.OAUTH_STARTREK_TOKEN }}"
+            }

--- a/.github/workflows/link_startrek.yml
+++ b/.github/workflows/link_startrek.yml
@@ -24,3 +24,4 @@ jobs:
                "Link": "<${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}>; rel=\"relates\"",
                "Authorization": "OAuth ${{ secrets.OAUTH_STARTREK_TOKEN }}"
             }
+          ignoreStatusCodes: '409'


### PR DESCRIPTION
Add workflow to link with startrek issue ticket. The issue name is parsed from a branch name.
Example of an appropriate branch name `MDB-24383_link_pull_request_with_startrek`