### PR TITLE
DO NOT MERGE: check replication sync with the old replication entry t…

### DIFF
--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -45,3 +45,20 @@ Feature: chadmin commands.
     """
     chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
     """
+  Scenario: Check warning old entry replication sync
+    When we create fake replication entry on clickhouse01
+    """
+    zk_table_root: /tables/table_01
+    replica_name: clickhouse01.ch_tools_test
+    id: '00000001'
+    create_time: 2021-07-28 18:53:14
+    """
+    And we execute command on clickhouse01
+    """
+    supervisorctl restart clickhouse-server
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
+    """
+    

--- a/tests/modules/chadmin.py
+++ b/tests/modules/chadmin.py
@@ -11,12 +11,14 @@ class Chadmin:
         result = self._container.exec_run(["bash", "-c", ch_admin_cmd], user="root")
         return result
 
-    def create_zk_node(self, zk_node, no_ch_config=True, recursive=True):
-        cmd = "zookeeper {use_config} create {make_parents} {node}".format(
+    def create_zk_node(self, zk_node, no_ch_config=True, recursive=True, content=None):
+        cmd = "zookeeper {use_config} create {make_parents} {node} {value}".format(
             use_config="--no-ch-config" if no_ch_config else "",
             make_parents="--make-parents" if recursive else "",
             node=zk_node,
+            value=f"'{content}'" if content else "",
         )
+        print(cmd)
         return self.exec_cmd(cmd)
 
     def zk_delete(self, zk_nodes, no_ch_config=True):


### PR DESCRIPTION
check replication sync with the old replication entry the queue.
Example:
```
/var/log/clickhouse-server # chadmin zookeeper get <path_to_zk_table_root>/<replica>/queue/queue-00000000
format version: 4
create_time: 2021-07-28 18:53:18
source replica: 
block_id: 
get
98_0_0_0
```