### PR TITLE
Fixed TypeError in get_replication_queue_tasks

### DIFF
--- a/ch_tools/chadmin/cli/replication_queue_group.py
+++ b/ch_tools/chadmin/cli/replication_queue_group.py
@@ -47,6 +47,7 @@ def replication_queue_group():
 )
 @option(
     "--type",
+    "type_",
     help="Filter replication queue tasks to output by the specified type."
     " Multiple values can be specified through a comma.",
 )


### PR DESCRIPTION
Fix for the following error:
```
# chadmin replication-queue list -l 5
Traceback (most recent call last):
  File "/usr/bin/chadmin", line 8, in <module>
    sys.exit(main())
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/ch_tools/chadmin/chadmin_cli.py", line 154, in main
    cli.main()
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/yandex/ch-tools/lib/python3.6/site-packages/ch_tools/chadmin/cli/replication_queue_group.py", line 79, in list_replication_queue_command
    print(get_replication_queue_tasks(ctx, **kwargs, format_="Vertical"))
TypeError: get_replication_queue_tasks() got an unexpected keyword argument 'type'
```