### PR TITLE
Fix config and default_map handling in "status" command

### DIFF
--- a/ch_tools/monrun_checks/status.py
+++ b/ch_tools/monrun_checks/status.py
@@ -19,6 +19,7 @@ def status_command(commands):
         """
         checks_status = []
         ctx.obj["status_mode"] = True
+        ctx.default_map = ctx.obj["config"]["ch-monitoring"]
         for cmd in commands:
             status = ctx.invoke(cmd)
             checks_status.append(

--- a/ch_tools/monrun_checks_keeper/status.py
+++ b/ch_tools/monrun_checks_keeper/status.py
@@ -19,6 +19,7 @@ def status_command(commands):
         """
         checks_status = []
         ctx.obj.update({"status_mode": True})
+        ctx.default_map = ctx.obj["config"]["keeper-monitoring"]
         for cmd in commands:
             status = ctx.invoke(cmd)
             checks_status.append(


### PR DESCRIPTION
without fix
```
# ch-monitoring status
----------------  --------------------------------------------------------------------------------------------------------------------
ping              OK
log-errors        Unknown error: unsupported type for timedelta seconds component: NoneType
replication-lag   Unknown error: '<' not supported between instances of 'int' and 'NoneType'
system-queues     Unknown error: '>' not supported between instances of 'int' and 'NoneType'
core-dumps        Unknown error: expected str, bytes or os.PathLike object, not NoneType
dist-tables       OK
resetup-state     OK
ro-replica        OK
geobase           OK
backup            OK
orphaned-backups  OK
tls               OK
keeper            OK
```

with fix
```
# ch-monitoring status
----------------  --------------------------------------------------------------------------------------------------------------------
ping              OK
log-errors        OK, 0 errors for last 600 seconds
replication-lag   OK
system-queues     OK
core-dumps        OK
dist-tables       OK
resetup-state     OK
ro-replica        OK
geobase           OK
backup            OK
orphaned-backups  OK
tls               OK
keeper            OK
```

Relates to https://github.com/yandex/ch-tools/pull/122
