### PR TITLE
Replace print with logging

### DIFF
--- a/ch_tools/chadmin/cli/chs3_backup_group.py
+++ b/ch_tools/chadmin/cli/chs3_backup_group.py
@@ -87,7 +87,7 @@ def _delete_chs3_backups(ctx, chs3_backups, *, keep_going, dry_run):
             unfreeze_backup(ctx, chs3_backup, dry_run=dry_run)
         except Exception as e:
             if keep_going:
-                logging.warning(f"{e!r}\n")
+                logging.warning("{!r}\n", e)
             else:
                 raise
 
@@ -99,7 +99,7 @@ def _delete_chs3_backups_comp(ctx, chs3_backups, *, dry_run):
     """
     tables = get_tables_dict(ctx)
     for chs3_backup in chs3_backups:
-        logging.info(f"Removing backup: {chs3_backup}")
+        logging.info("Removing backup: {}", chs3_backup)
         for table in tables:
             try:
                 unfreeze_table(
@@ -111,7 +111,9 @@ def _delete_chs3_backups_comp(ctx, chs3_backups, *, dry_run):
                 )
             except requests.exceptions.HTTPError:
                 logging.error(
-                    f"Can't unfreeze table {table} in backup {chs3_backup}. Maybe it was deleted."
+                    "Can't unfreeze table {} in backup {}. Maybe it was deleted.",
+                    table,
+                    chs3_backup,
                 )
             if not dry_run:
                 clear_empty_backup(chs3_backup)
@@ -132,6 +134,6 @@ def clear_empty_backup(orphaned_chs3_backup):
             os.rmdir(backup_directory)
     except FileNotFoundError:
         logging.error(
-            f"Cannot remove backup directory {backup_directory} as it doesn`t exist. "
-            f"Maybe it was already removed."
+            "Cannot remove backup directory {} as it doesn`t exist.\nMaybe it was already removed.",
+            backup_directory,
         )

--- a/ch_tools/chadmin/cli/chs3_backup_group.py
+++ b/ch_tools/chadmin/cli/chs3_backup_group.py
@@ -6,6 +6,7 @@ from click import ClickException, argument, group, option, pass_context
 from ch_tools.chadmin.internal.backup import unfreeze_backup, unfreeze_table
 from ch_tools.chadmin.internal.system import match_ch_version
 from ch_tools.chadmin.internal.table import list_tables
+from ch_tools.common import logging
 from ch_tools.common.backup import (
     CHS3_BACKUPS_DIRECTORY,
     get_chs3_backups,
@@ -26,7 +27,7 @@ def list_backups(orphaned):
     """List backups."""
     backups = get_orphaned_chs3_backups() if orphaned else get_chs3_backups()
     for backup in backups:
-        print(backup)
+        logging.info(backup)
 
 
 @chs3_backup_group.command("delete")
@@ -86,7 +87,7 @@ def _delete_chs3_backups(ctx, chs3_backups, *, keep_going, dry_run):
             unfreeze_backup(ctx, chs3_backup, dry_run=dry_run)
         except Exception as e:
             if keep_going:
-                print(f"{e!r}\n")
+                logging.warning(f"{e!r}\n")
             else:
                 raise
 
@@ -98,7 +99,7 @@ def _delete_chs3_backups_comp(ctx, chs3_backups, *, dry_run):
     """
     tables = get_tables_dict(ctx)
     for chs3_backup in chs3_backups:
-        print(f"Removing backup: {chs3_backup}")
+        logging.info(f"Removing backup: {chs3_backup}")
         for table in tables:
             try:
                 unfreeze_table(
@@ -109,7 +110,7 @@ def _delete_chs3_backups_comp(ctx, chs3_backups, *, dry_run):
                     dry_run=dry_run,
                 )
             except requests.exceptions.HTTPError:
