### PR TITLE
Reworked "ch-monitoring backup" command

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -121,7 +121,7 @@ argument-naming-style=snake_case
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style. If left empty, argument names will be checked with the set
 # naming style.
-argument-rgx=[a-z_][a-z0-9_]{0,30}$
+argument-rgx=[a-z_][a-z0-9_]{0,35}$
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case

--- a/ch_tools/common/result.py
+++ b/ch_tools/common/result.py
@@ -1,5 +1,10 @@
+OK = 0
+WARNING = 1
+CRIT = 2
+
+
 class Result:
-    def __init__(self, code=0, message="Ok", verbose=""):
+    def __init__(self, code=OK, message="OK", verbose=""):
         self.code = code
         self.message = message
         self.verbose = verbose

--- a/ch_tools/monrun_checks/ch_backup.py
+++ b/ch_tools/monrun_checks/ch_backup.py
@@ -144,7 +144,7 @@ def _check_backup_age(
             checking_backup = backup
             break
 
-    if len(checking_backup) == 0:
+    if not checking_backup:
         return Result(OK)
 
     backup_age = _get_backup_age(checking_backup)
@@ -197,7 +197,7 @@ def _check_restored_data() -> Result:
             )
             if failed != 0:
                 failed_percent = int((failed / (failed + restored)) * 100)
-                status = 1 if failed_percent < FAILED_PARTS_THRESHOLD else 2
+                status = WARNING if failed_percent < FAILED_PARTS_THRESHOLD else CRIT
                 return Result(
                     status, f"Some parts restore failed: {failed}({failed_percent}%)"
                 )


### PR DESCRIPTION
- Replaced cluster age check with ClickHouse uptime check. It covers more false positive scenarios.
- Replaced several internal constants with command-line options.
- Simplified backup count check.
