### PR TITLE
Set timeout for list_detached_parts

### DIFF
--- a/ch_tools/chadmin/internal/part.py
+++ b/ch_tools/chadmin/internal/part.py
@@ -204,6 +204,7 @@ def list_detached_parts(
     return execute_query(
         ctx,
         query,
+        timeout=ctx.obj["config"]["clickhouse"]["alter_table_timeout"],
         database=database,
         table=table,
         partition_id=partition_id,


### PR DESCRIPTION
Default timeout of 60 seconds for select from detached_parts is not enough for large hosts, this causes timeout for commands like `chadmin part delete --detached`