### PR TITLE
Disable fail-fast for tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,6 +47,7 @@ jobs:
   build:
     needs: lint
     strategy:
+      fail-fast: false
       matrix:
         target:
           - {python: "3.6.15", ubuntu: "20.04"}


### PR DESCRIPTION
To avoid automatic cancellation of non-failed jobs. If it's failed only one job, it allows to re-run only this failed job and do not re-run all jobs in workflow.  