### PR TITLE
chadmin object-storage clean: support of disabling --on-cluster mode

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -74,7 +74,7 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     help=("End of inspecting interval in human-friendly format."),
 )
 @option(
-    "--on-cluster",
+    "--on-cluster/--no-on-cluster",
     "on_cluster",
     is_flag=True,
     help=("List objects on all hosts in a cluster."),


### PR DESCRIPTION
For the case when --on-cluster mode is enabled by default in config.