### PR TITLE
Wait replication sync using SYNC REPLICA

### DIFF
--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -9,6 +9,7 @@ from ch_tools.chadmin.internal.utils import execute_query
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.commands.replication_lag import estimate_replication_lag
 from ch_tools.common.utils import execute
+from requests.exceptions import ReadTimeout
 
 BASE_TIMEOUT = 600
 LOCAL_PART_LOAD_SPEED = 10  # in data parts per second
@@ -23,6 +24,20 @@ def wait_group():
 
 @wait_group.command("replication-sync")
 @option(
+    "--replica-timeout",
+    "replica_timeout",
+    type=TimeSpanParamType(),
+    default="1h",
+    help="Timeout for SYNC REPLICA command.",
+)
+@option(
+    "--total-timeout",
+    "total_timeout",
+    type=TimeSpanParamType(),
+    default="3d",
+    help="Max amount of time to wait.",
+)
+@option(
     "-s",
     "--status",
     type=int,
@@ -34,14 +49,7 @@ def wait_group():
     "--pause",
     type=TimeSpanParamType(),
     default="30s",
-    help="Pause between requests.",
-)
-@option(
-    "-t",
-    "--timeout",
-    type=TimeSpanParamType(),
-    default="3d",
-    help="Max amount of time to wait.",
+    help="Pause between replication lag requests.",
 )
 @option(
     "-x",
@@ -76,29 +84,57 @@ def wait_group():
     default=50.0,
     help="Warning threshold in percent of max_replicated_merges_in_queue.",
 )
-@option(
-    "-v",
-    "--verbose",
-    "verbose",
-    type=int,
-    count=True,
-    default=0,
-    help="Show details about lag.",
-)
 @pass_context
 def wait_replication_sync_command(
-    ctx, status, pause, timeout, xcrit, crit, warn, mwarn, mcrit, verbose
+    ctx,
+    replica_timeout,
+    total_timeout,
+    status,
+    pause,
+    xcrit,
+    crit,
+    warn,
+    mwarn,
+    mcrit,
 ):
-    """Wait for ClickHouse server to sync replication with other replicas using replication-lag command."""
+    """Wait for ClickHouse server to sync replication with other replicas."""
 
-    deadline = time.time() + timeout.total_seconds()
+    start_time = time.time()
+    deadline = start_time + total_timeout.total_seconds()
+
+    # Get replicated tables
+    tables = execute_query(
+        ctx,
+        "SELECT name, database FROM system.tables WHERE engine = 'ReplicatedMergeTree'",
+        format_="JSON",
+    )["data"]
+
+    # Sync tables in cycle
+    for t in tables:
+        full_name = f"{t['database']}.{t['name']}"
+        time_left = deadline - time.time()
+
+        try:
+            execute_query(
+                ctx,
+                f"SYSTEM SYNC REPLICA {full_name}",
+                format_=None,
+                timeout=min(replica_timeout.total_seconds(), time_left),
+            )
+        except ReadTimeout:
+            print(f"Timeout while runnung SYNC REPLICA on {full_name}.")
+            sys.exit(1)
+        except:
+            raise
+
+    # Replication lag
     while time.time() < deadline:
-        res = estimate_replication_lag(ctx, xcrit, crit, warn, mwarn, mcrit, verbose)
+        res = estimate_replication_lag(ctx, xcrit, crit, warn, mwarn, mcrit)
         if res.code <= status:
             sys.exit(0)
         time.sleep(pause.total_seconds())
 
