### PR TITLE
Add old packaging names to Conflicts clause in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,3 +22,4 @@ Package: clickhouse-tools
 Architecture: any
 Description: A set of tools for administration and diagnostics of ClickHouse DBMS.
 Replaces: mdb-ch-tools, ch-tools
+Conflicts: mdb-ch-tools, ch-tools


### PR DESCRIPTION
According to that https://debian-handbook.info/browse/stable/sect.package-meta-information.html#id-1.8.6.7.13.2
and https://www.debian.org/doc/debian-policy/ch-relationships.html#replacing-whole-packages-forcing-their-removal