### PR TITLE
Fix logging for 'keeper-monitoring status' command

### DIFF
--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -85,6 +85,7 @@ def configure(
     """
     Configure logger.
     """
+    logger_config.clear()
     logger_config["module"] = module
     loguru_handlers = []
 

--- a/tests/features/monrun_keeper.feature
+++ b/tests/features/monrun_keeper.feature
@@ -6,6 +6,12 @@ Feature: keeper-monitoring tool
     And a working zookeeper
     And a working clickhouse on clickhouse01
 
+  Scenario: Check status command not throwing
+    When we execute command on zookeeper01
+    """
+    keeper-monitoring status
+    """
+
   Scenario: Check Zookeeper alive with keeper monitoring
     When we execute command on zookeeper01
     """


### PR DESCRIPTION
Command calls another commands and causes logger reconfiguration, but `logger_config` dict was not cleared.