### PR TITLE
--failed/--completed option for "part-log list" command

### DIFF
--- a/ch_tools/chadmin/cli/part_log_group.py
+++ b/ch_tools/chadmin/cli/part_log_group.py
@@ -21,16 +21,26 @@ def part_log_group():
 
 
 @part_log_group.command("list")
-@option("-d", "--database")
-@option("-t", "--table")
-@option("--partition")
-@option("--part")
-@option("--date")
-@option("--min-date")
-@option("--max-date")
-@option("--min-time")
-@option("--max-time")
-@option("--time")
+@option("-d", "--database", help="Filter log records to output by database name.")
+@option("-t", "--table", help="Filter log records to output by table name.")
+@option("--partition", help="Filter log records to output by partition ID.")
+@option("--part", help="Filter log records to output by part name.")
+@option("--date", help="Filter log records to output by date.")
+@option("--time", help="Filter log records to output by time.")
+@option("--min-date", help="Filter out log records created before the specified date.")
+@option("--max-date", help="Filter out log records created after the specified date.")
+@option(
+    "--min-time", help="Filter out log records created before the specified timestamp."
+)
+@option(
+    "--max-time", help="Filter out log records created after the specified timestamp."
+)
+@option(
+    "--failed/--completed",
+    "failed",
+    default=None,
+    help="Output only log records on failed / successful part operations.",
+)
 @option(
     "--order-by",
     type=Choice(["time", "size", "rows", "peak_memory_usage"]),
@@ -42,7 +52,7 @@ def part_log_group():
     "--limit",
     type=int,
     default=10,
-    help="Limit the max number of objects in the output.",
+    help="Limit the max number of log records in the output.",
 )
 @pass_context
 def list_part_log_command(

--- a/ch_tools/chadmin/cli/query_log_group.py
+++ b/ch_tools/chadmin/cli/query_log_group.py
@@ -36,24 +36,42 @@ def get_query_command(ctx, **kwargs):
 @option("-u", "--user", help="Filter log records to output by user.")
 @option("-U", "--exclude-user", help="Filter log records to not output by user.")
 @option(
-    "--query", "query_pattern", help="Filter log records to output by query pattern."
+    "--query",
+    "query_pattern",
+    help="Filter log records to output by query pattern.",
 )
 @option(
     "--exclude-query",
     "exclude_query_pattern",
     help="Filter log records to not output by query pattern.",
 )
-@option("--error")
-@option("--date")
-@option("--min-date")
-@option("--max-date")
-@option("--min-time")
-@option("--max-time")
-@option("--time")
-@option("--client")
-@option("--failed", is_flag=True)
-@option("--completed", is_flag=True)
-@option("--is-initial-query", "--initial", "is_initial_query", type=bool)
+@option("--date", help="Filter log records to output by date.")
+@option("--time", help="Filter log records to output by time.")
+@option("--min-date", help="Filter out log records created before the specified date.")
+@option("--max-date", help="Filter out log records created after the specified date.")
+@option(
+    "--min-time",
+    help="Filter out log records created before the specified timestamp.",
+)
+@option(
+    "--max-time",
+    help="Filter out log records created after the specified timestamp.",
+)
+@option(
+    "--failed/--completed",
+    "failed",
+    default=None,
+    help="Output only log records on failed / successful part operations.",
+)
+@option("--error", help="Filter log records to output by error pattern.")
+@option("--client", help="Filter log records to output by client.")
+@option(
+    "--is-initial-query",
+    "--initial",
+    "is_initial_query",
+    type=bool,
+    help="Filter log records to output by is_initial flag.",
+)
 @option("-v", "--verbose", is_flag=True, help="Verbose mode.")
 @option(
     "--cluster",
@@ -277,7 +295,6 @@ def get_queries(
     max_time=None,
     client=None,
     failed=None,
-    completed=None,
     is_initial_query=None,
     on_cluster=False,
     limit=10,
@@ -354,10 +371,9 @@ def get_queries(
         {% if exclude_query_pattern -%}
           AND lower(query) NOT LIKE lower('{{ exclude_query_pattern }}')
         {% endif -%}
-        {% if failed -%}
+        {% if failed is true -%}
           AND exception != ''
-        {% endif -%}
-        {% if completed -%}
+        {% elif failed is false -%}
           AND exception = ''
         {% endif -%}
         {% if is_initial_query is true -%}
@@ -390,7 +406,6 @@ def get_queries(
         max_time=max_time,
         client=client,
         failed=failed,
-        completed=completed,
         is_initial_query=is_initial_query,
         cluster=cluster,
         limit=limit,

--- a/ch_tools/chadmin/internal/part.py
+++ b/ch_tools/chadmin/internal/part.py
@@ -270,6 +270,7 @@ def list_part_log(
     max_date=None,
     min_time=None,
     max_time=None,
+    failed=None,
     order_by=None,
     limit=None,
 ):
@@ -334,6 +335,11 @@ def list_part_log(
         {% if max_time %}
           AND event_time <= toDateTime('{{ max_time }}')
         {% endif %}
+        {% if failed is true -%}
+          AND exception != ''
+        {% elif failed is false -%}
+          AND exception = ''
+        {% endif -%}
         ORDER BY {{ order_by }}
         {% if limit %}
         LIMIT {{ limit }}
@@ -351,6 +357,7 @@ def list_part_log(
         min_time=min_time,
         max_time=max_time,
         order_by=order_by,
+        failed=failed,
         limit=limit,
         format_="JSON",
     )["data"]


### PR DESCRIPTION
Usage example:
```
# chadmin part-log list -t postgres_part -l 5 --failed
event_time           event_type    completed      duration_ms  database    table                          part_name       rows    size  peak_memory_usage
-------------------  ------------  -----------  -------------  ----------  -------------  -------------------------  ---------  ------  -------------------
2024-02-16 09:41:04  MergeParts    False               267583  test        postgres_part  20240203_153579_212556_25  106991097       0  4.63 GiB
2024-02-16 09:26:35  MergeParts    False               669269  test        postgres_part  20240203_153579_212556_25  106991097       0  162.65 GiB
2024-02-16 09:25:35  MergeParts    False               305241  test        postgres_part        20240131_0_56099_15   75020522       0  35.71 GiB
2024-02-16 09:25:10  MergeParts    False                    2  test        postgres_part  20240215_155617_264971_29          0       0  4.45 MiB
2024-02-16 09:25:10  MergeParts    False                    2  test        postgres_part  20240213_157547_260096_34          0       0  4.38 MiB
```
```
# chadmin -f yaml part-log list -t postgres_part -l 10 --failed
- event_time: '2024-02-16 09:26:35'
  event_type: MergeParts
  merge_reason: RegularMerge
  duration_ms: '669269'
  database: test
  table: postgres_part
  partition_id: '20240203'
  part_name: '20240203_153579_212556_25'
  part_type: Unknown
  disk_name: ''
  rows: '106991097'
  size_in_bytes: '0'
  merged_from:
  - '20240203_153579_158965_16'
  - '20240203_158966_171083_18'
  - '20240203_171084_183381_19'
  - '20240203_183382_191118_22'
  - '20240203_191119_204602_24'
  - '20240203_204603_208378_21'
  - '20240203_208379_211714_21'
  - '20240203_211715_212556_13'
  read_rows: '106991097'
  read_bytes: 119.4 GiB
  peak_memory_usage: 162.65 GiB
  exception: |-
    Code: 241. DB::Exception: Memory limit (total) exceeded: would use 129.63 GiB (attempt to allocate chunk of 34359738368 bytes), maximum: 113.23 GiB. OvercommitTracker decision: Memory overcommit isn't used. Waiting time or overcommit denominator are set to zero. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):

    0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c7faf9b in /usr/bin/clickhouse
    1. DB::Exception::Exception<char const*, char const*, String, long&, String, char const*, std::basic_string_view<char, std::char_traits<char>>>(int, FormatStringHelperImpl<std::type_identity<char const*>::type, std::type_identity<char const*>::type, std::type_identity<String>::type, std::type_identity<long&>::type, std::type_identity<String>::type, std::type_identity<char const*>::type, std::type_identity<std::basic_string_view<char, std::char_traits<char>>>::type>, char const*&&, char const*&&, String&&, long&, String&&, char const*&&, std::basic_string_view<char, std::char_traits<char>>&&) @ 0x000000000c810d8a in /usr/bin/clickhouse
    2. MemoryTracker::allocImpl(long, bool, MemoryTracker*, double) @ 0x000000000c8109c8 in /usr/bin/clickhouse
    3. MemoryTracker::allocImpl(long, bool, MemoryTracker*, double) @ 0x000000000c810409 in /usr/bin/clickhouse
    4. MemoryTracker::allocImpl(long, bool, MemoryTracker*, double) @ 0x000000000c810409 in /usr/bin/clickhouse
    5. MemoryTracker::allocImpl(long, bool, MemoryTracker*, double) @ 0x000000000c810409 in /usr/bin/clickhouse
    6. Allocator<false, false>::realloc(void*, unsigned long, unsigned long, unsigned long) @ 0x000000000c7cfe07 in /usr/bin/clickhouse
    7. void DB::PODArrayBase<1ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::resize<>(unsigned long) @ 0x000000000721c207 in /usr/bin/clickhouse
    8. DB::ColumnString::insertFrom(DB::IColumn const&, unsigned long) @ 0x0000000011ae272c in /usr/bin/clickhouse
    9. DB::IColumn::createWithOffsets(DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::ColumnConst const&, unsigned long, unsigned long) const @ 0x0000000011c761f2 in /usr/bin/clickhouse
    10. DB::ColumnSparse::convertToFullColumnIfSparse() const @ 0x0000000011ad3e14 in /usr/bin/clickhouse
    11. DB::recursiveRemoveSparse(COW<DB::IColumn>::immutable_ptr<DB::IColumn> const&) @ 0x0000000011ad8610 in /usr/bin/clickhouse
    12. DB::convertToFullIfSparse(DB::Chunk&) @ 0x00000000129608d4 in /usr/bin/clickhouse
    13. DB::IMergingTransformBase::prepare() @ 0x0000000012cc25d6 in /usr/bin/clickhouse
    14. DB::ExecutingGraph::updateNode(unsigned long, std::queue<DB::ExecutingGraph::Node*, std::deque<DB::ExecutingGraph::Node*, std::allocator<DB::ExecutingGraph::Node*>>>&, std::queue<DB::ExecutingGraph::Node*, std::deque<DB::ExecutingGraph::Node*, std::allocator<DB::ExecutingGraph::Node*>>>&) @ 0x000000001298054c in /usr/bin/clickhouse
    15. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x000000001297d4f9 in /usr/bin/clickhouse
    16. DB::PipelineExecutor::executeStep(std::atomic<bool>*) @ 0x000000001297cee8 in /usr/bin/clickhouse
    17. DB::PullingPipelineExecutor::pull(DB::Chunk&) @ 0x000000001298b5d7 in /usr/bin/clickhouse
    18. DB::PullingPipelineExecutor::pull(DB::Block&) @ 0x000000001298b793 in /usr/bin/clickhouse
    19. DB::MergeTask::VerticalMergeStage::executeVerticalMergeForOneColumn() const @ 0x000000001233645d in /usr/bin/clickhouse
    20. bool std::__function::__policy_invoker<bool ()>::__call_impl<std::__function::__default_alloc_func<DB::MergeTask::VerticalMergeStage::subtasks::'lambda0'(), bool ()>>(std::__function::__policy_storage const*) @ 0x000000001233dd4e in /usr/bin/clickhouse
    21. DB::MergeTask::VerticalMergeStage::execute() @ 0x0000000012339ecb in /usr/bin/clickhouse
    22. DB::MergeTask::execute() @ 0x00000000123398f9 in /usr/bin/clickhouse
    23. DB::ReplicatedMergeMutateTaskBase::executeStep() @ 0x0000000012607267 in /usr/bin/clickhouse
    24. DB::MergeTreeBackgroundExecutor<DB::DynamicRuntimeQueue>::threadFunction() @ 0x000000001234be24 in /usr/bin/clickhouse
    25. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x000000000c8e5141 in /usr/bin/clickhouse
    26. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x000000000c8e897a in /usr/bin/clickhouse
    27. void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000c8e777e in /usr/bin/clickhouse
    28. start_thread @ 0x00000000000076db in /lib/x86_64-linux-gnu/libpthread-2.27.so
    29. ? @ 0x000000000012161f in /lib/x86_64-linux-gnu/libc-2.27.so
     (version 24.1.4.20 (official build))
```