-                print(
+                logging.error(
                     f"Can't unfreeze table {table} in backup {chs3_backup}. Maybe it was deleted."
                 )
             if not dry_run:
@@ -130,7 +131,7 @@ def clear_empty_backup(orphaned_chs3_backup):
             os.remove(os.path.join(backup_directory, "revision.txt"))
             os.rmdir(backup_directory)
     except FileNotFoundError:
-        print(
+        logging.error(
             f"Cannot remove backup directory {backup_directory} as it doesn`t exist. "
             f"Maybe it was already removed."
         )

--- a/ch_tools/chadmin/cli/crash_log_group.py
+++ b/ch_tools/chadmin/cli/crash_log_group.py
@@ -1,6 +1,7 @@
 from click import group, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_cluster_name
 
 
@@ -41,4 +42,4 @@ def list_crashes_command(ctx, on_cluster):
         {% endif %}
         ORDER BY event_time DESC
         """
-    print(execute_query(ctx, query_str, cluster=cluster, format_="Vertical"))
+    logging.info(execute_query(ctx, query_str, cluster=cluster, format_="Vertical"))

--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -230,9 +230,8 @@ def cleanup_data_dir(ctx, remove, disk, keep_going, max_sql_objects, max_workers
                     future.result()
                 except Exception as e:
                     if keep_going:
-                        logging.exception(
-                            "Ignoring the exception due to keep-going flag : %s ",
-                            repr(e),
+                        logging.warning(
+                            f"Ignoring the exception due to keep-going flag : {repr(e)}",
                         )
                     else:
                         raise
@@ -297,7 +296,7 @@ def remove_from_disk(
     disk: str, path: str, disk_config_path: Optional[str] = None
 ) -> Tuple[int, bytes]:
     cmd = f"clickhouse-disks { '-C ' + disk_config_path if disk_config_path else ''} --disk {disk} remove {path}"
-    logging.info("Run : %s", cmd)
+    logging.info(f"Run : {cmd}")
     proc = subprocess.run(
         cmd, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )

--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -72,7 +72,7 @@ def process_path(
     column: str,
     remove: bool,
 ) -> dict:
-    logging.info(f"Processing path {path} with prefix {prefix}:")
+    logging.info("Processing path {} with prefix {}:", path, prefix)
 
     result = {
         "path": path,
@@ -82,13 +82,13 @@ def process_path(
     }
 
     size = du(path)
-    logging.info(f"Size of path {path}: {size}")
+    logging.info("Size of path {}: {}", path, size)
     result["size"] = size
 
     file = prefix_exists_in_metadata(prefix)
 
     if file:
-        logging.info(f'Prefix "{prefix}" is used in metadata file "{file}"')
+        logging.info('Prefix "{}" is used in metadata file "{}"', prefix, file)
         result["status"] = "used"
         return result
 
@@ -97,17 +97,18 @@ def process_path(
         result["status"] = "not_passed_column_check"
         return result
 
-    logging.info(f'Prefix "{prefix}" is NOT used in any metadata file')
+    logging.info('Prefix "{}" is NOT used in any metadata file', prefix)
     result["status"] = "not_used"
 
     if remove:
-        logging.info(f'Trying to remove path "{path}"')
+        logging.info('Trying to remove path "{}"', path)
 
         remove_data(path)
         result["removed"] = True
     else:
         logging.info(
-            f'Path "{path}" is not removed because of remove-parameter is not specified'
+            'Path "{}" is not removed because of remove-parameter is not specified',
+            path,
         )
         result["removed"] = False
 
@@ -148,7 +149,7 @@ def du(path: str) -> str:
 def remove_data(path: str) -> None:
     def onerror(*args):
         errors = "\n".join(list(args))
-        logging.error(f"ERROR: {errors}")
+        logging.error("ERROR: {}", errors)
 
     shutil.rmtree(path=path, onerror=onerror)
 
@@ -231,7 +232,7 @@ def cleanup_data_dir(ctx, remove, disk, keep_going, max_sql_objects, max_workers
                 except Exception as e:
                     if keep_going:
                         logging.warning(
-                            f"Ignoring the exception due to keep-going flag : {repr(e)}",
+                            "Ignoring the exception due to keep-going flag : {!r}", e
                         )
                     else:
                         raise
@@ -296,7 +297,7 @@ def remove_from_disk(
     disk: str, path: str, disk_config_path: Optional[str] = None
 ) -> Tuple[int, bytes]:
     cmd = f"clickhouse-disks { '-C ' + disk_config_path if disk_config_path else ''} --disk {disk} remove {path}"
-    logging.info(f"Run : {cmd}")
+    logging.info("Run : {}", cmd)
     proc = subprocess.run(
         cmd, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )

--- a/ch_tools/chadmin/cli/database_group.py
+++ b/ch_tools/chadmin/cli/database_group.py
@@ -2,6 +2,7 @@ from cloup import argument, group, option, option_group, pass_context
 from cloup.constraints import RequireAtLeast
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_cluster_name
 
 
@@ -22,7 +23,7 @@ def database_group():
 )
 @pass_context
 def get_database_command(ctx, database, active_parts):
-    print(
+    logging.info(
         get_databases(
             ctx, database=database, active_parts=active_parts, format_="Vertical"
         )
@@ -41,7 +42,7 @@ def get_database_command(ctx, database, active_parts):
 )
 @pass_context
 def list_databases_command(ctx, **kwargs):
-    print(get_databases(ctx, **kwargs, format_="PrettyCompact"))
+    logging.info(get_databases(ctx, **kwargs, format_="PrettyCompact"))
 
 
 @database_group.command("delete")

--- a/ch_tools/chadmin/cli/dictionary_group.py
+++ b/ch_tools/chadmin/cli/dictionary_group.py
@@ -37,7 +37,7 @@ def reload_command(ctx, name, status):
     """
     dictionaries = list_dictionaries(ctx, name=name, status=status)
     for dictionary in dictionaries:
-        logging.info(f"Reloading dictionary {_full_name(dictionary)}")
+        logging.info("Reloading dictionary {}", _full_name(dictionary))
         reload_dictionary(ctx, database=dictionary["database"], name=dictionary["name"])
 
 

--- a/ch_tools/chadmin/cli/dictionary_group.py
+++ b/ch_tools/chadmin/cli/dictionary_group.py
@@ -1,6 +1,7 @@
 from click import group, option, pass_context
 
 from ch_tools.chadmin.internal.dictionary import list_dictionaries, reload_dictionary
+from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_response
 
 
@@ -36,7 +37,7 @@ def reload_command(ctx, name, status):
     """
     dictionaries = list_dictionaries(ctx, name=name, status=status)
     for dictionary in dictionaries:
-        print(f"Reloading dictionary {_full_name(dictionary)}")
+        logging.info(f"Reloading dictionary {_full_name(dictionary)}")
         reload_dictionary(ctx, database=dictionary["database"], name=dictionary["name"])
 
 

--- a/ch_tools/chadmin/cli/disk_group.py
+++ b/ch_tools/chadmin/cli/disk_group.py
@@ -4,6 +4,8 @@ import shutil
 
 from click import group, option
 
+from ch_tools.common import logging
+
 
 @group("disks")
 def disks_group():
@@ -28,13 +30,12 @@ def check_dir(path, cleanup):
     for dirpath, _, filenames in os.walk(path):
         for filename in filenames:
             if not check_file(f"{dirpath}/{filename}"):
-                print(f"{dirpath}/{filename}")
+                logging.info(f"{dirpath}/{filename}")
                 if dirpath not in corrupted_dirs:
                     corrupted_dirs.append(dirpath)
     if cleanup:
-        print("")
         for dirpath in corrupted_dirs:
-            print(f'Remove directory "{dirpath}"')
+            logging.info(f'Remove directory "{dirpath}"')
             shutil.rmtree(dirpath)
 
 

--- a/ch_tools/chadmin/cli/disk_group.py
+++ b/ch_tools/chadmin/cli/disk_group.py
@@ -30,12 +30,12 @@ def check_dir(path, cleanup):
     for dirpath, _, filenames in os.walk(path):
         for filename in filenames:
             if not check_file(f"{dirpath}/{filename}"):
-                logging.info(f"{dirpath}/{filename}")
+                logging.info("{}/{}", dirpath, filename)
                 if dirpath not in corrupted_dirs:
                     corrupted_dirs.append(dirpath)
     if cleanup:
         for dirpath in corrupted_dirs:
-            logging.info(f'Remove directory "{dirpath}"')
+            logging.info('Remove directory "{}"', dirpath)
             shutil.rmtree(dirpath)
 
 

--- a/ch_tools/chadmin/cli/list_async_metrics_command.py
+++ b/ch_tools/chadmin/cli/list_async_metrics_command.py
@@ -1,6 +1,7 @@
 from click import command, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("async-metrics")
@@ -9,4 +10,4 @@ def list_async_metrics_command(ctx):
     """
     Show metrics from system.async_metrics.
     """
-    print(execute_query(ctx, "SELECT * FROM system.asynchronous_metrics"))
+    logging.info(execute_query(ctx, "SELECT * FROM system.asynchronous_metrics"))

--- a/ch_tools/chadmin/cli/list_events_command.py
+++ b/ch_tools/chadmin/cli/list_events_command.py
@@ -1,6 +1,7 @@
 from click import command, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("events")
@@ -9,4 +10,4 @@ def list_events_command(ctx):
     """
     Show metrics from system.events.
     """
-    print(execute_query(ctx, "SELECT * FROM system.events"))
+    logging.info(execute_query(ctx, "SELECT * FROM system.events"))

--- a/ch_tools/chadmin/cli/list_functions_command.py
+++ b/ch_tools/chadmin/cli/list_functions_command.py
@@ -1,6 +1,7 @@
 from click import command, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("functions")
@@ -17,4 +18,4 @@ def list_functions_command(ctx, name):
         WHERE lower(name) {{ format_str_imatch(name) }}
         {% endif %}
         """
-    print(execute_query(ctx, query, name=name))
+    logging.info(execute_query(ctx, query, name=name))

--- a/ch_tools/chadmin/cli/list_macros_command.py
+++ b/ch_tools/chadmin/cli/list_macros_command.py
@@ -1,6 +1,7 @@
 from click import command, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("macros")
@@ -9,4 +10,4 @@ def list_macros_command(ctx):
     """
     Show macros.
     """
-    print(execute_query(ctx, "SELECT * FROM system.macros"))
+    logging.info(execute_query(ctx, "SELECT * FROM system.macros"))

--- a/ch_tools/chadmin/cli/list_metrics_command.py
+++ b/ch_tools/chadmin/cli/list_metrics_command.py
@@ -1,6 +1,7 @@
 from click import command, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("metrics")
@@ -9,4 +10,4 @@ def list_metrics_command(ctx):
     """
     Show metrics from system.metrics.
     """
-    print(execute_query(ctx, "SELECT * FROM system.metrics"))
+    logging.info(execute_query(ctx, "SELECT * FROM system.metrics"))

--- a/ch_tools/chadmin/cli/list_settings_command.py
+++ b/ch_tools/chadmin/cli/list_settings_command.py
@@ -1,6 +1,7 @@
 from click import command, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("settings")
@@ -22,4 +23,4 @@ def list_settings_command(ctx, name, changed):
           AND changed
         {% endif %}
         """
-    print(execute_query(ctx, query, name=name, changed=changed))
+    logging.info(execute_query(ctx, query, name=name, changed=changed))

--- a/ch_tools/chadmin/cli/mutation_group.py
+++ b/ch_tools/chadmin/cli/mutation_group.py
@@ -1,6 +1,7 @@
 from click import argument, group, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_cluster_name
 
 
@@ -31,7 +32,7 @@ def get_mutation(ctx, mutation, last):
         LIMIT 1
         {% endif %}
         """
-    print(execute_query(ctx, query, mutation=mutation, format_="Vertical"))
+    logging.info(execute_query(ctx, query, mutation=mutation, format_="Vertical"))
 
 
 @mutation_group.command("list")
@@ -102,7 +103,7 @@ def list_mutations(ctx, is_done, command_pattern, on_cluster, limit):
         limit=limit,
         format_="Vertical",
     )
-    print(response)
+    logging.info(response)
 
 
 @mutation_group.command("kill")
@@ -138,4 +139,4 @@ def kill_mutation(ctx, command_pattern, on_cluster):
         echo=True,
         format_="PrettyCompact",
     )
