### PR TITLE
Reduce exception info for chadmin output

### DIFF
--- a/ch_tools/chadmin/cli/chadmin_group.py
+++ b/ch_tools/chadmin/cli/chadmin_group.py
@@ -50,8 +50,10 @@ class Chadmin(cloup.Group):
             try:
                 cmd_callback(*a, **kw)
                 logging.debug("Command '{}' completed", cmd.name)
-            except Exception:
+            except Exception as e:
+                logging.disable_stdout_logger()
                 logging.exception("Command '{}' failed with error:", cmd.name)
+                logging.print_last_exception(e)
 
         cmd.callback = wrapper
         super().add_command(

--- a/ch_tools/chadmin/cli/chadmin_group.py
+++ b/ch_tools/chadmin/cli/chadmin_group.py
@@ -50,10 +50,10 @@ class Chadmin(cloup.Group):
             try:
                 cmd_callback(*a, **kw)
                 logging.debug("Command '{}' completed", cmd.name)
-            except Exception as e:
-                logging.disable_stdout_logger()
-                logging.exception("Command '{}' failed with error:", cmd.name)
-                logging.print_last_exception(e)
+            except Exception:
+                logging.exception(
+                    "Command '{}' failed with error:", cmd.name, short_stdout=True
+                )
 
         cmd.callback = wrapper
         super().add_command(

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -103,14 +103,13 @@ def wait_replication_sync_command(
         for replica in list_table_replicas(ctx):
             full_name = f"`{replica['database']}`.`{replica['table']}`"
             time_left = deadline - time.time()
-            timeout = min(replica_timeout.total_seconds(), time_left)
 
             execute_query(
                 ctx,
                 f"SYSTEM SYNC REPLICA {full_name}",
                 format_=None,
-                timeout=time_left,
-                settings={"receive_timeout": timeout},
+                timeout=replica_timeout.total_seconds(),
+                settings={"receive_timeout": time_left},
             )
     except requests.exceptions.ReadTimeout:
         logging.error("Read timeout while running query.")

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -109,7 +109,7 @@ def wait_replication_sync_command(
                 ctx,
                 f"SYSTEM SYNC REPLICA {full_name}",
                 format_=None,
-                timeout=timeout,
+                timeout=time_left,
                 settings={"receive_timeout": timeout},
             )
     except requests.exceptions.ReadTimeout:

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -143,11 +143,20 @@ def error(msg, *args, **kwargs):
     _log("ERROR", msg, *args, **kwargs)
 
 
-def exception(msg, *args, exc_info=True, **kwargs):
+def exception(msg, *args, exc_info=True, short_stdout=False, **kwargs):
     """
     Log a message with severity 'ERROR' with exception information.
     """
-    _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+    if not short_stdout:
+        _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+    else:
+        print_last_exception()
+        if logger_config.get("stdout_logger_id", None) is not None:
+            disable_stdout_logger()
+            _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+            enable_stdout_logger()
+        else:
+            _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
 
 
 def warning(msg, *args, **kwargs):
@@ -237,5 +246,6 @@ def enable_stdout_logger():
         )
 
 
-def print_last_exception(e):
-    traceback.print_exception(BaseException, e, e.__traceback__, chain=False)
+def print_last_exception():
+    exc_type, value, traceback_ = sys.exc_info()
+    traceback.print_exception(exc_type, value, traceback_, chain=False)

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -14,6 +14,7 @@ from logging import (  # noqa # pylint:disable=unused-import
     WARN,
     WARNING,
 )
+import traceback
 from typing import Any, Dict, Optional
 
 from loguru import logger
@@ -96,6 +97,7 @@ def configure(
             "format": format_,
             "enqueue": True,
             "diagnose": False,
+            "backtrace": False,
         }
         if "level" in value:
             handler["level"] = value["level"]
@@ -230,4 +232,10 @@ def enable_stdout_logger():
             level="INFO",
             format="{message}",
             filter=make_filter(logger_config["module"]),
+            backtrace=False,
+            diagnose=False,
         )
+
+
+def print_last_exception(e):
+    traceback.print_exception(BaseException, e, e.__traceback__, chain=False)

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -5,6 +5,7 @@ Logging module.
 import inspect
 import logging
 import sys
+import traceback
 from logging import (  # noqa # pylint:disable=unused-import
     CRITICAL,
     DEBUG,
@@ -14,7 +15,6 @@ from logging import (  # noqa # pylint:disable=unused-import
     WARN,
     WARNING,
 )
-import traceback
 from typing import Any, Dict, Optional
 
 from loguru import logger

--- a/ch_tools/common/logging.py
+++ b/ch_tools/common/logging.py
@@ -149,14 +149,15 @@ def exception(msg, *args, exc_info=True, short_stdout=False, **kwargs):
     """
     if not short_stdout:
         _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+        return
+
+    print_last_exception()
+    if logger_config.get("stdout_logger_id", None):
+        disable_stdout_logger()
+        _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+        enable_stdout_logger()
     else:
-        print_last_exception()
-        if logger_config.get("stdout_logger_id", None) is not None:
-            disable_stdout_logger()
-            _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
-            enable_stdout_logger()
-        else:
-            _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
+        _log("ERROR", msg, *args, exc_info=exc_info, **kwargs)
 
 
 def warning(msg, *args, **kwargs):

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -145,7 +145,7 @@ Feature: chadmin commands.
     """
     Then it fails with response contains
     """
-    Timeout while running query.
+    Read timeout while running query.
     """
     When we execute query on clickhouse01
     """

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -145,7 +145,7 @@ Feature: chadmin commands.
     """
     Then it fails with response contains
     """
-    Read timeout while running query.
+    Timeout while running query.
     """
     When we execute query on clickhouse01
     """


### PR DESCRIPTION
Only last exception without diagnose is printed, but full exception is logged.

Logged example:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/usr/local/lib/python3.8/dist-packages/urllib3/util/connection.py", line 72, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Temporary failure in name resolution

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/botocore/httpsession.py", line 443, in send
    urllib_response = conn.urlopen(
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connectionpool.py", line 802, in urlopen
    retries = retries.increment(
  File "/usr/local/lib/python3.8/dist-packages/urllib3/util/retry.py", line 527, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/usr/local/lib/python3.8/dist-packages/urllib3/packages/six.py", line 770, in reraise
    raise value
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connectionpool.py", line 716, in urlopen
    httplib_response = self._make_request(
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connectionpool.py", line 416, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connection.py", line 244, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib/python3.8/http/client.py", line 1256, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.8/dist-packages/botocore/awsrequest.py", line 94, in _send_request
    rval = super()._send_request(
  File "/usr/lib/python3.8/http/client.py", line 1302, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1251, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.8/dist-packages/botocore/awsrequest.py", line 123, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.8/dist-packages/botocore/awsrequest.py", line 218, in send
    return super().send(str)
  File "/usr/lib/python3.8/http/client.py", line 951, in send
    self.connect()
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
  File "/usr/local/lib/python3.8/dist-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPConnection object at 0x70cccc2aa910>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/cli/chadmin_group.py", line 52, in wrapper
    cmd_callback(*a, **kw)
  File "/usr/local/lib/python3.8/dist-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/cli/object_storage_group.py", line 142, in clean_command
    deleted, total_size = clean(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 75, in clean
    deleted, total_size = _clean_object_storage(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 116, in _clean_object_storage
    _traverse_object_storage(ctx, listing_table, from_time, to_time, prefix)
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 202, in _traverse_object_storage
    for obj in s3_object_storage_iterator(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/internal/object_storage/s3_iterator.py", line 27, in s3_object_storage_iterator
    for obj in bucket.objects.filter(Prefix=object_name_prefix):
  File "/usr/local/lib/python3.8/dist-packages/boto3/resources/collection.py", line 81, in __iter__
    for page in self.pages():
  File "/usr/local/lib/python3.8/dist-packages/boto3/resources/collection.py", line 171, in pages
    for page in pages:
  File "/usr/local/lib/python3.8/dist-packages/botocore/paginate.py", line 264, in __iter__
    response = self._make_request(current_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/paginate.py", line 352, in _make_request
    return self._method(**current_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 508, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 894, in _make_api_call
    http, parsed_response = self._make_request(
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 917, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 116, in make_request
    return self._send_request(request_dict, operation_model)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 199, in _send_request
    while self._needs_retry(
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 351, in _needs_retry
    responses = self._event_emitter.emit(
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 207, in __call__
    if self._checker(**checker_kwargs):
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 284, in __call__
    should_retry = self._should_retry(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 320, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 363, in __call__
    checker_response = checker(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 247, in __call__
    return self._check_caught_exception(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 416, in _check_caught_exception
    raise caught_exception
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 278, in _do_get_response
    http_response = self._send(request)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 374, in _send
    return self.http_session.send(request)
  File "/usr/local/lib/python3.8/dist-packages/botocore/httpsession.py", line 472, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://minio01:9000/cloud-storage-test?prefix=data%2F&encoding-type=url"
```
Printed example:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/cli/chadmin_group.py", line 52, in wrapper
    cmd_callback(*a, **kw)
  File "/usr/local/lib/python3.8/dist-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/cli/object_storage_group.py", line 142, in clean_command
    deleted, total_size = clean(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 75, in clean
    deleted, total_size = _clean_object_storage(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 116, in _clean_object_storage
    _traverse_object_storage(ctx, listing_table, from_time, to_time, prefix)
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/common/commands/clean_object_storage.py", line 202, in _traverse_object_storage
    for obj in s3_object_storage_iterator(
  File "/usr/local/lib/python3.8/dist-packages/ch_tools/chadmin/internal/object_storage/s3_iterator.py", line 27, in s3_object_storage_iterator
    for obj in bucket.objects.filter(Prefix=object_name_prefix):
  File "/usr/local/lib/python3.8/dist-packages/boto3/resources/collection.py", line 81, in __iter__
    for page in self.pages():
  File "/usr/local/lib/python3.8/dist-packages/boto3/resources/collection.py", line 171, in pages
    for page in pages:
  File "/usr/local/lib/python3.8/dist-packages/botocore/paginate.py", line 264, in __iter__
    response = self._make_request(current_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/paginate.py", line 352, in _make_request
    return self._method(**current_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 508, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 894, in _make_api_call
    http, parsed_response = self._make_request(
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 917, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 116, in make_request
    return self._send_request(request_dict, operation_model)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 199, in _send_request
    while self._needs_retry(
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 351, in _needs_retry
    responses = self._event_emitter.emit(
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 207, in __call__
    if self._checker(**checker_kwargs):
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 284, in __call__
    should_retry = self._should_retry(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 320, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 363, in __call__
    checker_response = checker(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 247, in __call__
    return self._check_caught_exception(
  File "/usr/local/lib/python3.8/dist-packages/botocore/retryhandler.py", line 416, in _check_caught_exception
    raise caught_exception
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 278, in _do_get_response
    http_response = self._send(request)
  File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 374, in _send
    return self.http_session.send(request)
  File "/usr/local/lib/python3.8/dist-packages/botocore/httpsession.py", line 472, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://minio01:9000/cloud-storage-test?prefix=data%2F&encoding-type=url"
```