### PR TITLE
Output escaping rules

### DIFF
--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -46,6 +46,16 @@ DEFAULT_CONFIG = {
             },
         },
     },
+    "monitoring": {
+        "output": {
+            "escaping_rules": [
+                {
+                    "pattern": "\n",
+                    "replacement": "",
+                },
+            ],
+        },
+    },
     "ch-monitoring": {
         "log-errors": {
             "crit": 60,

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -96,7 +96,7 @@ class MonrunChecks(cloup.Group):
 
             if ctx.obj and ctx.obj.get("status_mode", False):
                 return status
-            status.report()
+            status.report(ctx)
 
         cmd.callback = callback_wrapper
         super().add_command(

--- a/ch_tools/monrun_checks_keeper/main.py
+++ b/ch_tools/monrun_checks_keeper/main.py
@@ -77,7 +77,7 @@ class KeeperChecks(cloup.Group):
 
             if ctx.obj and ctx.obj.get("status_mode", False):
                 return status
-            status.report()
+            status.report(ctx)
 
         cmd.callback = wrapper
         super().add_command(


### PR DESCRIPTION
The changes make escaping rules tunable through config file.

Default set of escaping rules is minimal and doesn't include escaping rules for Prometheus-compatibility to better readability. 

_Without changes_
```
# ch-monitoring system-queues
2;test db.action: parts to check 34 > 20 (crit); test db.action: queue size 961 > 20 (crit); test db.action: merges in queue 17 > 10 (warn);
```

_With changes_
```
# ch-monitoring system-queues
2;test_db.action: parts_to_check 34 > 20 (crit); test_db.action: queue_size 961 > 20 (crit); test_db.action: merges_in_queue 17 > 10 (warn);
```

Now the output contains correct database and table names.  