### PR TITLE
Introduce object storage cleaning on the shard scope (by default)

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -78,12 +78,6 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     help=("End of inspecting interval in human-friendly format."),
 )
 @option(
-    "--on-cluster/--no-on-cluster",
-    "_on_cluster",
-    is_flag=True,
-    help=("List objects on all hosts in a cluster. Deprecated, see --clean-scope"),
-)
-@option(
     "--clean-scope",
     "clean_scope",
     default="shard",
@@ -134,7 +128,6 @@ def clean_command(
     object_name_prefix: str,
     from_time: Optional[timedelta],
     to_time: timedelta,
-    _on_cluster: bool,
     clean_scope: str,
     cluster_name: str,
     dry_run: bool,

--- a/ch_tools/common/clickhouse/client/clickhouse_client.py
+++ b/ch_tools/common/clickhouse/client/clickhouse_client.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Any, Dict, Optional
 
 import requests
+from click import Context
 from jinja2 import Environment
 from typing_extensions import Self
 
@@ -272,7 +273,7 @@ class ClickhouseClient:
         return self.query(query=None, port=port)
 
 
-def clickhouse_client(ctx):
+def clickhouse_client(ctx: Context) -> ClickhouseClient:
     """
     Return ClickHouse client from the context if it exists.
     Init ClickHouse client and store to the context if it doesn't exist.

--- a/ch_tools/monrun_checks/ch_tls.py
+++ b/ch_tools/monrun_checks/ch_tls.py
@@ -51,4 +51,4 @@ def get_ports(ctx: click.Context, ports: Optional[str]) -> List[str]:
         result.append(client.get_port(ClickhousePort.HTTPS))
     if client.check_port(ClickhousePort.TCP_SECURE):
         result.append(client.get_port(ClickhousePort.TCP_SECURE))
-    return result
+    return [str(port) for port in result]

--- a/tests/features/monrun.feature
+++ b/tests/features/monrun.feature
@@ -392,7 +392,7 @@ Feature: ch-monitoring tool
   Scenario: Check clickhouse orphaned objects with state-zk-path option
     When we execute command on clickhouse01
     """
-    chadmin object-storage clean --dry-run --to-time 0h --on-cluster --keep-paths --store-state-zk-path /tmp/shard_1
+    chadmin object-storage clean --dry-run --to-time 0h --keep-paths --store-state-zk-path /tmp/shard_1
     """
     When we execute command on clickhouse01
     """
@@ -410,7 +410,7 @@ Feature: ch-monitoring tool
     """
     When we execute command on clickhouse01
     """
-    chadmin object-storage clean --dry-run --to-time 0h --on-cluster --keep-paths --store-state-zk-path /tmp/shard_1
+    chadmin object-storage clean --dry-run --to-time 0h --keep-paths --store-state-zk-path /tmp/shard_1
     """
     When we execute command on clickhouse01
     """
@@ -440,7 +440,7 @@ Feature: ch-monitoring tool
   Scenario: Check clickhouse orphaned objects with state-local option
     When we execute command on clickhouse01
     """
-    chadmin object-storage clean --dry-run --to-time 0h --on-cluster --keep-paths --store-state-local
+    chadmin object-storage clean --dry-run --to-time 0h --keep-paths --store-state-local
     """
     When we execute command on clickhouse01
     """
@@ -458,7 +458,7 @@ Feature: ch-monitoring tool
     """
     When we execute command on clickhouse01
     """
-    chadmin object-storage clean --dry-run --to-time 0h --on-cluster --keep-paths --store-state-local
+    chadmin object-storage clean --dry-run --to-time 0h --keep-paths --store-state-local
     """
     When we execute command on clickhouse01
     """


### PR DESCRIPTION
- Introduce object storage cleaning on the shard scope (by default) using `remote/remoteSecure` table functions.
- Add new parameter `--clean-scope` for `object-storage clean` command with possible values `host`, `shard`, `cluster`. `shard` is used by default.
- Deprecate `--on-cluster` parameter. Now it is not respected anymore. Add hint about this in the help message.