### PR TITLE
Move zookeeper.py in chadmin

### DIFF
--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -7,7 +7,7 @@ from kazoo.security import make_digest_acl
 from ch_tools.chadmin.internal.table_replica import get_table_replica
 from ch_tools.chadmin.internal.zookeeper import (
     check_zk_node,
-    clean_zk_nodes,
+    clean_zk_metadata_for_hosts,
     create_zk_nodes,
     delete_zk_nodes,
     get_zk_node,
@@ -42,8 +42,19 @@ from ch_tools.common.cli.parameters import ListParamType, StringParamType
     help="Do not try to get parameters from clickhouse config.xml.",
     default=False,
 )
+@option(
+    "-c",
+    "--chroot",
+    "zk_root_path",
+    type=str,
+    help="Cluster ZooKeeper root path. If not specified,the root path will be used.",
+    required=False,
+    default="/",
+)
 @pass_context
-def zookeeper_group(ctx, host, port, timeout, zkcli_identity, no_chroot, no_ch_config):
+def zookeeper_group(
+    ctx, host, port, timeout, zkcli_identity, no_chroot, no_ch_config, zk_root_path
+):
     """ZooKeeper management commands.
 
     ZooKeeper command runs client which connects to Zookeeper node.
@@ -58,6 +69,7 @@ def zookeeper_group(ctx, host, port, timeout, zkcli_identity, no_chroot, no_ch_c
         "zkcli_identity": zkcli_identity,
         "no_chroot": no_chroot,
         "no_ch_config": no_ch_config,
+        "zk_root_path": zk_root_path,
     }
 
 
@@ -269,18 +281,11 @@ def delete_ddl_task_command(ctx, tasks):
     delete_zk_nodes(ctx, paths)
 
 
-@zookeeper_group.command(name="clickhouse-hosts-cleanup")
-@option("-f", "--fqdn", type=str, help="Removed FQDNs, comma separated", required=True)
-@option(
-    "-c",
-    "--root",
-    "zk_root_path",
-    type=str,
-    help="Cluster ZooKeeper root path. If not specified,the root path will be used.",
-    required=False,
-    default="/",
+@zookeeper_group.command(
+    name="cleanup-removed-hosts-metadata",
+    help="Remove metadata from Zookeeper for specified hosts.",
 )
+@argument("fqdn", type=ListParamType())
 @pass_context
-def clickhouse_hosts_command(ctx, fqdn, zk_root_path):
-    hosts = fqdn.split(",")
-    clean_zk_nodes(ctx, zk_root_path, hosts)
+def clickhouse_hosts_command(ctx, fqdn):
+    clean_zk_metadata_for_hosts(ctx, fqdn)

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -49,7 +49,6 @@ from ch_tools.common.cli.parameters import ListParamType, StringParamType
     type=str,
     help="Cluster ZooKeeper root path. If not specified,the root path will be used.",
     required=False,
-    default="/",
 )
 @pass_context
 def zookeeper_group(

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -7,6 +7,7 @@ from kazoo.security import make_digest_acl
 from ch_tools.chadmin.internal.table_replica import get_table_replica
 from ch_tools.chadmin.internal.zookeeper import (
     check_zk_node,
+    clean_zk_nodes,
     create_zk_nodes,
     delete_zk_nodes,
     get_zk_node,
@@ -266,3 +267,20 @@ def delete_ddl_task_command(ctx, tasks):
     """
     paths = [f"/clickhouse/task_queue/ddl/{task}" for task in tasks]
     delete_zk_nodes(ctx, paths)
+
+
+@zookeeper_group.command(name="clickhouse-hosts-cleanup")
+@option("-f", "--fqdn", type=str, help="Removed FQDNs, comma separated", required=True)
+@option(
+    "-c",
+    "--root",
+    "zk_root_path",
+    type=str,
+    help="Cluster ZooKeeper root path. If not specified,the root path will be used.",
+    required=False,
+    default="/",
+)
+@pass_context
+def clickhouse_hosts_command(ctx, fqdn, zk_root_path):
+    hosts = fqdn.split(",")
+    clean_zk_nodes(ctx, zk_root_path, hosts)

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -272,7 +272,7 @@ def _get_zk_client(ctx):
             f'{host if host else node["host"]}:{port if port else node["port"]}'
             for node in zk_config.nodes
         )
-        if not zk_root_path:
+        if zk_root_path:
             connect_str += zk_root_path
         elif not no_chroot and zk_config.root is not None:
             connect_str += zk_config.root

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -1,4 +1,4 @@
-Feature: keeper-monitoring tool
+Feature: chadmin zookeeper commands.
 
   Background:
     Given default configuration

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -1,0 +1,43 @@
+Feature: keeper-monitoring tool
+
+  Background:
+    Given default configuration
+    And a working s3
+    And a working zookeeper
+    And a working clickhouse on clickhouse01
+
+
+  Scenario: Cleanup all hosts
+    When we execute chadmin create zk nodes on zookeeper01
+    """
+    /test/write_sli_part/shard1/replicas/host1.net
+    /test/write_sli_part/shard1/replicas/host2.net
+    /test/read_sli_part/shard1/replicas/host1.net
+    /test/read_sli_part/shard1/replicas/host2.net
+    /test/write_sli_part/shard1/log
+    """
+    And we do hosts cleanup on zookeeper01 with fqdn host1.net,host2.net and zk root /test
+
+    Then the list of children on zookeeper01 for zk node /test/write_sli_part are empty
+    And the list of children on zookeeper01 for zk node /test/read_sli_part are empty
+
+  Scenario: Cleanup single host 
+    When we execute chadmin create zk nodes on zookeeper01
+    """
+    /test/write_sli_part/shard1/replicas/host1.net
+    /test/write_sli_part/shard1/replicas/host2.net
+    /test/read_sli_part/shard1/replicas/host1.net
+    /test/read_sli_part/shard1/replicas/host2.net
+    /test/write_sli_part/shard1/log
+    """
+    And we do hosts cleanup on zookeeper01 with fqdn host1.net and zk root /test
+    
+
+    Then the list of children on zookeeper01 for zk node /test/write_sli_part/shard1/replicas/ are equal to
+    """
+    /test/write_sli_part/shard1/replicas/host2.net
+    """
+    And the list of children on zookeeper01 for zk node  /test/read_sli_part/shard1/replicas/ are equal to
+    """
+    /test/read_sli_part/shard1/replicas/host2.net
+    """

