### PR TITLE
Fix tls check when not all ports in config

### DIFF
--- a/ch_tools/monrun_checks/ch_tls.py
+++ b/ch_tools/monrun_checks/ch_tls.py
@@ -85,10 +85,12 @@ def get_ports(ctx: click.Context, ports: Optional[str]) -> List[str]:
     if ports:
         return ports.split(",")
     client = clickhouse_client(ctx)
-    return [
-        client.get_port(ClickhousePort.HTTPS),
-        client.get_port(ClickhousePort.TCP_SECURE),
-    ]
+    result = []
+    if client.check_port(ClickhousePort.HTTPS):
+        result.append(client.get_port(ClickhousePort.HTTPS))
+    if client.check_port(ClickhousePort.TCP_SECURE):
+        result.append(client.get_port(ClickhousePort.TCP_SECURE))
+    return result
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
client.get_port returns 0 if port is not set in config.
In this case tls check tries to connect to port 0 and fails