### PR TITLE
Moved setuptools to the main dependencies group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ typing-extensions = "~4.1.1"
 xmltodict = "*"
 loguru = "*"
 cffi = { version = "1.16.0", python = ">=3.12" }
+setuptools = { version = "*", python = ">=3.12" }
 
 [tool.poetry.dev-dependencies]
 # TODO: use groups in a modern version of poetry
@@ -117,7 +118,6 @@ pyfakefs = [
     { version = "*", python = "<3.12" },
     { version = "5.5.0", python = ">=3.12" }
 ]
-setuptools = { version = "*", python = ">=3.12" }
 
 # lint
 black = { version = "^22.0", python = ">=3.10" }


### PR DESCRIPTION
After https://github.com/yandex/ch-tools/pull/202 it turned out that we need `setuptools` package for py3.12+ during runtime and not only for tests, currently it fixes the following issue:

```
# chadmin
Traceback (most recent call last):
  File "/usr/bin/chadmin", line 5, in <module>
    from ch_tools.chadmin.chadmin_cli import main
  File "/opt/yandex/clickhouse-tools/lib/python3.12/site-packages/ch_tools/chadmin/chadmin_cli.py", line 35, in <module>
    from ch_tools.chadmin.cli.object_storage_group import object_storage_group
  File "/opt/yandex/clickhouse-tools/lib/python3.12/site-packages/ch_tools/chadmin/cli/object_storage_group.py", line 11, in <module>
    from ch_tools.common.commands.clean_object_storage import DEFAULT_GUARD_INTERVAL, clean
  File "/opt/yandex/clickhouse-tools/lib/python3.12/site-packages/ch_tools/common/commands/clean_object_storage.py", line 16, in <module>
    from ch_tools.chadmin.internal.system import match_ch_version
  File "/opt/yandex/clickhouse-tools/lib/python3.12/site-packages/ch_tools/chadmin/internal/system.py", line 2, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
```