### PR TITLE
Fix AttributeError: module 'ssl' has no attribute 'TLSVersion'

### DIFF
--- a/ch_tools/monrun_checks_keeper/keeper_commands.py
+++ b/ch_tools/monrun_checks_keeper/keeper_commands.py
@@ -18,7 +18,6 @@ KEEPER_DEFAULT_PATH = "/var/lib/clickhouse-keeper/snapshots"
 CH_DBMS_DEFAULT_PATH = "/var/lib/clickhouse/snapshots"
 
 context = ssl.create_default_context()
-context.minimum_version = ssl.TLSVersion.TLSv1_2
 
 
 @command("alive")


### PR DESCRIPTION
The fix for:
```
2023-11-27 12:59:24,757 763834 [ERROR] max_latency: Error occurred while executing:
Traceback (most recent call last):
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks_keeper/main.py", line 64, in wrapper
    result = ctx.invoke(cmd_callback, *a, **kw)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks_keeper/keeper_commands.py", line 64, in max_latency_command
    return Result(0, keeper_mntr(ctx)["zk_max_latency"])
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks_keeper/keeper_commands.py", line 246, in keeper_mntr
    raise e
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks_keeper/keeper_commands.py", line 233, in keeper_mntr
    not ctx.obj.get("no_verify_ssl_certs"),
  File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/monrun_checks_keeper/keeper_commands.py", line 203, in keeper_command
    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
AttributeError: module 'ssl' has no attribute 'TLSVersion'
```

Relates to https://github.com/yandex/ch-tools/pull/76