-    logging.error("ClickHouse can't sync replicas.")
+    print(f"Timeout while waiting on replication-lag command.")
     sys.exit(1)
 
 

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -124,8 +124,6 @@ def wait_replication_sync_command(
         except ReadTimeout:
             print(f"Timeout while running SYNC REPLICA on {full_name}.")
             sys.exit(1)
-        except:
-            raise
 
     # Replication lag
     while time.time() < deadline:
@@ -134,7 +132,7 @@ def wait_replication_sync_command(
             sys.exit(0)
         time.sleep(pause.total_seconds())
 
-    print(f"Timeout while waiting on replication-lag command.")
+    print("Timeout while waiting on replication-lag command.")
     sys.exit(1)
 
 

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -105,7 +105,7 @@ def wait_replication_sync_command(
     # Get replicated tables
     tables = execute_query(
         ctx,
-        "SELECT name, database FROM system.tables WHERE engine = 'ReplicatedMergeTree'",
+        "SELECT name, database FROM system.tables WHERE engine LIKE 'Replicated%' AND engine LIKE '%MergeTree'",
         format_="JSON",
     )["data"]
 

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -122,7 +122,7 @@ def wait_replication_sync_command(
                 timeout=min(replica_timeout.total_seconds(), time_left),
             )
         except ReadTimeout:
-            print(f"Timeout while runnung SYNC REPLICA on {full_name}.")
+            print(f"Timeout while running SYNC REPLICA on {full_name}.")
             sys.exit(1)
         except:
             raise

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -4,12 +4,12 @@ import sys
 import time
 
 from click import FloatRange, group, option, pass_context
+from requests.exceptions import ReadTimeout
 
 from ch_tools.chadmin.internal.utils import execute_query
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.commands.replication_lag import estimate_replication_lag
 from ch_tools.common.utils import execute
-from requests.exceptions import ReadTimeout
 
 BASE_TIMEOUT = 600
 LOCAL_PART_LOAD_SPEED = 10  # in data parts per second

--- a/ch_tools/common/clickhouse/client/clickhouse_client.py
+++ b/ch_tools/common/clickhouse/client/clickhouse_client.py
@@ -82,7 +82,10 @@ class ClickhouseClient:
         if dry_run:
             return None
 
-        timeout = max(self._timeout, timeout or 0)
+        if timeout:
+            timeout = timeout
+        else:
+            timeout = self._timeout
         per_query_settings = settings or {}
 
         logging.debug("Executing query: %s", query)

--- a/ch_tools/common/clickhouse/client/clickhouse_client.py
+++ b/ch_tools/common/clickhouse/client/clickhouse_client.py
@@ -82,10 +82,9 @@ class ClickhouseClient:
         if dry_run:
             return None
 
-        if timeout:
-            timeout = timeout
-        else:
+        if timeout is None:
             timeout = self._timeout
+
         per_query_settings = settings or {}
 
         logging.debug("Executing query: %s", query)

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -35,7 +35,7 @@ Feature: chadmin commands.
     """
     Then it fails with response contains
     """
-    Timeout while runnung SYNC REPLICA on
+    Timeout while running SYNC REPLICA on
     """
     When we execute query on clickhouse01
     """

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -18,7 +18,7 @@ Feature: chadmin commands.
   Scenario: Check wait replication sync
     When we execute command on clickhouse01
     """
-    chadmin wait replication-sync -t 10 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
     """
     When we execute query on clickhouse01
     """
@@ -31,14 +31,17 @@ Feature: chadmin commands.
     And we sleep for 5 seconds
     When we try to execute command on clickhouse01
     """
-    chadmin wait replication-sync -t 10 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
     """
-    Then it fails
+    Then it fails with response contains
+    """
+    Timeout while runnung SYNC REPLICA on
+    """
     When we execute query on clickhouse01
     """
     SYSTEM START FETCHES
     """
     When we execute command on clickhouse01
     """
-    chadmin wait replication-sync -t 10 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
     """

--- a/tests/steps/common.py
+++ b/tests/steps/common.py
@@ -46,6 +46,14 @@ def step_command_fail(context):
     ), f'"{context.command}" succeeded, but failure was expected'
 
 
+@then("it fails with response contains")
+def step_command_fail(context):
+    assert (
+        context.exit_code != 0
+    ), f'"{context.command}" succeeded, but failure was expected'
+    assert_that(context.response, contains_string(context.text))
+
+
 @then("we get response")
 def step_get_response(context):
     assert_that(context.response, equal_to(context.text))

--- a/tests/steps/common.py
+++ b/tests/steps/common.py
@@ -47,7 +47,7 @@ def step_command_fail(context):
 
 
 @then("it fails with response contains")
-def step_command_fail(context):
+def step_command_fail_response_contains(context):
     assert (
         context.exit_code != 0
     ), f'"{context.command}" succeeded, but failure was expected'


### PR DESCRIPTION
Not sure what default timeout value for SYNC REPLICA should be.
Command throws on SYNC REPLICA timeout. I thought we can just retry sync until total_timeout is reached, but I think current implementation allows us to know that something is not as expected much earlier.
Replication lag check is not removed in case something really weird happens.
Also I just print() on timeout because throwing exceptions result in some ugly traceback and useless message being printed, maybe there is a better way to do it.