### PR TITLE
additional info about RO tables

### DIFF
--- a/ch_tools/monrun_checks/ch_ro_replica.py
+++ b/ch_tools/monrun_checks/ch_ro_replica.py
@@ -17,7 +17,7 @@ def ro_replica_command(ctx, verbose=False):
     Check for readonly replicated tables.
     """
     query = """
-        SELECT database, table, last_queue_update_exception, zookeeper_exception
+        SELECT database, table, replica_path, last_queue_update_exception, zookeeper_exception
         FROM system.replicas WHERE is_readonly
     """
     response = clickhouse_client(ctx).query_json_data(query, compact=False)
@@ -28,6 +28,7 @@ def ro_replica_command(ctx, verbose=False):
             headers = [
                 "database",
                 "table",
+                "replica_path",
                 "last_queue_update_exception",
                 "zookeeper_exception",
             ]

--- a/ch_tools/monrun_checks/ch_ro_replica.py
+++ b/ch_tools/monrun_checks/ch_ro_replica.py
@@ -17,7 +17,7 @@ def ro_replica_command(ctx, verbose=False):
     Check for readonly replicated tables.
     """
     query = """
-        SELECT database, table, last_queue_update_exception, zookeeper_exception 
+        SELECT database, table, last_queue_update_exception, zookeeper_exception
         FROM system.replicas WHERE is_readonly
     """
     response = clickhouse_client(ctx).query_json_data(query, compact=False)

--- a/ch_tools/monrun_checks/ch_ro_replica.py
+++ b/ch_tools/monrun_checks/ch_ro_replica.py
@@ -5,17 +5,53 @@ from ch_tools.common.result import CRIT, OK, Result
 
 
 @click.command("ro-replica")
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Show details about ro tables.",
+)
 @click.pass_context
-def ro_replica_command(ctx):
+def ro_replica_command(ctx, verbose=False):
     """
     Check for readonly replicated tables.
     """
-    query = "SELECT database, table FROM system.replicas WHERE is_readonly"
+    query = """
+        SELECT database, table, last_queue_update_exception, zookeeper_exception 
+        FROM system.replicas WHERE is_readonly
+    """
     response = clickhouse_client(ctx).query_json_data(query, compact=False)
     if response:
+        msg_verbose = ""
+
+        if verbose:
+            headers = [
+                "database",
+                "table",
+                "last_queue_update_exception",
+                "zookeeper_exception",
+            ]
+
+            formatted_data = []
+
+            for item in response:
+                formatted_row = "\n".join(
+                    [
+                        f"{header}: {item[header]}"
+                        for header in headers
+                        if header in item
+                    ]
+                )
+                formatted_data.append(formatted_row)
+
+            msg_verbose = "\n\n".join(data for data in formatted_data)
+
         tables_str = ", ".join(
             f"{item['database']}.{item['table']}" for item in response
         )
-        return Result(CRIT, f"Readonly replica tables: {tables_str}")
+
+        return Result(
+            CRIT, f"Readonly replica tables: {tables_str}", verbose=msg_verbose
+        )
 
     return Result(OK)


### PR DESCRIPTION
Output with 2 RO tables:
```
$ sudo ch-monitoring ro-replica -v
2;Readonly replica tables: default.test_table_repl, default.test_table_repl_2


database: default
table: test_table_repl
last_queue_update_exception: 
zookeeper_exception: Code: 999. Coordination::Exception: Coordination error: No node, path /clickhouse/tables/shard1/test_table_repl/log. (KEEPER_EXCEPTION) (version 24.3.2.23 (official build))

database: default
table: test_table_repl_2
last_queue_update_exception: 
zookeeper_exception: Code: 999. Coordination::Exception: Coordination error: No node, path /clickhouse/tables/shard1/test_table_repl_2/log. (KEEPER_EXCEPTION) (version 24.3.2.23 (official build))
```