### PR TITLE
Return warning on user's fault backup fail reasons

### DIFF
--- a/ch_tools/monrun_checks/ch_backup.py
+++ b/ch_tools/monrun_checks/ch_backup.py
@@ -120,8 +120,8 @@ def _check_last_backup_not_failed(backups: List[Dict], crit_threshold: int) -> R
             break
 
         if (state == "failed") or (state == "creating" and i > 0):
-            if "fail_reason" not in backup or not _is_userfault_exception(
-                backup["fail_reason"]
+            if "exception" not in backup or not _is_userfault_exception(
+                backup["exception"]
             ):
                 counter += 1
             else:

--- a/ch_tools/monrun_checks/ch_backup.py
+++ b/ch_tools/monrun_checks/ch_backup.py
@@ -242,7 +242,7 @@ def _suppress_if_required(
         and counter - userfault_counter < failed_backup_count_crit_threshold
     ):
         result.code = WARNING
-        result.message += " (supressed due to user fault backup exceptions)"
+        result.message += " (suppressed due to user fault backup exceptions)"
 
 
 def _get_uptime(ctx: Context) -> timedelta:

--- a/tests/unit/monrun/test_last_backup.py
+++ b/tests/unit/monrun/test_last_backup.py
@@ -13,7 +13,7 @@ from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
         (({"state": "created"},), OK),
         (
             (
-                {"state": "failed", "fail_reason": None},
+                {"state": "failed", "exception": None},
                 {"state": "created"},
             ),
             WARNING,
@@ -44,7 +44,7 @@ from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
         ),
         (
             (
-                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "failed", "exception": "Disk quota exceeded"},
                 {"state": "failed"},
                 {"state": "failed"},
                 {"state": "created"},
@@ -53,7 +53,7 @@ from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
         ),
         (
             (
-                {"state": "failed", "fail_reason": "God's will"},
+                {"state": "failed", "exception": "God's will"},
                 {"state": "failed"},
                 {"state": "failed"},
                 {"state": "created"},
@@ -62,7 +62,7 @@ from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
         ),
         (
             (
-                {"state": "failed", "fail_reason": None},
+                {"state": "failed", "exception": None},
                 {"state": "failed"},
                 {"state": "failed"},
                 {"state": "created"},
@@ -71,9 +71,9 @@ from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
         ),
         (
             (
-                {"state": "failed", "fail_reason": "Disk quota exceeded"},
-                {"state": "failed", "fail_reason": "Disk quota exceeded"},
-                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "failed", "exception": "Disk quota exceeded"},
+                {"state": "failed", "exception": "Disk quota exceeded"},
+                {"state": "failed", "exception": "Disk quota exceeded"},
                 {"state": "created"},
             ),
             WARNING,

--- a/tests/unit/monrun/test_last_backup.py
+++ b/tests/unit/monrun/test_last_backup.py
@@ -1,0 +1,88 @@
+from typing import Dict, Sequence
+
+from hamcrest import assert_that, equal_to
+from pytest import mark
+
+from ch_tools.common.result import CRIT, OK, WARNING
+from ch_tools.monrun_checks.ch_backup import _check_last_backup_not_failed
+
+
+@mark.parametrize(
+    ["backups", "status_expected"],
+    [
+        (({"state": "created"},), OK),
+        (
+            (
+                {"state": "failed", "fail_reason": None},
+                {"state": "created"},
+            ),
+            WARNING,
+        ),
+        (
+            (
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            WARNING,
+        ),
+        (
+            (
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            WARNING,
+        ),
+        (
+            (
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            CRIT,
+        ),
+        (
+            (
+                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            WARNING,
+        ),
+        (
+            (
+                {"state": "failed", "fail_reason": "God's will"},
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            CRIT,
+        ),
+        (
+            (
+                {"state": "failed", "fail_reason": None},
+                {"state": "failed"},
+                {"state": "failed"},
+                {"state": "created"},
+            ),
+            CRIT,
+        ),
+        (
+            (
+                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "failed", "fail_reason": "Disk quota exceeded"},
+                {"state": "created"},
+            ),
+            WARNING,
+        ),
+    ],
+)
+def test_last_backup_not_failed(
+    backups: Sequence[Dict], status_expected: Sequence[int]
+) -> None:
+    assert_that(
+        _check_last_backup_not_failed(list(backups), 3).code, equal_to(status_expected)
+    )


### PR DESCRIPTION
Backups that failed with user's fault now will cause `WARNING` status instead of `CRIT`