### PR TITLE
monrun ch-backup check: replace datetime.strptime to dateutil.parse to parse timezone with column

### DIFF
--- a/ch_tools/monrun_checks/ch_backup.py
+++ b/ch_tools/monrun_checks/ch_backup.py
@@ -4,11 +4,11 @@ Check ClickHouse backups: its state, age and count.
 
 import json
 from datetime import datetime, timedelta, timezone
-from dateutil import parse as dateutil_parse
 from os.path import exists
 from typing import Dict, List, Optional
 
 import click
+from dateutil.parser import parse as dateutil_parse
 
 from ch_tools.common.backup import BackupConfig, get_backups
 from ch_tools.common.clickhouse.client import ClickhouseClient


### PR DESCRIPTION
Fix datetime parse exception on restored cluster:
`time data '2023-08-29T02:43:53.953465+03:00' does not match format '%Y-%m-%dT%H:%M:%S.%f%z'`
