### PR TITLE
Speed up cleanup-removed-hosts-metadata script

### DIFF
--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -171,23 +171,24 @@ def _delete_nodes_transaction(zk, to_delete_in_trasaction):
 
 def _remove_subpaths(paths):
     """
-    Removing from the list paths that are subpath of antoher.
+    Removing from the list paths that are subpath of another.
 
     Example:
     [/a, /a/b/c<-remove it]
     """
+    if not paths:
+        return
     # Sorting the list in the lexicographic order
     paths.sort()
     paths = [path.split("/") for path in paths]
-    normalized = [paths[0]]
-    # If path[i] have subnode path[j] then all paths from i to j will be subnode of i.
+    normalized_paths = [paths[0]]
+    # If path[i] has subnode path[j] then all paths from i to j will be subnode of i.
     for path in paths:
-        if (
-            len(normalized[-1]) > len(path)
-            or path[: len(normalized[-1])] != normalized[-1]
-        ):
-            normalized.append(path)
-    return ["/".join(normalized_list) for normalized_list in normalized]
+        last = normalized_paths[-1]
+        # Ignore the path if the last normalized one is its prefix
+        if len(last) > len(path) or path[: len(last)] != last:
+            normalized_paths.append(path)
+    return ["/".join(path) for path in normalized_paths]
 
 
 def _delete_recursive(zk, paths):

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -194,7 +194,7 @@ def _delete_recursive(zk, paths):
                 normalized.append(path)
         return normalized
 
-    if not len(paths):
+    if len(paths) == 0:
         return
     print("Node to recursive delete", paths)
     paths = remove_subpaths(paths)

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -66,6 +66,25 @@ Feature: chadmin zookeeper commands.
     '/test/clickhouse/databases/test/shard1/counter'
     """
     And we do hosts cleanup on zookeeper01 with fqdn host1.net,host2.net and zk root /test
-    Then the list of children on zookeeper01 for zk node /test/clickhouse/databases/test/ are equal to
+    Then the list of children on zookeeper01 for zk node test/clickhouse/databases/test/ are empty
+
+  Scenario: Zookeeper recursive delete command
+    When we execute chadmin create zk nodes on zookeeper01
     """
+      /test/a/b/c
+      /test/a/b/d
+      /test/a/f
     """
+    And we delete zookeepers nodes /test/a on zookeeper01
+    Then the list of children on zookeeper01 for zk node /test are empty
+
+  Scenario: Zookeeper delete parent and child nodes
+    When we execute chadmin create zk nodes on zookeeper01
+    """
+      /test/a/b
+      /test/c/d
+    """
+    # Make sure that it is okey to delete the node and its child.
+    And we delete zookeepers nodes /test/a,/test/a/b on zookeeper01
+    And we delete zookeepers nodes /test/c/d,/test/c on zookeeper01
+    Then the list of children on zookeeper01 for zk node /test are empty

--- a/tests/modules/chadmin.py
+++ b/tests/modules/chadmin.py
@@ -19,6 +19,13 @@ class Chadmin:
         )
         return self.exec_cmd(cmd)
 
+    def zk_delete(self, zk_nodes, no_ch_config=True):
+        cmd = "zookeeper {use_config} delete {nodes}".format(
+            use_config="--no-ch-config" if no_ch_config else "",
+            nodes=zk_nodes,
+        )
+        return self.exec_cmd(cmd)
+
     def zk_list(self, zk_node, no_ch_config=True):
         cmd = "zookeeper {use_config} list {node}".format(
             use_config="--no-ch-config" if no_ch_config else "",

--- a/tests/steps/chadmin.py
+++ b/tests/steps/chadmin.py
@@ -38,3 +38,10 @@ def step_childen_list_empty(context, node, zk_node):
     container = get_container(context, node)
     result = Chadmin(container).zk_list(zk_node)
     assert_that(result.output.decode(), equal_to("\n"))
+
+
+@when("we delete zookeepers nodes {zk_nodes} on {node:w}")
+def step_delete_command(context, zk_nodes, node):
+    container = get_container(context, node)
+    result = Chadmin(container).zk_delete(zk_nodes)
+    assert result.exit_code == 0, f" output:\n {result.output.decode().strip()}"


### PR DESCRIPTION
Performance improvement for `cleanup-removed-hosts-metadata`. In this implementation we unite the nodes to delete in transactions to do single operation for batch of nodes.

Script for time comparison:
`cat populate.sh `
```
clickhouse client --query "DROP DATABASE IF EXISTS test_db"
clickhouse client --query "CREATE DATABASE test_db"

for i in $(seq 1 $1);
do
    
	
    clickhouse client --query "CREATE TABLE test_db.test$i (a int, b int) engine=ReplicatedMergeTree('/clickhouse/tables/{shard}/test_db.table$i', '{replica}') order by a partition by a"
    clickhouse client --query "SYSTEM STOP MERGES test_db.table$1"
    for j in $(seq 1 $2);
    do
      clickhouse client --query "INSERT INTO test_db.test1 SELECT rand()%10000, rand(1)%1000 FROM numbers(100)"
    done

done
sudo service clickhouse-server stop
```
Results:
cmd : `time chadmin zookeeper cleanup-removed-hosts-metadata  <host>`
| data | new |  old | 
|---|---|---|
|  ./populate.sh 10 20  |  0m15.114s  | 2m46.153s  | 
|  ./populate.sh 20 2  |  0m4.864s  |  0m51.093s  | 
|  ./populate.sh 2 40  |  0m8.673s  |  5m54.860s  | 
|  ./populate.sh 15 15  |  2m46.116s  |  8m42.093s  | 




    