### PR TITLE
Remove return from chadmin command

### DIFF
--- a/ch_tools/chadmin/cli/chadmin_group.py
+++ b/ch_tools/chadmin/cli/chadmin_group.py
@@ -48,12 +48,10 @@ class Chadmin(cloup.Group):
             )
 
             try:
-                result = cmd_callback(*a, **kw)
+                cmd_callback(*a, **kw)
                 logging.debug("Command '{}' completed", cmd.name)
             except Exception:
                 logging.exception("Command '{}' failed with error:", cmd.name)
-
-            return result
 
         cmd.callback = wrapper
         super().add_command(


### PR DESCRIPTION
Fix for `UnboundLocalError: local variable 'result' referenced before assignment`.
Chadmin commands should not return anything anyway.