### PR TITLE
Fixed TypeError in "ch-monitoring backup" command

### DIFF
--- a/ch_tools/common/cli/context_settings.py
+++ b/ch_tools/common/cli/context_settings.py
@@ -10,6 +10,7 @@ CONTEXT_SETTINGS = Context.settings(
     align_option_groups=False,
     align_sections=True,
     show_constraints=True,
+    show_default=True,
     formatter_settings=HelpFormatter.settings(
         theme=HelpTheme.light(),
     ),

--- a/ch_tools/monrun_checks/ch_backup.py
+++ b/ch_tools/monrun_checks/ch_backup.py
@@ -11,6 +11,7 @@ import click
 from dateutil.parser import parse as dateutil_parse
 
 from ch_tools.common.backup import BackupConfig, get_backups
+from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.client import ClickhouseClient
 from ch_tools.common.dbaas import DbaasConfig
 from ch_tools.monrun_checks.exceptions import die
@@ -24,13 +25,14 @@ FAILED_PARTS_THRESHOLD = 10
     "--critical-failed",
     "crit_failed",
     default=3,
-    help="Critical threshold for failed backupd.",
+    help="Critical threshold for failed backups.",
 )
 @click.option(
     "--critical-absent",
     "crit_absent",
-    default=timedelta(days=2),
-    help="Critical threshold for absent backupd",
+    default="2d",
+    type=TimeSpanParamType(),
+    help="Critical threshold for absent backups.",
 )
 def backup_command(crit_failed, crit_absent):
     """
@@ -92,7 +94,7 @@ def check_last_backup_not_failed(backups, crit=3):
     die(status, message)
 
 
-def check_backup_age(ch_client, backups, age_threshold=timedelta(days=1), crit=None):
+def check_backup_age(ch_client, backups, *, age_threshold=timedelta(days=1), crit=None):
     """
     Check that the last backup is not too old.
     """


### PR DESCRIPTION
```
2023-09-05 17:35:36,155 518168 [ERROR] backup: Got error TypeError("'>=' not supported between instances of 'datetime.timedelta' and 'str'",)
Traceback (most recent call last):
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks/main.py", line 77, in callback_wrapper
    result = ctx.invoke(cmd_callback, *args, **kwargs)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks/ch_backup.py", line 53, in backup_command
    check_backup_age(ch_client, backups, crit=crit_absent)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks/ch_backup.py", line 123, in check_backup_age
    if crit is not None and uptime >= crit and backup_age >= crit:
TypeError: '>=' not supported between instances of 'datetime.timedelta' and 'str'
```