### PR TITLE
Quote database and table names in SYSTEM SYNC REPLICA query

### DIFF
--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -112,7 +112,7 @@ def wait_replication_sync_command(
 
     # Sync tables in cycle
     for t in tables:
-        full_name = f"{t['database']}.{t['name']}"
+        full_name = f"`{t['database']}`.`{t['name']}`"
         time_left = deadline - time.time()
         timeout = min(replica_timeout.total_seconds(), time_left)
 


### PR DESCRIPTION
Fix for the following error:

```
            Traceback (most recent call last):
              File "/usr/bin/chadmin", line 8, in <module>
                sys.exit(main())
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/chadmin/chadmin_cli.py", line 159, in main
                cli.main()
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 1053, in main
                rv = self.invoke(ctx)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 1659, in invoke
                return _process_result(sub_ctx.command.invoke(sub_ctx))
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 1659, in invoke
                return _process_result(sub_ctx.command.invoke(sub_ctx))
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 1395, in invoke
                return ctx.invoke(self.callback, **ctx.params)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/core.py", line 754, in invoke
                return __callback(*args, **kwargs)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/click/decorators.py", line 26, in new_func
                return f(get_current_context(), *args, **kwargs)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/chadmin/cli/wait_group.py", line 125, in wait_replication_sync_command
                settings={"receive_timeout": timeout},
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/chadmin/internal/utils.py", line 36, in execute_query
                settings=settings,
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/tenacity/__init__.py", line 289, in wrapped_f
                return self(f, *args, **kw)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/tenacity/__init__.py", line 379, in __call__
                do = self.iter(retry_state=retry_state)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/tenacity/__init__.py", line 314, in iter
                return fut.result()
              File "/usr/lib/python3.6/concurrent/futures/_base.py", line 425, in result
                return self.__get_result()
              File "/usr/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
                raise self._exception
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/tenacity/__init__.py", line 382, in __call__
                result = fn(*args, **kwargs)
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/common/clickhouse/client/clickhouse_client.py", line 241, in query
                found_port,
              File "/opt/yandex/clickhouse-tools/lib/python3.6/site-packages/ch_tools/common/clickhouse/client/clickhouse_client.py", line 148, in _execute_http
                raise ClickhouseError(query, e.response) from None
            ch_tools.common.clickhouse.client.error.ClickhouseError: Code: 62. DB::Exception: Syntax error: failed at position 26 ('.'): .inner_id.0fb9b053-6828-464a-bc34-dd8dd1347a11
            . Expected identifier. (SYNTAX_ERROR) (version 23.3.19.32 (official build))

            Query: SYSTEM SYNC REPLICA logs..inner_id.0fb9b053-6828-464a-bc34-dd8dd1347a11
```