### PR TITLE
Replace root tag in configs.

### DIFF
--- a/tests/features/monrun.feature
+++ b/tests/features/monrun.feature
@@ -103,10 +103,10 @@ Feature: ch-monitoring tool
     When we execute command on clickhouse01
     """
     echo -e "
-        <yandex>
+        <clickhouse>
             <path_to_regions_hierarchy_file>/opt/geo/regions_hierarchy.txt</path_to_regions_hierarchy_file>
             <path_to_regions_names_files>/opt/geo/</path_to_regions_names_files>
-        </yandex>
+        </clickhouse>
         " > /etc/clickhouse-server/config.d/geo.xml && \
     supervisorctl restart clickhouse-server
     """

--- a/tests/features/s3_credentials.feature
+++ b/tests/features/s3_credentials.feature
@@ -36,12 +36,12 @@ Feature: ch_s3_credentials tool
     Then we get response
     """
     <?xml version="1.0" encoding="utf-8"?>
-    <clickhouse>
+    <yandex>
         <s3>
             <cloud_storage>
                 <endpoint>storage.com</endpoint>
                 <header>X-YaCloud-SubjectToken: IAM_TOKEN</header>
             </cloud_storage>
         </s3>
-    </clickhouse>
+    </yandex>
     """

--- a/tests/features/s3_credentials.feature
+++ b/tests/features/s3_credentials.feature
@@ -36,12 +36,12 @@ Feature: ch_s3_credentials tool
     Then we get response
     """
     <?xml version="1.0" encoding="utf-8"?>
-    <yandex>
+    <clickhouse>
         <s3>
             <cloud_storage>
                 <endpoint>storage.com</endpoint>
                 <header>X-YaCloud-SubjectToken: IAM_TOKEN</header>
             </cloud_storage>
         </s3>
-    </yandex>
+    </clickhouse>
     """

--- a/tests/images/clickhouse/config/config.xml
+++ b/tests/images/clickhouse/config/config.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
     <logger>
         <console>1</console>
     </logger>
@@ -87,4 +87,4 @@
         <replica>{{ instance_name }}.{{ conf.network_name }}</replica>
         <cluster>cluster</cluster>
     </macros>
-</yandex>
+</clickhouse>

--- a/tests/images/clickhouse/config/users.xml
+++ b/tests/images/clickhouse/config/users.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<yandex>
+<clickhouse>
     <profiles>
         <default>
             <distributed_ddl_task_timeout>20</distributed_ddl_task_timeout>
@@ -36,4 +36,4 @@
     <quotas>
         <default/>
     </quotas>
-</yandex>
+</clickhouse>


### PR DESCRIPTION
Replaced  the `<yandex>` tag in xml config to `<clickhouse>`. Sometimes this can lead to incorrect configuration, because after merging the configs we will have:
```
{'clickhouse':  {...}, 'yandex': {''} }
```
And then we will take [only first value](https://github.com/yandex/ch-tools/blob/766b29c021a837cf4b9fe6781341eaafe11df4d8/ch_tools/common/utils.py#L82)