-    print(response)
+    logging.info(response)

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -192,7 +192,7 @@ def _clean_object_storage(
           ON object_table.remote_path = object_storage.obj_path
             AND object_table.disk_name = '{disk_conf.name}'
     """
-    logging.info(f"Antijoin query: {antijoin_query}")
+    logging.info("Antijoin query: {}", antijoin_query)
 
     if dry_run:
         logging.info("Counting orphaned objects...")
@@ -279,7 +279,7 @@ def _traverse_object_storage(
     if obj_paths_batch:
         _insert_listing_batch(ctx, obj_paths_batch, listing_table)
 
-    logging.info(f"Collected {counter} objects")
+    logging.info("Collected {} objects", counter)
 
 
 def _insert_listing_batch(

--- a/ch_tools/chadmin/cli/part_group.py
+++ b/ch_tools/chadmin/cli/part_group.py
@@ -199,7 +199,7 @@ def attach_parts_command(ctx, _all, keep_going, dry_run, **kwargs):
             )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise
 
@@ -272,7 +272,7 @@ def detach_parts_command(ctx, _all, keep_going, dry_run, **kwargs):
             )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise
 
@@ -383,7 +383,7 @@ def delete_parts_command(
                 )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise
 
@@ -461,6 +461,6 @@ def move_parts_command(
             )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise

--- a/ch_tools/chadmin/cli/part_group.py
+++ b/ch_tools/chadmin/cli/part_group.py
@@ -13,6 +13,7 @@ from ch_tools.chadmin.internal.part import (
     move_part,
 )
 from ch_tools.chadmin.internal.system import match_ch_version
+from ch_tools.common import logging
 from ch_tools.common.cli.formatting import format_bytes, print_response
 from ch_tools.common.cli.parameters import BytesParamType
 
@@ -198,7 +199,7 @@ def attach_parts_command(ctx, _all, keep_going, dry_run, **kwargs):
             )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise
 
@@ -271,7 +272,7 @@ def detach_parts_command(ctx, _all, keep_going, dry_run, **kwargs):
             )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise
 
@@ -382,7 +383,7 @@ def delete_parts_command(
                 )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise
 
@@ -460,6 +461,6 @@ def move_parts_command(
             )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise

--- a/ch_tools/chadmin/cli/partition_group.py
+++ b/ch_tools/chadmin/cli/partition_group.py
@@ -9,6 +9,7 @@ from ch_tools.chadmin.internal.partition import (
     optimize_partition,
 )
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.cli.parameters import BytesParamType
 
 
@@ -86,7 +87,7 @@ def partition_group():
 @pass_context
 def list_partitions_command(ctx, **kwargs):
     """List partitions."""
-    print(get_partitions(ctx, format_="PrettyCompact", **kwargs))
+    logging.info(get_partitions(ctx, format_="PrettyCompact", **kwargs))
 
 
 @partition_group.command("attach")
@@ -162,7 +163,7 @@ def attach_partitions_command(
             )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise
 
@@ -256,7 +257,7 @@ def detach_partitions_command(
             )
         except Exception as e:
             if keep_going:
-                print(repr(e))
+                logging.warning(repr(e))
             else:
                 raise
 

--- a/ch_tools/chadmin/cli/partition_group.py
+++ b/ch_tools/chadmin/cli/partition_group.py
@@ -163,7 +163,7 @@ def attach_partitions_command(
             )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise
 
@@ -257,7 +257,7 @@ def detach_partitions_command(
             )
         except Exception as e:
             if keep_going:
-                logging.warning(repr(e))
+                logging.warning("{!r}\n", e)
             else:
                 raise
 

--- a/ch_tools/chadmin/cli/query_log_group.py
+++ b/ch_tools/chadmin/cli/query_log_group.py
@@ -3,6 +3,7 @@ import datetime
 from click import Choice, argument, group, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_cluster_name
 
 
@@ -25,11 +26,8 @@ def query_log_group():
 )
 @pass_context
 def get_query_command(ctx, **kwargs):
-    print(get_queries(ctx, **kwargs, verbose=True))
-    print("\nProfileEvents:")
-    print(get_query_metrics(ctx, **kwargs))
-    print("\nSettings:")
-    print(get_query_settings(ctx, **kwargs))
+    result = f"{get_queries(ctx, **kwargs, verbose=True)}\nProfileEvents:{get_query_metrics(ctx, **kwargs)}\nSettings:{get_query_settings(ctx, **kwargs)}"
+    logging.info(result)
 
 
 @query_log_group.command("list")
@@ -112,7 +110,7 @@ def list_queries_command(
     max_date = max_date or date
     min_time = min_time or time
     max_time = max_time or time
-    print(
+    logging.info(
         get_queries(
             ctx,
             min_date=min_date,
@@ -206,7 +204,7 @@ def get_statistics_command(
           AND lower(exception) LIKE lower('{{ error }}')
         {% endif -%}
     """
-    print(
+    logging.info(
         execute_query(
             ctx,
             query_str,
@@ -249,7 +247,7 @@ def get_query_settings_command(ctx, query_id, on_cluster):
         WHERE type != 1
           AND query_id = '{{ query_id }}'
         """
-    print(execute_query(ctx, query_str, query_id=query_id, cluster=cluster))
+    logging.info(execute_query(ctx, query_str, query_id=query_id, cluster=cluster))
 
 
 @query_log_group.command("get-metrics")
@@ -278,7 +276,7 @@ def get_query_metrics_command(ctx, query_id, on_cluster):
           AND query_id = '{{ query_id }}'
         ORDER BY name
         """
-    print(execute_query(ctx, query_str, query_id=query_id, cluster=cluster))
+    logging.info(execute_query(ctx, query_str, query_id=query_id, cluster=cluster))
 
 
 def get_queries(

--- a/ch_tools/chadmin/cli/replication_queue_group.py
+++ b/ch_tools/chadmin/cli/replication_queue_group.py
@@ -4,6 +4,7 @@ from click import group, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
 from ch_tools.chadmin.internal.zookeeper import delete_zk_node
+from ch_tools.common import logging
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.config import get_cluster_name
 
@@ -77,7 +78,7 @@ def list_replication_queue_command(ctx, **kwargs):
     """
     List replication queue tasks.
     """
-    print(get_replication_queue_tasks(ctx, **kwargs, format_="Vertical"))
+    logging.info(get_replication_queue_tasks(ctx, **kwargs, format_="Vertical"))
 
 
 @replication_queue_group.command("delete")
@@ -136,7 +137,7 @@ def delete_command(ctx, **kwargs):
     for table, tasks in group_tasks_by_table(tasks).items():
         database, table = table
 
-        print(f"Detaching table `{database}`.`{table}`")
+        logging.info(f"Detaching table `{database}`.`{table}`")
         execute_query(
             ctx,
             f"""DETACH TABLE `{database}`.`{table}`""",
@@ -147,10 +148,10 @@ def delete_command(ctx, **kwargs):
 
         for task in tasks:
             zk_path = task["zk_path"]
-            print(f"Deleting task from ZooKeeper: {zk_path}")
+            logging.info(f"Deleting task from ZooKeeper: {zk_path}")
             delete_zk_node(ctx, zk_path)
 
-        print(f"Attaching table `{database}`.`{table}`")
+        logging.info(f"Attaching table `{database}`.`{table}`")
         execute_query(
             ctx,
             f"""ATTACH TABLE `{database}`.`{table}`""",

--- a/ch_tools/chadmin/cli/replication_queue_group.py
+++ b/ch_tools/chadmin/cli/replication_queue_group.py
@@ -137,7 +137,7 @@ def delete_command(ctx, **kwargs):
     for table, tasks in group_tasks_by_table(tasks).items():
         database, table = table
 
-        logging.info(f"Detaching table `{database}`.`{table}`")
+        logging.info("Detaching table `{}`.`{}`", database, table)
         execute_query(
             ctx,
             f"""DETACH TABLE `{database}`.`{table}`""",
@@ -148,10 +148,10 @@ def delete_command(ctx, **kwargs):
 
         for task in tasks:
             zk_path = task["zk_path"]
-            logging.info(f"Deleting task from ZooKeeper: {zk_path}")
+            logging.info("Deleting task from ZooKeeper: {}", zk_path)
             delete_zk_node(ctx, zk_path)
 
-        logging.info(f"Attaching table `{database}`.`{table}`")
+        logging.info("Attaching table `{}`.`{}`", database, table)
         execute_query(
             ctx,
             f"""ATTACH TABLE `{database}`.`{table}`""",

--- a/ch_tools/chadmin/cli/stack_trace_command.py
+++ b/ch_tools/chadmin/cli/stack_trace_command.py
@@ -1,6 +1,7 @@
 from click import command, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @command("stack-trace")
@@ -25,4 +26,4 @@ def stack_trace_command(ctx):
         GROUP BY thread_name, trace
         ORDER BY min_thread_id
     """
-    print(execute_query(ctx, query_str, format_="Vertical"))
+    logging.info(execute_query(ctx, query_str, format_="Vertical"))

--- a/ch_tools/chadmin/cli/table_group.py
+++ b/ch_tools/chadmin/cli/table_group.py
@@ -12,6 +12,7 @@ from ch_tools.chadmin.internal.table import (
     materialize_ttl,
 )
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_response
 from ch_tools.common.cli.parameters import StringParamType
 from ch_tools.common.clickhouse.config import get_cluster_name
@@ -109,7 +110,7 @@ def columns_command(ctx, database, table):
         WHERE database = '{{ database }}'
           AND table = '{{ table }}'
         """
-    print(execute_query(ctx, query, database=database, table=table))
+    logging.info(execute_query(ctx, query, database=database, table=table))
 
 
 @table_group.command("delete")
@@ -527,4 +528,4 @@ def set_flag_command(
 
     if verbose:
         for table_, flag_path in zip(tables, flag_paths):
-            print(f"{table_['table']}: {flag_path}")
+            logging.info(f"{table_['table']}: {flag_path}")

--- a/ch_tools/chadmin/cli/table_group.py
+++ b/ch_tools/chadmin/cli/table_group.py
@@ -528,4 +528,4 @@ def set_flag_command(
 
     if verbose:
         for table_, flag_path in zip(tables, flag_paths):
-            logging.info(f"{table_['table']}: {flag_path}")
+            logging.info("{}: {}", table_["table"], flag_path)

--- a/ch_tools/chadmin/cli/thread_log_group.py
+++ b/ch_tools/chadmin/cli/thread_log_group.py
@@ -1,6 +1,7 @@
 from click import argument, group, option, pass_context
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 @group("thread-log")
@@ -25,7 +26,7 @@ def list_threads_command(
 ):
     min_date = min_date or date
     max_date = max_date or date
-    print(
+    logging.info(
         get_threads(
             ctx,
             query_id=query_id,
@@ -135,7 +136,7 @@ def get_thread_metrics_command(
         {% endif %}
         ORDER BY thread_name, thread_number, name
         """
-    print(
+    logging.info(
         execute_query(
             ctx,
             query_str,

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -117,11 +117,11 @@ def wait_replication_sync_command(
                 settings={"receive_timeout": timeout},
             )
         except ReadTimeout:
-            print(f"Timeout while running SYNC REPLICA on {full_name}.")
+            logging.error(f"Timeout while running SYNC REPLICA on {full_name}.")
             sys.exit(1)
         except ClickhouseError as e:
             if "TIMEOUT_EXCEEDED" in str(e):
-                print(f"Timeout while running SYNC REPLICA on {full_name}.")
+                logging.error(f"Timeout while running SYNC REPLICA on {full_name}.")
                 sys.exit(1)
             raise
 
@@ -132,7 +132,7 @@ def wait_replication_sync_command(
             sys.exit(0)
         time.sleep(pause.total_seconds())
 
-    print("Timeout while waiting on replication-lag command.")
+    logging.error("Timeout while waiting on replication-lag command.")
     sys.exit(1)
 
 
@@ -147,9 +147,8 @@ def wait_replication_sync_command(
 @pass_context
 def wait_started_command(ctx, timeout, quiet):
     """Wait for ClickHouse server to start up."""
-    if not quiet:
-        logging.add(sys.stdout, level="INFO", format_="{message}")
-
+    if quiet:
+        logging.disable_stdout_logger()
     if not timeout:
         timeout = get_timeout()
 

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -117,11 +117,11 @@ def wait_replication_sync_command(
                 settings={"receive_timeout": timeout},
             )
         except ReadTimeout:
-            logging.error(f"Timeout while running SYNC REPLICA on {full_name}.")
+            logging.error("Timeout while running SYNC REPLICA on {}.", full_name)
             sys.exit(1)
         except ClickhouseError as e:
             if "TIMEOUT_EXCEEDED" in str(e):
-                logging.error(f"Timeout while running SYNC REPLICA on {full_name}.")
+                logging.error("Timeout while running SYNC REPLICA on {}.", full_name)
                 sys.exit(1)
             raise
 
@@ -216,7 +216,7 @@ def is_clickhouse_alive():
             return True
 
     except Exception as e:
-        logging.error(f"Failed to perform ch_ping check: {repr(e)}")
+        logging.error("Failed to perform ch_ping check: {!r}", e)
 
     return False
 

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -16,6 +16,7 @@ from ch_tools.chadmin.internal.zookeeper import (
     update_acls_zk_node,
     update_zk_nodes,
 )
+from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_json, print_response
 from ch_tools.common.cli.parameters import ListParamType, StringParamType
 from ch_tools.common.config import load_config
@@ -99,7 +100,7 @@ def get_command(ctx, path, binary):
 
     Node path can be specified with ClickHouse macros. Example: "/test_table/{shard}/replicas/{replica}".
     """
-    print(get_zk_node(ctx, path, binary=binary))
+    logging.info(get_zk_node(ctx, path, binary=binary))
 
 
 @zookeeper_group.command("exists")
@@ -111,9 +112,9 @@ def exists_command(ctx, path):
     Node path can be specified with ClickHouse macros. Example: "/test_table/{shard}/replicas/{replica}".
     """
     if check_zk_node(ctx, path):
-        print(True)
+        logging.info(True)
         return
-    print(False)
+    logging.error(False)
     sys.exit(1)
 
 
@@ -141,7 +142,7 @@ def list_command(ctx, path, verbose):
     if verbose:
         print_response(ctx, nodes, format_="table")
     else:
-        print("\n".join(nodes))
+        logging.info("\n".join(nodes))
 
 
 @zookeeper_group.command("stat")
@@ -152,7 +153,7 @@ def stat_command(ctx, path):
 
     Node path can be specified with ClickHouse macros. Example: "/test_table/{shard}/replicas/{replica}".
     """
-    print(get_zk_node_acls(ctx, path)[1])
+    logging.info(get_zk_node_acls(ctx, path)[1])
 
 
 @zookeeper_group.command("create")
@@ -207,7 +208,7 @@ def get_table_metadata_command(ctx, database, table):
     """Get table metadata stored in ZooKeeper."""
     table_replica = get_table_replica(ctx, database, table)
     path = table_replica["zookeeper_path"] + "/metadata"
-    print(get_zk_node(ctx, path))
+    logging.info(get_zk_node(ctx, path))
 
 
 @zookeeper_group.command("update-table-metadata")
@@ -274,7 +275,7 @@ def get_table_replica_metadata_command(ctx, database, table):
     """Get table replica metadata stored in ZooKeeper."""
     table_replica = get_table_replica(ctx, database, table)
     path = table_replica["replica_path"] + "/metadata"
-    print(get_zk_node(ctx, path))
+    logging.info(get_zk_node(ctx, path))
 
 
 @zookeeper_group.command("get-ddl-task")
@@ -283,7 +284,7 @@ def get_table_replica_metadata_command(ctx, database, table):
 def get_ddl_task_command(ctx, task):
     """Get DDL queue task metadata stored in ZooKeeper."""
     path = f"/clickhouse/task_queue/ddl/{task}"
-    print(get_zk_node(ctx, path))
+    logging.info(get_zk_node(ctx, path))
 
 
 @zookeeper_group.command("delete-ddl-task")

--- a/ch_tools/chadmin/internal/diagnostics/data.py
+++ b/ch_tools/chadmin/internal/diagnostics/data.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 import yaml
 from requests.exceptions import RequestException
 
+from ch_tools.common import logging
 from ch_tools.common.clickhouse.client import ClickhouseClient, OutputFormat
 
 from .utils import delayed
@@ -74,7 +75,7 @@ class DiagnosticsData:
             compressor = gzip.GzipFile(mode="wb", fileobj=sys.stdout.buffer)
             compressor.write(result.encode())
         else:
-            print(result)
+            logging.info(result)
 
     def _section(self, name=None):
         if self._sections[-1]["section"] != name:

--- a/ch_tools/chadmin/internal/process.py
+++ b/ch_tools/chadmin/internal/process.py
@@ -1,6 +1,7 @@
 from click import ClickException
 
 from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
 
 
 def get_process(ctx, query_id):
@@ -118,7 +119,7 @@ def kill_process(ctx, query_id=None, user=None, exclude_user=None):
           AND query_id = '{{ query_id }}'
         {% endif %}
         """
-    print(
+    logging.info(
         execute_query(
             ctx, query_str, query_id=query_id, user=user, exclude_user=exclude_user
         )

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -112,7 +112,7 @@ def _set_node_value(zk, path, value):
         try:
             zk.set(path, value.encode())
         except NoNodeError:
-            logging.warning(f"Can not set for node: {path}  value : {value}")
+            logging.warning("Can not set for node: {}  value : {}", path, value)
 
 
 def _find_paths(zk, root_path, included_paths_regexp, excluded_paths_regexp=None):
@@ -170,7 +170,7 @@ def _delete_nodes_transaction(zk, to_delete_in_trasaction):
                 successful_delete = True
             except NoNodeError:
                 #  Someone deleted node before us. Do nothing.
-                logging.error(f"Node {node} is already absent, skipped")
+                logging.error("Node {} is already absent, skipped", node)
                 successful_delete = True
             except NotEmptyError:
                 # Someone created a node while we deleting. Restart the operation.
@@ -210,7 +210,7 @@ def _delete_recursive(zk, paths):
 
     if len(paths) == 0:
         return
-    logging.info(f"Node to recursive delete {paths}")
+    logging.info("Node to recursive delete {}", paths)
     paths = _remove_subpaths(paths)
     nodes_to_delete = []
     queue = deque(paths)
@@ -317,7 +317,7 @@ def clean_zk_metadata_for_hosts(
 
             for node in nodes:
                 is_lost_flag_path = os.path.join(replica_path, node, "is_lost")
-                logging.info(f"Set is_lost_flag {is_lost_flag_path}")
+                logging.info("Set is_lost_flag {}", is_lost_flag_path)
                 _set_node_value(zk, is_lost_flag_path, "1")
 
     def _remove_replicas_queues(zk, paths, replica_names):
@@ -405,7 +405,7 @@ def clean_zk_metadata_for_hosts(
 
         for ddl_task in _get_children(zk, _format_path(ctx, zk_ddl_query_path)):
             ddl_task_full = os.path.join(zk_ddl_query_path, ddl_task)
-            logging.info(f"DDL task full path: {ddl_task_full}")
+            logging.info("DDL task full path: {}", ddl_task_full)
             for host in nodes:
                 host_mention = get_host_mention_in_task(zk, host, ddl_task_full)
                 if not host_mention:
@@ -413,9 +413,9 @@ def clean_zk_metadata_for_hosts(
                     continue
                 finished_path = os.path.join(ddl_task_full, f"finished/{host_mention}")
                 if zk.exists(finished_path):
-                    logging.info(f"Finished path already exists: {finished_path}")
+                    logging.info("Finished path already exists: {}", finished_path)
                     continue
-                logging.info(f"Add {host} to finished for ddl_task: {ddl_task}")
+                logging.info("Add {} to finished for ddl_task: {}", host, ddl_task)
                 zk.create(finished_path, b"0\n")
         logging.info("Finish mark ddl query")
 

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -112,7 +112,7 @@ def _set_node_value(zk, path, value):
         try:
             zk.set(path, value.encode())
         except NoNodeError:
-            print(f"Can not set for node: {path}  value : {value}")
+            logging.warning(f"Can not set for node: {path}  value : {value}")
 
 
 def _find_paths(zk, root_path, included_paths_regexp, excluded_paths_regexp=None):
@@ -158,7 +158,7 @@ def _delete_nodes_transaction(zk, to_delete_in_trasaction):
         # Transaction completed successfully, exit.
         return
 
-    print(
+    logging.info(
         "Delete transaction have failed. Fallthrough to single delete operations for zk_nodes : ",
         to_delete_in_trasaction,
     )
@@ -170,7 +170,7 @@ def _delete_nodes_transaction(zk, to_delete_in_trasaction):
                 successful_delete = True
             except NoNodeError:
                 #  Someone deleted node before us. Do nothing.
-                print("Node {node} is already absent, skipped".format(node=node))
+                logging.error(f"Node {node} is already absent, skipped")
                 successful_delete = True
             except NotEmptyError:
                 # Someone created a node while we deleting. Restart the operation.
@@ -210,7 +210,7 @@ def _delete_recursive(zk, paths):
 
     if len(paths) == 0:
         return
-    print("Node to recursive delete", paths)
+    logging.info(f"Node to recursive delete {paths}")
     paths = _remove_subpaths(paths)
     nodes_to_delete = []
     queue = deque(paths)
@@ -317,7 +317,7 @@ def clean_zk_metadata_for_hosts(
 
             for node in nodes:
                 is_lost_flag_path = os.path.join(replica_path, node, "is_lost")
-                print("Set is_lost_flag " + is_lost_flag_path)
+                logging.info(f"Set is_lost_flag {is_lost_flag_path}")
                 _set_node_value(zk, is_lost_flag_path, "1")
 
     def _remove_replicas_queues(zk, paths, replica_names):
@@ -405,19 +405,19 @@ def clean_zk_metadata_for_hosts(
 
         for ddl_task in _get_children(zk, _format_path(ctx, zk_ddl_query_path)):
             ddl_task_full = os.path.join(zk_ddl_query_path, ddl_task)
-            print(f"DDL task full path: {ddl_task_full}")
+            logging.info(f"DDL task full path: {ddl_task_full}")
             for host in nodes:
                 host_mention = get_host_mention_in_task(zk, host, ddl_task_full)
                 if not host_mention:
-                    print("Host is not mentioned in DDL task value")
+                    logging.info("Host is not mentioned in DDL task value")
                     continue
                 finished_path = os.path.join(ddl_task_full, f"finished/{host_mention}")
                 if zk.exists(finished_path):
-                    print(f"Finished path already exists: {finished_path}")
+                    logging.info(f"Finished path already exists: {finished_path}")
                     continue
-                print(f"Add {host} to finished for ddl_task: {ddl_task}")
+                logging.info(f"Add {host} to finished for ddl_task: {ddl_task}")
                 zk.create(finished_path, b"0\n")
-        print("Finish mark ddl query")
+        logging.info("Finish mark ddl query")
 
     zk_root_path = _format_path(ctx, zk_cleanup_root_path)
 
@@ -493,7 +493,7 @@ def _get_zk_client(ctx):
         connect_str,
         auth_data=auth_data,
         timeout=timeout,
-        logger=logging.getLogger("chadmin"),
+        logger=logging.getNativeLogger("kazoo"),
         use_ssl=use_ssl,
         verify_certs=verify_ssl_certs,
         randomize_hosts=zk_randomize_hosts,

--- a/ch_tools/common/clickhouse/client/clickhouse_client.py
+++ b/ch_tools/common/clickhouse/client/clickhouse_client.py
@@ -204,7 +204,7 @@ class ClickhouseClient:
             if port is None:
                 raise UserWarning(2, "Can't find any port in clickhouse-server config")
 
-        logging.debug(f"Executing query: {query}")
+        logging.debug("Executing query: {}", query)
         if port in [ClickhousePort.HTTPS, ClickhousePort.HTTP]:
             return self._execute_http(
                 query,

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -124,6 +124,7 @@ DEFAULT_CONFIG = {
                 "nose": S3_LOG_CONFIG,
                 "s3transfer": S3_LOG_CONFIG,
                 "urllib3": S3_LOG_CONFIG,
+                "kazoo": S3_LOG_CONFIG,
             },
             "ch-monitoring": {
                 "ch-monitoring": {

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -223,9 +223,10 @@ def enable_stdout_logger():
     """
     Adds stdout logger.
     """
-    logger_config["stdout_logger_id"] = logger.add(
-        sink=sys.stdout,
-        level="INFO",
-        format="{message}",
-        filter=make_filter(logger_config["module"]),
-    )
+    if logger_config.get("stdout_logger_id", None) is None:
+        logger_config["stdout_logger_id"] = logger.add(
+            sink=sys.stdout,
+            level="INFO",
+            format="{message}",
+            filter=make_filter(logger_config["module"]),
+        )

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -4,6 +4,7 @@ Logging module.
 
 import inspect
 import logging
+import sys
 from logging import (  # noqa # pylint:disable=unused-import
     CRITICAL,
     DEBUG,
@@ -112,6 +113,8 @@ def configure(
 
     logger.configure(handlers=loguru_handlers, activation=[("", True)], extra=extra)
 
+    enable_stdout_logger()
+
     # Configure logging.
     logging.basicConfig(handlers=[InterceptHandler()], level=0)
 
@@ -127,47 +130,47 @@ def critical(msg, *args, **kwargs):
     """
     Log a message with severity 'CRITICAL'.
     """
-    _log(CRITICAL, msg, *args, **kwargs)
+    _log("CRITICAL", msg, *args, **kwargs)
 
 
 def error(msg, *args, **kwargs):
     """
     Log a message with severity 'ERROR'.
     """
-    _log(ERROR, msg, *args, **kwargs)
+    _log("ERROR", msg, *args, **kwargs)
 
 
 def exception(msg, *args, exc_info=True, **kwargs):
     """
     Log a message with severity 'ERROR' with exception information.
     """
-    _log(ERROR, msg, *args, exc_info=exc_info, **kwargs)
+    _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
 
 
 def warning(msg, *args, **kwargs):
     """
     Log a message with severity 'WARNING'.
     """
-    _log(WARNING, msg, *args, **kwargs)
+    _log("WARNING", msg, *args, **kwargs)
 
 
 def info(msg, *args, **kwargs):
     """
     Log a message with severity 'INFO'.
     """
-    _log(INFO, msg, *args, **kwargs)
+    _log("INFO", msg, *args, **kwargs)
 
 
 def debug(msg, *args, **kwargs):
     """
     Log a message with severity 'DEBUG'.
     """
-    _log(DEBUG, msg, *args, **kwargs)
+    _log("DEBUG", msg, *args, **kwargs)
 
 
 def log_status(status, msg):
     """
-    Log a message with by status code.
+    Log a message by status code.
     """
     if status == result.OK:
         debug(msg)
@@ -185,6 +188,14 @@ def getLogger(name: str) -> Any:
     return logger.bind(logger_name=name)
 
 
+# pylint: disable=invalid-name
+def getNativeLogger(name: str) -> Any:
+    """
+    Get logging logger with specific name. Might be used for interaction with other libraries.
+    """
+    return logging.getLogger(name)
+
+
 def add(sink, level, format_):
     """
     Add new log handler.
@@ -196,4 +207,25 @@ def set_module_log_level(module, level):
     """
     Set level for logging's logger. Might be used to control logs from other libraries.
     """
-    logging.getLogger(module).setLevel(level)
+    getNativeLogger(module).setLevel(level)
+
+
+def disable_stdout_logger():
+    """
+    Removes stdout handler. May be used for commands with "quiet" option.
+    """
+    if logger_config["stdout_logger_id"]:
+        logger.remove(logger_config["stdout_logger_id"])
+        logger_config["stdout_logger_id"] = None
+
+
+def enable_stdout_logger():
+    """
+    Adds stdout logger.
+    """
+    logger_config["stdout_logger_id"] = logger.add(
+        sink=sys.stdout,
+        level="INFO",
+        format="{message}",
+        filter=make_filter(logger_config["module"]),
+    )

--- a/ch_tools/monrun_checks/ch_ping.py
+++ b/ch_tools/monrun_checks/ch_ping.py
@@ -47,7 +47,7 @@ def ping_command(ctx, number, crit, warn):
                 fails[ClickhousePort.TCP] += 1
                 has_fails = True
         except Exception as e:
-            logging.debug(f"Error on tcp port: {repr(e)}")
+            logging.debug("Error on tcp port: {!r}", e)
             fails[ClickhousePort.TCP] += 1
             has_fails = True
 
@@ -62,7 +62,7 @@ def ping_command(ctx, number, crit, warn):
                     fails[ClickhousePort.TCP_SECURE] += 1
                     has_fails = True
         except Exception as e:
-            logging.debug(f"Error on tcps port: {repr(e)}")
+            logging.debug("Error on tcps port: {!r}", e)
             fails[ClickhousePort.TCP_SECURE] += 1
             has_fails = True
 
@@ -78,7 +78,7 @@ def ping_command(ctx, number, crit, warn):
                     fails[ClickhousePort.HTTP] += 1
                     has_fails = True
         except Exception as e:
-            logging.debug(f"Error on http port: {repr(e)}")
+            logging.debug("Error on http port: {!r}", e)
             fails[ClickhousePort.HTTP] += 1
             has_fails = True
 
@@ -94,7 +94,7 @@ def ping_command(ctx, number, crit, warn):
                     fails[ClickhousePort.HTTPS] += 1
                     has_fails = True
         except Exception as e:
-            logging.debug(f"Error on https port: {repr(e)}")
+            logging.debug("Error on https port: {!r}", e)
             fails[ClickhousePort.HTTPS] += 1
             has_fails = True
 

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -80,7 +80,7 @@ class MonrunChecks(cloup.Group):
                         status.add_verbose(result.verbose)
             except Exception as exc:
                 if not isinstance(exc, UserWarning):
-                    logging.exception(f"Got error:")
+                    logging.exception("Got error:")
                 status = translate_to_status(exc, status)
 
             log_message = f"Completed with {status.code};{status.message}"

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -73,18 +73,19 @@ class MonrunChecks(cloup.Group):
             status = Status()
             try:
                 result = ctx.invoke(cmd_callback, *args, **kwargs)
+                logging.disable_stdout_logger()
                 if result:
                     status.append(result.message)
                     status.set_code(result.code)
                     if result.verbose:
                         status.add_verbose(result.verbose)
             except Exception as exc:
+                logging.disable_stdout_logger()
                 if not isinstance(exc, UserWarning):
                     logging.exception("Got error:")
                 status = translate_to_status(exc, status)
 
             log_message = f"Completed with {status.code};{status.message}"
-            logging.disable_stdout_logger()
             logging.log_status(status.code, log_message)
 
             if ctx.obj and ctx.obj.get("status_mode", False):

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -80,10 +80,11 @@ class MonrunChecks(cloup.Group):
                         status.add_verbose(result.verbose)
             except Exception as exc:
                 if not isinstance(exc, UserWarning):
-                    logging.exception("Got error %s", repr(exc))
+                    logging.exception(f"Got error:")
                 status = translate_to_status(exc, status)
 
             log_message = f"Completed with {status.code};{status.message}"
+            logging.disable_stdout_logger()
             logging.log_status(status.code, log_message)
 
             if ctx.obj and ctx.obj.get("status_mode", False):

--- a/ch_tools/monrun_checks_keeper/main.py
+++ b/ch_tools/monrun_checks_keeper/main.py
@@ -66,6 +66,7 @@ class KeeperChecks(cloup.Group):
                 status.set_code(1)
 
             log_message = f"Completed with {status.code};{status.message}"
+            logging.disable_stdout_logger()
             logging.log_status(status.code, log_message)
 
             if ctx.obj and ctx.obj.get("status_mode", False):

--- a/ch_tools/monrun_checks_keeper/main.py
+++ b/ch_tools/monrun_checks_keeper/main.py
@@ -57,16 +57,17 @@ class KeeperChecks(cloup.Group):
             status = Status()
             try:
                 result = ctx.invoke(cmd_callback, *a, **kw)
+                logging.disable_stdout_logger()
                 if result:
                     status.append(result.message)
                     status.set_code(result.code)
             except Exception as e:
+                logging.disable_stdout_logger()
                 logging.exception("Error occurred while executing:")
                 status.append(repr(e))
                 status.set_code(1)
 
             log_message = f"Completed with {status.code};{status.message}"
-            logging.disable_stdout_logger()
             logging.log_status(status.code, log_message)
 
             if ctx.obj and ctx.obj.get("status_mode", False):

--- a/tests/features/monrun_keeper.feature
+++ b/tests/features/monrun_keeper.feature
@@ -45,7 +45,7 @@ Feature: keeper-monitoring tool
     """
     keeper-monitoring version
     """
-    Then we get response
+    Then we get response contains
     """
     1;ConnectionRefusedError(111, 'Connection refused')
     """

--- a/tests/features/monrun_keeper.feature
+++ b/tests/features/monrun_keeper.feature
@@ -45,7 +45,7 @@ Feature: keeper-monitoring tool
     """
     keeper-monitoring version
     """
-    Then we get response contains
+    Then we get response
     """
     1;ConnectionRefusedError(111, 'Connection refused')
     """

--- a/tests/modules/chadmin.py
+++ b/tests/modules/chadmin.py
@@ -7,7 +7,7 @@ class Chadmin:
 
     def exec_cmd(self, cmd):
         ch_admin_cmd = f"chadmin {cmd}"
-        logging.debug(f"chadmin command: {ch_admin_cmd}")
+        logging.debug("chadmin command: {}", ch_admin_cmd)
 
         result = self._container.exec_run(["bash", "-c", ch_admin_cmd], user="root")
         return result

--- a/tests/modules/clickhouse.py
+++ b/tests/modules/clickhouse.py
@@ -138,7 +138,6 @@ def execute_query(
     client = clickhouse_client(context, node)
 
     try:
-        logging.debug(f"Executing ClickHouse query: {query}")
         response = client.query(query, format_=format_)
     except HTTPError as e:
         logging.critical(f"Error while performing request: {e.response.text}")

--- a/tests/modules/utils.py
+++ b/tests/modules/utils.py
@@ -41,11 +41,11 @@ def env_stage(event, fail=False):
         @wraps(fun)
         def _wrapped_fun(*args, **kwargs):
             stage_name = f"{fun.__module__}.{fun.__name__}"
-            logging.info(f"initiating {event} stage {stage_name}")
+            logging.info("initiating {} stage {}", event, stage_name)
             try:
                 return fun(*args, **kwargs)
             except Exception as e:
-                logging.error(f"{stage_name} failed: {repr(e)}")
+                logging.error("{} failed: {!r}", stage_name, e)
                 if fail:
                     raise
 


### PR DESCRIPTION
- Almost all prints are replaced with logging call
- Stdout handler is added by default
- Method to disable stdout logger is added so it can be used with `quiet` option(like in `chadmin wait started`)