### PR TITLE
Fix "release (3.10, latest)" job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -100,7 +100,7 @@ jobs:
       matrix:
         target:
           - {python: "3.6", ubuntu: "20.04"}
-          - {python: "3.10", ubuntu: "latest"}
+          - {python: "3.10", ubuntu: "22.04"}
 
     runs-on: ubuntu-${{ matrix.target.ubuntu }}
     steps:


### PR DESCRIPTION
Fix for the following error:
```
#10 [5/5] WORKDIR /src
#10 DONE 0.0s

#11 exporting to image
#11 exporting layers
#11 exporting layers 3.4s done
#11 writing image sha256:a97d0053af3c8b809dbd88723bf416539136f7848722a5d9cafc8f6ce5831595 done
#11 naming to docker.io/library/clickhouse-tools-build-ubuntu-latest done
#11 DONE 3.4s
Traceback (most recent call last):
  File "/opt/poetry/bin/poetry", line 5, in <module>
    from poetry.console import main
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/console/__init__.py", line 1, in <module>
    from .application import Application
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/console/application.py", line 7, in <module>
    from .commands.about import AboutCommand
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/console/commands/__init__.py", line 2, in <module>
    from .add import AddCommand
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/console/commands/add.py", line 8, in <module>
    from .init import InitCommand
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/console/commands/init.py", line 16, in <module>
    from poetry.core.pyproject import PyProjectException
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/core/pyproject/__init__.py", line 2, in <module>
    from poetry.core.pyproject.tables import BuildSystem
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/core/pyproject/tables.py", line 5, in <module>
    from poetry.core.utils._compat import Path
  File "/opt/poetry/venv/lib/python3.12/site-packages/poetry/core/utils/_compat.py", line 8, in <module>
    import six.moves.urllib.parse as urllib_parse
ModuleNotFoundError: No module named 'six.moves'
make: *** [Makefile:296: prepare-version] Error 1
make: *** [Makefile:316: build-deb-package] Error 2
```
https://github.com/yandex/ch-tools/actions/runs/8836156216/job/24285543971