### PR TITLE
Lightweight sync

### DIFF
--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -102,13 +102,19 @@ def wait_replication_sync_command(
     lightweight,
 ):
     """Wait for ClickHouse server to sync replication with other replicas."""
+    # Lightweight sync is added in 23.4
+    try:
+        if lightweight and not match_ch_version(ctx, "23.4"):
+            logging.warning(
+                "Lightweight sync requires version 23.4, will do full sync instead."
+            )
+            lightweight = False
+    except Exception:
+        logging.error("Connection error while getting CH version.")
+        sys.exit(1)
 
     start_time = time.time()
     deadline = start_time + total_timeout.total_seconds()
-    # Lightweight sync is added in 23.4
-    if lightweight and not match_ch_version(23.4):
-        logging.warning("Lightweight sync requires version 23.4, will do full sync instead.")
-        lightweight = False
 
     try:
         # Sync tables in cycle

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -161,7 +161,7 @@ Feature: chadmin commands.
     """
     Then it fails with response contains
     """
-    Connection error while running query.
+    Connection error
     """
     When we execute command on clickhouse01
     """

--- a/tests/features/chadmin.feature
+++ b/tests/features/chadmin.feature
@@ -118,7 +118,7 @@ Feature: chadmin commands.
       | --database=db2                                       | table_01\tReplicatedMergeTree\ntable_02\tMergeTree\ntable_03\tReplicatedMergeTree\ntable_04\tReplicatedMergeTree            |
       | --database=db2            --table=table_01           | table_01\tReplicatedMergeTree\ntable_02\tMergeTree\ntable_03\tMergeTree\ntable_04\tMergeTree                                |
 
-  Scenario: Check wait replication sync
+  Scenario Outline: Check wait replication sync
     Given we have executed queries on clickhouse01
     """
     CREATE DATABASE IF NOT EXISTS test ON CLUSTER 'cluster';
@@ -128,7 +128,7 @@ Feature: chadmin commands.
     """
     When we execute command on clickhouse01
     """
-    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4 <options>
     """
     When we execute query on clickhouse01
     """
@@ -141,7 +141,7 @@ Feature: chadmin commands.
     And we sleep for 5 seconds
     When we try to execute command on clickhouse01
     """
-    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4 <options>
     """
     Then it fails with response contains
     """
@@ -157,7 +157,7 @@ Feature: chadmin commands.
     """
     When we try to execute command on clickhouse01
     """
-    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4 <options>
     """
     Then it fails with response contains
     """
@@ -169,8 +169,14 @@ Feature: chadmin commands.
     """
     When we execute command on clickhouse01
     """
-    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3 -p 1 -w 4 <options>
     """
+    Examples:
+      | options             |
+      |                     |
+      | --lightweight       |
+      | --full              |
+
 
   Scenario Outline: Check replica restore (<replicas_count> replicas, <workers> workers) 
     Given populated clickhouse with <replicas_count> replicated tables on clickhouse01 with db database and table_ prefix


### PR DESCRIPTION
Added default lightweight option to replication sync command. Full version can still be used in case we decide to rollback.