### PR TITLE
Make ch_tools/__init__.py fully generated and add missing dependencies between makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/reports/
 tests/staging/
 venv/
 version.txt
+ch_tools/__init__.py

--- a/ch_tools/__init__.py
+++ b/ch_tools/__init__.py
@@ -1,3 +1,0 @@
-"""A set of tools for administration and diagnostics of ClickHouse DBMS."""
-
-__version__ = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ packages = [
     { include = "ch_tools" },
 ]
 
-include = ["resources/"]
+include = [
+    "ch_tools/__init__.py",  # avoid exclusion of generated file listed in .gitignore
+    "resources/",
+]
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
The number of dirty files after running `make test-integration` is reduced to just `pyproject.toml`.
```
$ gmake test-integration
$ git status
On branch makefile_deps
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   pyproject.toml
```
