### PR TITLE
Remove useless multi_replicas flag.

### DIFF
--- a/ch_tools/common/commands/replication_lag.py
+++ b/ch_tools/common/commands/replication_lag.py
@@ -40,7 +40,7 @@ def estimate_replication_lag(ctx, xcrit, crit, warn, mwarn, mcrit, verbose=0):
                 item.get("max_execution", 0),
                 item.get("errors", 0),
                 item.get("user_fault", False),
-                item.get("re    tried_merges", 0),
+                item.get("retried_merges", 0),
             ]
             verbtab.append(tabletab)
             if verbose >= 2:


### PR DESCRIPTION
I suggest removing multi_replicas flag from replication_lag.

Right now we have a filter for total_replicas > 1 (because we don't calculate replication lag for 1 replica). So we don't use when total_replicas=1  (in all cases we check chart with if item.get("multi_replicas", False)). Instead 2 sql command we can use 1 with filter total_replicas>1.