### PR TITLE
[MDB-29707] Metatdata cleaner with system drop replica

### DIFF
--- a/ch_tools/chadmin/internal/database_replica.py
+++ b/ch_tools/chadmin/internal/database_replica.py
@@ -1,0 +1,10 @@
+from ch_tools.chadmin.internal.utils import execute_query
+
+
+def system_database_drop_replica(ctx, database_zk_path, replica, dry_run=False):
+    """
+    Perform "SYSTEM DROP DATABASE REPLICA" query.
+    """
+    timeout = ctx.obj["config"]["clickhouse"]["drop_replica_timeout"]
+    query = f"SYSTEM DROP DATABASE REPLICA '{replica}' FROM ZKPATH '{database_zk_path}'"
+    execute_query(ctx, query, timeout=timeout, echo=True, dry_run=dry_run, format_=None)

--- a/ch_tools/chadmin/internal/table_replica.py
+++ b/ch_tools/chadmin/internal/table_replica.py
@@ -144,3 +144,12 @@ def restore_table_replica(
     if cluster:
         query += f" ON CLUSTER '{cluster}'"
     execute_query(ctx, query, timeout=timeout, echo=True, dry_run=dry_run, format_=None)
+
+
+def system_table_drop_replica(ctx, table_zk_path, replica, dry_run=False):
+    """
+    Perform "SYSTEM DROP REPLICA" query.
+    """
+    timeout = ctx.obj["config"]["clickhouse"]["drop_replica_timeout"]
+    query = f"SYSTEM DROP REPLICA '{replica}' FROM ZKPATH '{table_zk_path}'"
+    execute_query(ctx, query, timeout=timeout, echo=True, dry_run=dry_run, format_=None)

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -4,16 +4,23 @@ import re
 import time
 from collections import deque
 from contextlib import contextmanager
+from dataclasses import dataclass
 from math import sqrt
-from typing import List
+from typing import Deque, Dict, Generator, List, Optional, Tuple
 
 from click import BadParameter
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError, NotEmptyError
+from kazoo.interfaces import IAsyncResult
 
+from ch_tools.chadmin.internal.database_replica import system_database_drop_replica
+from ch_tools.chadmin.internal.table_replica import system_table_drop_replica
 from ch_tools.chadmin.internal.utils import chunked, replace_macros
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_clickhouse_config, get_macros
+from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
+
+REPLICATED_DATABASE_MARKER = bytes("DatabaseReplicated", "utf-8")
 
 
 def get_zk_node(ctx, path, binary=False):
@@ -255,6 +262,129 @@ def replace_macros_in_nodes(func):
     return wrapper
 
 
+@dataclass
+class ZookeeperNode:
+    path: str
+    children: List[str]
+
+
+class ZookeeperTreeInspector:
+    """
+    Class for traversal zookeeper tree.
+    It is based on 3 queues (pending, active, finished). We are performing several (max_parrallel_tasks) async request,
+    so active queue has limited size.
+    Note: It doesn't inserts nodes, user should do it manually.
+
+    There are two main methods:
+        add() -> add list nodes to get children.
+        get() -> get the one node with list of children.
+    """
+
+    def __init__(self, zk: KazooClient, max_parrallel_tasks: int = 5):
+        self._zk_client = zk
+        self._max_active_tasks = max_parrallel_tasks
+
+        self._queue_pending: Deque[str] = deque()
+        self._queue_active: Deque[Tuple[str, IAsyncResult]] = deque(
+            maxlen=self._max_active_tasks
+        )
+        self._queue_finished: Deque[ZookeeperNode] = deque()
+
+    def _update_pending_queue(self) -> None:
+        """
+        Moves tasks to active and creates async get_children requests.
+        """
+
+        number_tasks_to_move_to_active = min(
+            len(self._queue_pending), self._max_active_tasks - len(self._queue_active)
+        )
+
+        for _ in range(0, number_tasks_to_move_to_active):
+            path = self._queue_pending.popleft()
+            async_task = self._zk_client.get_children_async(path)
+            self._queue_active.append((path, async_task))
+
+    def _update_active_queue(self, block_until_finised_tasks: bool = False) -> None:
+        """
+        Moves executed tasks from active to finished queues.
+        """
+
+        if block_until_finised_tasks:
+            self._queue_active[0][1].wait()
+
+        while len(self._queue_active) and self._queue_active[0][1].ready():
+            async_task = self._queue_active.popleft()
+            if async_task[1].successful():
+                self._queue_finished.append(
+                    ZookeeperNode(async_task[0], async_task[1].get())
+                )
+            else:
+                if isinstance(async_task[1].exception, NoNodeError):
+                    logging.warning(
+                        "Ignoring node {}, because someone delete it", async_task[0]
+                    )
+                    continue
+                raise async_task[1].exception
+
+    def _update_queues(self, block_until_finished_tasks: bool = False) -> None:
+        """
+        Perform queues updates.
+        """
+
+        self._update_active_queue(block_until_finished_tasks)
+        self._update_pending_queue()
+
+    def _exists_tasks_to_do(self) -> bool:
+        """
+        Check that exists tasks in queues.
+        """
+
+        return (
+            len(self._queue_finished)
+            + len(self._queue_pending)
+            + len(self._queue_active)
+        ) > 0
+
+    def _get_impl(self, with_block: bool = False) -> Optional[ZookeeperNode]:
+        """
+        Implementation of get functions. There are two mode:
+        with_block - wait until one of the tasks finished.
+        without_block - get one finished task if there are no finished, calls itself with block.
+        """
+        self._update_queues(with_block)
+
+        if len(self._queue_finished):
+            return self._queue_finished.popleft()
+
+        if not self._exists_tasks_to_do():
+            return None
+
+        return self._get_impl(with_block=True)
+
+    def add(self, pathes_to_inspect: List[str]) -> None:
+        """
+        Add list of paths in pending queue.
+        """
+        self._queue_pending.extend(pathes_to_inspect)
+        self._update_queues()
+
+    def get(self) -> Optional[ZookeeperNode]:
+        """
+        Get one finished task, if exists.
+        """
+        return self._get_impl(with_block=False)
+
+    def tree_iterator(self) -> Generator[ZookeeperNode, None, None]:
+        """
+        Iterator for tree.
+        """
+        while True:
+            next_zk_node = self.get()
+            if not next_zk_node:
+                return
+            yield next_zk_node
+
+
 # pylint: disable=too-many-statements
 @replace_macros_in_nodes
 def clean_zk_metadata_for_hosts(
@@ -271,10 +401,49 @@ def clean_zk_metadata_for_hosts(
     Perform cleanup in zookeeper after deleting hosts in the cluster or whole cluster deleting.
     """
 
-    def _find_tables(zk, root_path, nodes):
+    def _traverse_zk_tree_and_find_objects(
+        zk: KazooClient,
+        zk_root_path: str,
+        excluded_paths: List[str],
+        max_workers: int = 4,
+    ) -> List[ZookeeperNode]:
         """
-        Find nodes mentions in zk for table management.
+        Traverse zk tree and find replicated objects.
         """
+
+        inspector = ZookeeperTreeInspector(zk, max_parrallel_tasks=max_workers)
+        inspector.add([zk_root_path])
+
+        objects_paths: List[ZookeeperNode] = []
+
+        excluded_regexp = re.compile("|".join(excluded_paths))
+
+        for zk_node in inspector.tree_iterator():
+            if "replicas" in zk_node.children:
+                objects_paths.append(zk_node)
+                continue
+
+            children_to_traverse: List[str] = []
+            for children in zk_node.children:
+                children_full_path = os.path.join(zk_node.path, children)
+                if not re.match(excluded_regexp, children_full_path):
+                    children_to_traverse.append(children_full_path)
+            inspector.add(children_to_traverse)
+
+        logging.info("Found {} replicated objects", len(objects_paths))
+        return objects_paths
+
+    def _collect_objects_for_cleanup(
+        zk: KazooClient,
+        zk_root_path: str,
+        collect_tables: bool,
+        collect_database: bool,
+        max_workers: int = 4,
+    ) -> Tuple[Dict[str, List[Tuple[str, str]]], Dict[str, List[str]]]:
+        """
+        Gets list of all replicated objects in zk, determine tables and databases for cleanup.
+        """
+
         excluded_paths = [
             ".*clickhouse/task_queue",
             ".*clickhouse/zero_copy",
@@ -282,108 +451,123 @@ def clean_zk_metadata_for_hosts(
             ".*/block_numbers/.*",
         ]
 
-        hosts_mentions = _find_paths(
-            zk, root_path, [".*/replicas/" + node for node in nodes], excluded_paths
-        )
-
-        # Paths will be like */shard1/replicas/hostname. But we need */shard1.
-        # Go up for 2 directories.
-        table_paths = [os.sep.join(path.split(os.sep)[:-2]) for path in hosts_mentions]
-        # One path might be in list several times. Make list unique.
-        return (list(set(table_paths)), hosts_mentions)
-
-    def _find_databases(zk, root_path, nodes):
-        """
-        Databases contains replicas in zk in cases when engine is Replicated with
-        pattern: <shard>|<replica>
-        """
-        excluded_paths = [
-            ".*clickhouse/task_queue",
-            ".*clickhouse/zero_copy",
-            ".*/blocks/.*",
-            ".*/block_numbers/.*",
-        ]
-        hosts_mentions = _find_paths(
+        replicated_objects: List[ZookeeperNode] = _traverse_zk_tree_and_find_objects(
             zk,
-            root_path,
-            [".*/replicas/.*[|]" + node for node in nodes],
-            excluded_paths,
+            zk_root_path,
+            excluded_paths=excluded_paths,
+            max_workers=max_workers,
         )
 
-        databases_paths = [
-            os.sep.join(path.split(os.sep)[:-2]) for path in hosts_mentions
-        ]
+        nodes_set = set(nodes)
 
-        return (list(set(databases_paths)), hosts_mentions)
+        databases_to_cleanup: Dict[str, List[Tuple[str, str]]] = {}
+        tables_to_cleanup: Dict[str, List[str]] = {}
 
-    def _set_replicas_is_lost(zk, table_paths, nodes):
-        """
-        Set flag <path>/replicas/<replica_name>/is_lost to 1
-        """
-        for path in table_paths:
-            replica_path = os.path.join(path, "replicas")
-            if not zk.exists(replica_path):
+        for replicated_object in replicated_objects:
+            # Actually rn in the ch (10.24) there are no secure way to determine that node is the root of replicated table.
+            # So we are accuming that if object not database then it is table.
+            #
+            # Replicated table
+            # https://github.com/ClickHouse/ClickHouse/blob/eb984db51ea0309dd607eaf98280315b42347f65/src/Interpreters/InterpreterSystemQuery.cpp#L1029
+            #
+            # Replicated Database
+            # https://github.com/ClickHouse/ClickHouse/blob/eb984db51ea0309dd607eaf98280315b42347f65/src/Databases/DatabaseReplicated.cpp#L1529
+            try:
+                is_database = bool(
+                    zk.get(replicated_object.path)[0] == REPLICATED_DATABASE_MARKER
+                )
+            except NoNodeError:
+                logging.warning(
+                    "Someone delete node {}, ignore it", replicated_object.path
+                )
                 continue
 
-            for node in nodes:
-                is_lost_flag_path = os.path.join(replica_path, node, "is_lost")
-                logging.info("Set is_lost_flag {}", is_lost_flag_path)
-                if not dry_run:
-                    _set_node_value(zk, is_lost_flag_path, "1")
-
-    def _get_replicas_queues_to_remove(zk, paths, replica_names):
-        """
-        Remove <path>/replicas/<replica_name>/queue
-        """
-        to_remove: List[str] = []
-        for path in paths:
-            replica_name = os.path.join(path, "replicas")
-            if not zk.exists(replica_name):
+            is_table = not is_database
+            if is_database and not collect_database:
+                continue
+            if is_table and not collect_tables:
                 continue
 
-            for replica_name in replica_names:
-                queue_path = os.path.join(replica_name, replica_name, "queue")
-                if not zk.exists(queue_path):
-                    continue
+            replicas_list = _get_children(
+                zk, os.path.join(replicated_object.path, "replicas")
+            )
 
-                if zk.exists(queue_path):
-                    to_remove.append(queue_path)
-        return to_remove
+            for replica in replicas_list:
+                if is_database:
+                    shard, replica_parsed = replica.split("|")
+                    if replica_parsed in nodes_set:
+                        if replicated_object.path not in databases_to_cleanup:
+                            databases_to_cleanup[replicated_object.path] = []
+                        databases_to_cleanup[replicated_object.path].append(
+                            (shard, replica_parsed)
+                        )
+                elif is_table:
+                    if replica in nodes_set:
+                        if replicated_object.path not in tables_to_cleanup:
+                            tables_to_cleanup[replicated_object.path] = []
+                        tables_to_cleanup[replicated_object.path].append(replica)
+                else:
+                    raise RuntimeError("Unreacheble state")
 
-    def _remove_if_no_hosts_in_replicas(zk, paths):
-        """
-        Remove node if subnode is empty
-        """
-        to_delete = []
-        for path in paths:
-            child_full_path = os.path.join(path, "replicas")
-            if (
-                not zk.exists(child_full_path)
-                or len(_get_children(zk, child_full_path)) == 0
-            ):
-                to_delete.append(path)
-        _delete_recursive(zk, to_delete, dry_run)
+        logging.info(
+            "From {} objects, there are {} replicatad tables and {} replicated databases.",
+            len(replicated_objects),
+            len(tables_to_cleanup),
+            len(databases_to_cleanup),
+        )
+        return (databases_to_cleanup, tables_to_cleanup)
 
-    def tables_cleanup(zk, zk_root_path):
+    def cleanup_tables_and_databases(zk: KazooClient) -> None:
         """
-        Do cleanup for tables which contains nodes.
+        Collects all objects that have nodes to be deleted and runs drop repliaca for them.
         """
-        logging.info("Start tables cleanup for nodes: {}", ",".join(nodes))
-        (table_paths, hosts_paths) = _find_tables(zk, zk_root_path, nodes)
-        _set_replicas_is_lost(zk, table_paths, nodes)
+        max_workers = ctx.obj["config"]["chadmin"]["zookeeper"][
+            "clean_zk_metadata_for_hosts"
+        ]["workers"]
 
-        to_remove = _get_replicas_queues_to_remove(zk, table_paths, nodes) + hosts_paths
-        _delete_recursive(zk, to_remove, dry_run)
-        _remove_if_no_hosts_in_replicas(zk, table_paths)
+        database_to_drop, tables_to_drop = _collect_objects_for_cleanup(
+            zk,
+            zk_root_path,
+            collect_database=cleanup_database,
+            collect_tables=cleanup_tables,
+            max_workers=max_workers,
+        )
 
-    def databases_cleanups(zk, zk_root_path):
-        """
-        Do cleanup for databases which contains nodes.
-        """
-        logging.info("Start databases cleanup for nodes: {}", ",".join(nodes))
-        (databases_paths, hosts_paths) = _find_databases(zk, zk_root_path, nodes)
-        _delete_recursive(zk, hosts_paths, dry_run)
-        _remove_if_no_hosts_in_replicas(zk, databases_paths)
+        tasks: List[WorkerTask] = []
+        if cleanup_tables:
+            for zk_table_path, list_of_nodes in tables_to_drop.items():
+                for node in list_of_nodes:
+                    tasks.append(
+                        WorkerTask(
+                            f"system_table_drop_replica_{node}",
+                            system_table_drop_replica,
+                            {
+                                "ctx": ctx,
+                                "table_zk_path": zk_table_path,
+                                "replica": node,
+                                "dry_run": dry_run,
+                            },
+                        )
+                    )
+
+        if cleanup_database:
+            for zk_database_path, list_of_nodes in database_to_drop.items():  # type: ignore
+                for node in list_of_nodes:
+                    replica = f"{node[0]}|{node[1]}"
+                    tasks.append(
+                        WorkerTask(
+                            f"system_database_drop_replica_{replica}",
+                            system_database_drop_replica,
+                            {
+                                "ctx": ctx,
+                                "database_zk_path": zk_database_path,
+                                "replica": replica,
+                                "dry_run": dry_run,
+                            },
+                        )
+                    )
+
+        execute_tasks_in_parallel(tasks, max_workers=max_workers)
 
     def _get_hosts_from_ddl(zk, ddl_task_path):
         """
@@ -494,11 +678,8 @@ def clean_zk_metadata_for_hosts(
     zk_root_path = _format_path(ctx, zk_cleanup_root_path)
 
     with zk_client(ctx) as zk:
-        if cleanup_tables:
-            tables_cleanup(zk, zk_root_path)
 
-        if cleanup_database:
-            databases_cleanups(zk, zk_root_path)
+        cleanup_tables_and_databases(zk)
 
         if cleanup_ddl_queue:
             if not zk_ddl_query_path:

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = {
         "unfreeze_timeout": 10 * 60,
         "restart_replica_timeout": 10 * 60,
         "restore_replica_timeout": 10 * 60,
+        "drop_replica_timeout": 10 * 60,
     },
     "object_storage": {
         "bucket_name_prefix": "cloud-storage-",
@@ -64,6 +65,11 @@ DEFAULT_CONFIG = {
                 "warn": 300,
                 "mcrit": 90.0,
                 "mwarn": 50.0,
+            },
+        },
+        "zookeeper": {
+            "clean_zk_metadata_for_hosts": {
+                "workers": 10,
             },
         },
     },

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -76,6 +76,7 @@ Feature: chadmin zookeeper commands.
     /tables/table_02/replicas/clickhouse02.ch_tools_test
     """
 
+  @require_version_23.1
   Scenario: Remove single host from Replicated database.
     When we execute queries on clickhouse01
     """
@@ -88,6 +89,7 @@ Feature: chadmin zookeeper commands.
     /clickhouse/databases/test/replicas/shard1|clickhouse02.ch_tools_test
     """
 
+  @require_version_23.1
   Scenario: Remove all host from Replicated database.
     When we execute queries on clickhouse01
     """

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -19,9 +19,12 @@ Feature: chadmin zookeeper commands.
 
     CREATE TABLE test.table_02 ON CLUSTER 'cluster' (n Int32)
     ENGINE = ReplicatedMergeTree('/tables/table_02', '{replica}') PARTITION BY n ORDER BY n;
+
+    DETACH TABLE test.table_01 ON CLUSTER 'cluster';
+    DETACH TABLE test.table_02 ON CLUSTER 'cluster';
     """
 
-    And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root /tables
+    And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root /
     Then the list of children on clickhouse01 for zk node /tables/ are empty
 
   Scenario: Cleanup all hosts dry run
@@ -35,9 +38,12 @@ Feature: chadmin zookeeper commands.
 
     CREATE TABLE test.table_02 ON CLUSTER 'cluster' (n Int32)
     ENGINE = ReplicatedMergeTree('/tables/table_02', '{replica}') PARTITION BY n ORDER BY n;
+
+    DETACH TABLE test.table_01 ON CLUSTER 'cluster';
+    DETACH TABLE test.table_02 ON CLUSTER 'cluster';
     """
 
-    And we do hosts dry cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root /tables
+    And we do hosts dry cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root /
     Then the list of children on clickhouse01 for zk node /tables/ are equal to
     """
     /tables/table_01
@@ -45,50 +51,51 @@ Feature: chadmin zookeeper commands.
     """
 
   Scenario: Cleanup single host 
-    When we execute chadmin create zk nodes on clickhouse01
+    When we execute queries on clickhouse01
     """
-    /test/write_sli_part/shard1/replicas/host1.net
-    /test/write_sli_part/shard1/replicas/host2.net
-    /test/read_sli_part/shard1/replicas/host1.net
-    /test/read_sli_part/shard1/replicas/host2.net
-    /test/write_sli_part/shard1/log
-    """
-    And we do hosts cleanup on clickhouse01 with fqdn host1.net and zk root /test
-    
-    Then the list of children on clickhouse01 for zk node /test/write_sli_part/shard1/replicas/ are equal to
-    """
-    /test/write_sli_part/shard1/replicas/host2.net
-    """
-    And the list of children on clickhouse01 for zk node  /test/read_sli_part/shard1/replicas/ are equal to
-    """
-    /test/read_sli_part/shard1/replicas/host2.net
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n;
+
+    CREATE TABLE test.table_02 ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_02', '{replica}') PARTITION BY n ORDER BY n;
+
+    DETACH TABLE test.table_01 ON CLUSTER 'cluster';
+    DETACH TABLE test.table_02 ON CLUSTER 'cluster';
     """
 
+    And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test and zk root /
+    Then the list of children on clickhouse01 for zk node /tables/table_01/replicas are equal to
+    """
+    /tables/table_01/replicas/clickhouse02.ch_tools_test
+    """
+    And the list of children on clickhouse01 for zk node /tables/table_02/replicas are equal to
+    """
+    /tables/table_02/replicas/clickhouse02.ch_tools_test
+    """
 
   Scenario: Remove single host from Replicated database.
-    # Imitate that we got nodes in zk from replicated database.
-    When we execute chadmin create zk nodes on clickhouse01
+    When we execute queries on clickhouse01
     """
-    '/test/clickhouse/databases/test/shard1/replicas/shard1|host1.net'
-    '/test/clickhouse/databases/test/shard1/replicas/shard1|host2.net'
-    '/test/clickhouse/databases/test/shard1/counter'
+    CREATE DATABASE testdb ON CLUSTER 'cluster' ENGINE  = Replicated('/clickhouse/databases/test', 'shard1', '{replica}');
+    DETACH DATABASE testdb ON CLUSTER 'cluster';
     """
-    And we do hosts cleanup on clickhouse01 with fqdn host1.net and zk root /test
-    Then the list of children on clickhouse01 for zk node /test/clickhouse/databases/test/shard1/replicas/ are equal to
+    And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test and zk root /
+    Then the list of children on clickhouse01 for zk node /clickhouse/databases/test/replicas/ are equal to
     """
-    /test/clickhouse/databases/test/shard1/replicas/shard1|host2.net
+    /clickhouse/databases/test/replicas/shard1|clickhouse02.ch_tools_test
     """
 
   Scenario: Remove all host from Replicated database.
-    # Imitate that we got nodes in zk from replicated database.
-    When we execute chadmin create zk nodes on clickhouse01
+    When we execute queries on clickhouse01
     """
-    '/test/clickhouse/databases/test/shard1/replicas/shard1|host1.net'
-    '/test/clickhouse/databases/test/shard1/replicas/shard1|host2.net'
-    '/test/clickhouse/databases/test/shard1/counter'
+    CREATE DATABASE testdb ON CLUSTER 'cluster' ENGINE = Replicated('/clickhouse/databases/test', 'shard1', '{replica}');
+    DETACH DATABASE testdb ON CLUSTER 'cluster';
     """
-    And we do hosts cleanup on clickhouse01 with fqdn host1.net,host2.net and zk root /test
-    Then the list of children on clickhouse01 for zk node test/clickhouse/databases/test/ are empty
+    And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root /
+    Then the list of children on clickhouse01 for zk node /clickhouse/databases/ are empty
 
   Scenario: Zookeeper recursive delete command
     When we execute chadmin create zk nodes on clickhouse01
@@ -163,24 +170,3 @@ Feature: chadmin zookeeper commands.
     """
     0;OK, 0 errors for last 5 seconds
     """
-
-  Scenario: Remove host from table in zookeeper
-    When we execute queries on clickhouse01
-    """
-    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
-    CREATE DATABASE test ON CLUSTER 'cluster';
-
-    CREATE TABLE test.table_01 ON CLUSTER 'cluster' (n Int32)
-    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n;
-    """
-
-    And we do table cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test from table with /tables/table_01 zookeeper path
-    
-    Then the list of children on clickhouse01 for zk node  /tables/table_01/replicas/ are equal to
-    """
-    /tables/table_01/replicas/clickhouse02.ch_tools_test
-    """
-
-    When we do table cleanup on clickhouse01 with fqdn clickhouse02.ch_tools_test from table with /tables/table_01 zookeeper path
-    Then the list of children on clickhouse01 for zk node /tables are empty
- 

--- a/tests/images/clickhouse/config/users.xml
+++ b/tests/images/clickhouse/config/users.xml
@@ -28,6 +28,7 @@
     <profiles>
         <default>
             <distributed_ddl_task_timeout>20</distributed_ddl_task_timeout>
+            <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
A little performance test:
```
500 replicated tables + 0 ReplicatedDB
    old 5 runs: 
        median:  0m44.959s
        list : [2m56.825s, 2m56.635s, 0m44.959s, 0m41.463s, 0m44.481s]
    new 5 runs:  
        median:  0m9.965s
        list: [0m6.865s, 0m9.965s, 0m10.014s, 0m6.701s, 0m10.085s]


500 replicated tables + 200 Replicated databases
    old 5 runs: 
        median:  3m39.932s
        list : [0m50.593s, 0m52.412s, 3m39.697s, 3m40.830s, 3m39.932s]
    new 5 runs:  
        median:  0m8.550s
        list: [0m13.685s, 0m13.335s, 0m8.550s, 0m8.320s, 0m8.627s]
```




gen script:
```
REPLICA="non_exists"
DB='tests_db'

clickhouse client --query "ATTACH DATABASE $DB"
clickhouse client --query "DROP DATABASE $DB"

clickhouse client --query "CREATE DATABASE $DB"


for i in {1..500}
do
   QUERY="CREATE TABLE $DB.t$i (a int) ENGINE=ReplicatedMergeTree('/clickhouse/tables/$DB/t$i','$REPLICA') ORDER BY a"

   echo "$QUERY"
   clickhouse client --query "$QUERY"
done

clickhouse client --query "DETACH DATABASE $DB"


for i in {1..200}
do
        DB_REPL="repl$i"
        clickhouse client --query "ATTACH DATABASE $DB_REPL"
        clickhouse client --query "DROP DATABASE IF EXISTS $DB_REPL"
        QUERY="CREATE DATABASE $DB_REPL ENGINE = Replicated('/clickhouse/databases/$DB_REPL', 'shard1', '$REPLICA')"
        echo $QUERY
        clickhouse client --query "$QUERY"
        clickhouse client --query "DETACH DATABASE $DB_REPL"
done
```