### PR TITLE
Fix case when directory is removed while S3 metadata is collecting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ pylint: install-deps
 
 .PHONY: mypy
 mypy: install-deps
-	$(POETRY) run mypy $(SRC_DIR) $(TESTS_DIR)
+	$(POETRY) run mypy --python-version=3.6 $(SRC_DIR) $(TESTS_DIR)
 
 .PHONY: format
 format: install-deps

--- a/ch_tools/chadmin/internal/object_storage/collect_metadata.py
+++ b/ch_tools/chadmin/internal/object_storage/collect_metadata.py
@@ -1,6 +1,6 @@
 import logging
+import os
 from collections import defaultdict
-from itertools import chain
 from pathlib import Path
 from typing import Dict, Iterable
 
@@ -15,24 +15,29 @@ def collect_metadata(paths: Iterable[Path]) -> ObjectKeyToMetadata:
     """
     Return dictionary of parsed metadata from local disk with access by S3 object key.
     """
-    logging.debug("Metadata collecting...")
+    logging.debug("Metadata collecting for paths: %s", str(paths))
     res: ObjectKeyToMetadata = defaultdict(dict)
 
-    for path in paths:
-        if not path.exists():
-            logging.debug("Metadata path `%s` is not exist", path)
-
-    for file in chain.from_iterable(path.rglob("*") for path in paths if path.exists()):
-        if not file.is_file():
+    for top_dir in paths:
+        if not top_dir.exists():
+            logging.debug("Metadata top_dir `%s` is not exist", top_dir)
             continue
 
-        try:
-            metadata = S3ObjectLocalMetaData.from_file(file)
-        except Exception:
-            continue
+        for dirpath, _dirnames, filenames in os.walk(str(top_dir)):
+            for filename in filenames:
+                file_path = Path(dirpath) / filename
+                try:
+                    metadata = S3ObjectLocalMetaData.from_file(file_path)
+                except Exception as error:
+                    logging.debug(
+                        "Skip error occured while reading metadata from `%s`: %s",
+                        file_path,
+                        repr(error),
+                    )
+                    continue
 
-        for obj in metadata.objects:
-            res[obj.key][file] = metadata
+                for obj in metadata.objects:
+                    res[obj.key][file_path] = metadata
 
     logging.debug("Metadata collected")
     return res

--- a/ch_tools/chadmin/internal/object_storage/s3_disk_configuration.py
+++ b/ch_tools/chadmin/internal/object_storage/s3_disk_configuration.py
@@ -44,13 +44,13 @@ class S3DiskConfiguration:
 
 def _parse_endpoint(endpoint: str) -> tuple:
     """
-    Parse both virtual and path style S3 url.
+    Parse both virtual and path style S3 endpoints url.
     """
     url = urlparse(endpoint)
     if url.hostname is None:
         raise ValueError(f"Incorrect endpoint format {endpoint}")
 
-    path = url.path.removeprefix("/")
+    path = url.path[1:] if url.path.startswith("/") else url.path
     if url.hostname.startswith(BUCKET_NAME_PREFIX):
         # virtual addressing style
         bucket_name, host = url.hostname.split(".", maxsplit=1)


### PR DESCRIPTION
When directory is removed while S3 metdata is collecting for `chadmin object-storage` group of commands than we can get the following error:
```
  File "cloud/mdb/clickhouse/tools/src/chtools/chadmin/internal/object_storage/collect_metadata.py", line 24, in collect_metadata
    for file in chain.from_iterable(path.rglob('*') for path in paths if path.exists()):
  File "contrib/tools/python3/src/Lib/pathlib.py", line 968, in rglob
    for p in selector.select_from(self):
  File "contrib/tools/python3/src/Lib/pathlib.py", line 408, in _select_from
    for p in successor_select(starting_point, is_dir, exists, scandir):
  File "contrib/tools/python3/src/Lib/pathlib.py", line 355, in _select_from
    with scandir(parent_path) as scandir_it:
         ^^^^^^^^^^^^^^^^^^^^
  File "contrib/tools/python3/src/Lib/pathlib.py", line 938, in _scandir
    return os.scandir(self)
           ^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/clickhouse/disks/object_storage/store/943/9439ab61-2151-4ee6-8abe-0b0190ed3228/1687593600_3881_5629_5'
```