### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,6 +46,7 @@ jobs:
         target:
           - { python: "3.6", ubuntu: "20.04" }
           - { python: "3.10", ubuntu: "latest" }
+          - { python: "3.12", ubuntu: "24.04" }
         clickhouse:
           - "22.8.21.38"
           - "23.3.22.3"

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ update-deps:
 
 $(INSTALL_DEPS_STAMP): $(VENV_DIR) pyproject.toml poetry.lock
 	$(ensure_poetry)
-	@echo "UPDATE_POETRY_LOCK: $(UPDATE_POETRY_LOCK)"
 	@if [[ -n "${UPDATE_POETRY_LOCK}" ]]; then \
 		$(POETRY) update --lock; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,19 @@ export PYTHON ?= python3
 PYTHON_MAJOR := $(shell $(PYTHON) -c 'import sys; print(sys.version_info[0])')
 PYTHON_MINOR := $(shell $(PYTHON) -c 'import sys; print(sys.version_info[1])')
 
+POETRY_DEFAULT_VERSION = 1.1.15
 # The latest version supporting Python 3.6
-POETRY_VERSION ?= 1.1.15
+POETRY_VERSION ?= $(POETRY_DEFAULT_VERSION)
 POETRY_HOME ?= /opt/poetry
 POETRY := $(POETRY_HOME)/bin/poetry
 # The minimum officially supported version for Python 3.12 is 1.7.0 (https://python-poetry.org/history/#170---2023-11-03)
 ifeq ($(shell test $(PYTHON_MAJOR) -ge 3 && test $(PYTHON_MINOR) -ge 12; echo $$?),0)
 	POETRY_VERSION="1.8.3"
-	$(POETRY) update --lock
+endif
+
+UPDATE_POETRY_LOCK =
+ifneq ($(POETRY_VERSION), $(POETRY_DEFAULT_VERSION))
+	UPDATE_POETRY_LOCK="y"
 endif
 
 PREFIX ?= /opt/yandex/$(PROJECT_NAME)
@@ -109,6 +114,10 @@ update-deps:
 
 $(INSTALL_DEPS_STAMP): $(VENV_DIR) pyproject.toml poetry.lock
 	$(ensure_poetry)
+	@echo "UPDATE_POETRY_LOCK: $(UPDATE_POETRY_LOCK)"
+	@if [[ -n "${UPDATE_POETRY_LOCK}" ]]; then \
+		$(POETRY) update --lock; \
+	fi
 	$(POETRY) install --no-root
 	touch $(INSTALL_DEPS_STAMP)
 

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ PYTHON_MINOR := $(shell $(PYTHON) -c 'import sys; print(sys.version_info[1])')
 
 # The latest version supporting Python 3.6
 POETRY_VERSION ?= 1.1.15
+POETRY_HOME ?= /opt/poetry
+POETRY := $(POETRY_HOME)/bin/poetry
 # The minimum officially supported version for Python 3.12 is 1.7.0 (https://python-poetry.org/history/#170---2023-11-03)
 ifeq ($(shell test $(PYTHON_MAJOR) -ge 3 && test $(PYTHON_MINOR) -ge 12; echo $$?),0)
 	POETRY_VERSION="1.8.3"
+	$(POETRY) update --lock
 endif
-
-POETRY_HOME ?= /opt/poetry
-POETRY := $(POETRY_HOME)/bin/poetry
 
 PREFIX ?= /opt/yandex/$(PROJECT_NAME)
 export BUILD_PYTHON_OUTPUT_DIR ?= dist

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CLICKHOUSE_VERSION="1.2.3.4" make test-integration
 
 # For building deb packages
 make prepare-build-deb
-make build-deb-package  
+make build-deb-package
 ```
 
 Please note: base images for tests are pulled from [chtools Dockerhub](https://hub.docker.com/u/chtools).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,10 @@ behave = "*"
 docker = "*"
 docker-compose = "*"
 pyhamcrest = "*"
-pytest = "*"
-pyfakefs = "*"
+pyfakefs = [
+    { version = "*", python = "<3.12" },
+    { version = "5.5.0", python = ">=3.12" }
+]
 
 # lint
 black = { version = "^22.0", python = ">=3.10" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ tqdm = "*"
 typing-extensions = "~4.1.1"
 xmltodict = "*"
 loguru = "*"
+cffi = { version = "1.16.0", python = ">=3.12" }
 
 [tool.poetry.dev-dependencies]
 # TODO: use groups in a modern version of poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ behave = "*"
 docker = "*"
 docker-compose = "*"
 pyhamcrest = "*"
+pytest = "*"
 pyfakefs = [
     { version = "*", python = "<3.12" },
     { version = "5.5.0", python = ">=3.12" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ pyfakefs = [
     { version = "*", python = "<3.12" },
     { version = "5.5.0", python = ">=3.12" }
 ]
+setuptools = { version = "*", python = ">=3.12" }
 
 # lint
 black = { version = "^22.0", python = ">=3.10" }


### PR DESCRIPTION
We would like to build and run ch-tools with python3.12, and found the following issues during this migration:
- **poetry** `1.1.5` doesn't work on py3.12, we need at least `1.7.0` (https://python-poetry.org/history/#170---2023-11-03)
  - and due to this change we have to update lock file each time on the fly in case of using another version of poetry
- failed to install **cffi**, because we need at least `1.16.0` for py3.12 (https://cffi.readthedocs.io/en/stable/whatsnew.html#v1-16-0)
- unit tests are failing with old **pyfakefs** (seems like prior to 5.2.0) due to changes in **pathlib**
- **pkgutil** related stuff - just install **setuptools** (as for ch-backup as well)