### PR TITLE
Fix user checking

### DIFF
--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -1,4 +1,3 @@
-import getpass
 import logging
 import os
 import pwd
@@ -154,9 +153,11 @@ def main():
 
 
 def check_current_user():
-    user = getpass.getuser()
+    euid = os.geteuid()
+    user = pwd.getpwuid(euid).pw_name
+
     if user != DEFAULT_USER:
-        if os.geteuid() != 0:
+        if euid != 0:
             print(f"Wrong current user: {user}", file=sys.stderr)
             sys.exit(1)
         else:


### PR DESCRIPTION
After running highstate on CH host via `pssh-sh` state running `/usr/local/yandex/ch_wait_started.py` hangs up to timeout.
Because such a command does not work
```
sudo salt-call cmd.run "timeout 5 sudo -u monitor /usr/bin/ch-monitoring ping"
[ERROR   ] Command 'timeout' failed with return code: 1
[ERROR   ] stdout: Wrong current user: root
[ERROR   ] retcode: 1
[ERROR   ] Command 'timeout' failed with return code: 1
[ERROR   ] output: Wrong current user: root
```
Or without `salt-call`
```
sudo timeout 5 sudo -u monitor /usr/bin/ch-monitoring ping
Wrong current user: root
```

The point is that `getpass.getuser()` function relies on environment variables (`LOGNAME`, `USER`, etc) but nested sudo  does not update it:
```
$ sudo -u monitor printenv USER
monitor
$ sudo sudo -u monitor printenv USER
root
$ sudo -u alexfvk sudo -u monitor printenv USER
alexfvk
```
I propose to extract name for effective uid and not to rely on environment variables.
After fix:
```
$ timeout 5 sudo /usr/bin/ch-monitoring ping
0;OK
$ timeout 5 sudo -u monitor /usr/bin/ch-monitoring ping
0;OK
$ sudo timeout 5 sudo -u monitor /usr/bin/ch-monitoring ping
0;OK
$ sudo -u alexfvk timeout 5 sudo -u monitor /usr/bin/ch-monitoring ping
0;OK
$ sudo -u alexfvk timeout 5 sudo /usr/bin/ch-monitoring ping
0;OK
$ sudo -u alexfvk timeout 5 /usr/bin/ch-monitoring ping
Wrong current user: alexfvk
$ timeout 5 /usr/bin/ch-monitoring ping
Wrong current user: alexfvk
```