--- a/tests/modules/chadmin.py
+++ b/tests/modules/chadmin.py
@@ -1,0 +1,32 @@
+class Chadmin:
+    def __init__(self, container):
+        self._container = container
+
+    def exec_cmd(self, cmd):
+        ch_admin_cmd = f"chadmin {cmd}"
+        print("CMD: " + ch_admin_cmd)
+        result = self._container.exec_run(["bash", "-c", ch_admin_cmd], user="root")
+        return result
+
+    def create_zk_node(self, zk_node, no_ch_config=True, recursive=True):
+        cmd = "zookeeper {use_config} create {make_parents} {node}".format(
+            use_config="--no-ch-config" if no_ch_config else "",
+            make_parents="--make-parents" if recursive else "",
+            node=zk_node,
+        )
+        return self.exec_cmd(cmd)
+
+    def zk_list(self, zk_node, no_ch_config=True):
+        cmd = "zookeeper {use_config} list {node}".format(
+            use_config="--no-ch-config" if no_ch_config else "",
+            node=zk_node,
+        )
+        return self.exec_cmd(cmd)
+
+    def zk_cleanup(self, fqdn, zk_root, no_ch_config=True):
+        cmd = "zookeeper {use_config} clickhouse-hosts-cleanup --root {root} --fqdn {hosts}".format(
+            use_config="--no-ch-config" if no_ch_config else "",
+            root=zk_root,
+            hosts=fqdn,
+        )
+        return self.exec_cmd(cmd)

--- a/tests/modules/chadmin.py
+++ b/tests/modules/chadmin.py
@@ -1,10 +1,13 @@
+import logging
+
+
 class Chadmin:
     def __init__(self, container):
         self._container = container
 
     def exec_cmd(self, cmd):
         ch_admin_cmd = f"chadmin {cmd}"
-        print("CMD: " + ch_admin_cmd)
+        logging.debug("chadmin command:", ch_admin_cmd)
         result = self._container.exec_run(["bash", "-c", ch_admin_cmd], user="root")
         return result
 
@@ -24,7 +27,7 @@ class Chadmin:
         return self.exec_cmd(cmd)
 
     def zk_cleanup(self, fqdn, zk_root, no_ch_config=True):
-        cmd = "zookeeper {use_config} clickhouse-hosts-cleanup --root {root} --fqdn {hosts}".format(
+        cmd = "zookeeper {use_config} --chroot {root} cleanup-removed-hosts-metadata {hosts}".format(
             use_config="--no-ch-config" if no_ch_config else "",
             root=zk_root,
             hosts=fqdn,

--- a/tests/steps/chadmin.py
+++ b/tests/steps/chadmin.py
@@ -1,0 +1,40 @@
+"""
+Steps for interacting with chadmin.
+"""
+
+from behave import then, when
+from hamcrest import assert_that, equal_to
+from modules.chadmin import Chadmin
+from modules.docker import get_container
+
+
+@when("we execute chadmin create zk nodes on {node:w}")
+def step_create_(context, node):
+    container = get_container(context, node)
+    nodes = context.text.strip().split("\n")
+    chadmin = Chadmin(container)
+
+    for node in nodes:
+        result = chadmin.create_zk_node(node)
+        assert result.exit_code == 0, f" output:\n {result.output.decode().strip()}"
+
+
+@when("we do hosts cleanup on {node} with fqdn {fqdn} and zk root {zk_root}")
+def step_host_cleanup(context, node, fqdn, zk_root):
+    container = get_container(context, node)
+    result = Chadmin(container).zk_cleanup(fqdn, zk_root)
+    assert result.exit_code == 0, f" output:\n {result.output.decode().strip()}"
+
+
+@then("the list of children on {node:w} for zk node {zk_node} are equal to")
+def step_childen_list(context, node, zk_node):
+    container = get_container(context, node)
+    result = Chadmin(container).zk_list(zk_node)
+    assert_that(result.output.decode(), equal_to(context.text + "\n"))
+
+
+@then("the list of children on {node:w} for zk node {zk_node} are empty")
+def step_childen_list_empty(context, node, zk_node):
+    container = get_container(context, node)
+    result = Chadmin(container).zk_list(zk_node)
+    assert_that(result.output.decode(), equal_to("\n"))


### PR DESCRIPTION
- ClickHouse-host functionality has been moved to chadmin.
- Refactored: tree traversal has been replaced from recursive to iterative one(bfs).
- Added tests for `clickhouse-hosts-cleanup` cmd.

Also tested it manually on clusters, and the results with old scripts are similar to the new ones. 