### PR TITLE
Log full command names

### DIFF
--- a/ch_tools/chadmin/cli/chadmin_group.py
+++ b/ch_tools/chadmin/cli/chadmin_group.py
@@ -6,6 +6,7 @@ import cloup
 
 from ch_tools import __version__
 from ch_tools.common import logging
+from ch_tools.common.utils import get_full_command_name
 
 # pylint: disable=too-many-ancestors
 
@@ -33,12 +34,13 @@ class Chadmin(cloup.Group):
         @cloup.pass_context
         def wrapper(ctx, *a, **kw):
             logging.configure(
-                ctx.obj["config"]["loguru"], "chadmin", {"cmd_name": cmd.name}
+                ctx.obj["config"]["loguru"],
+                "chadmin",
+                {"cmd_name": get_full_command_name(ctx)},
             )
 
             logging.debug(
-                "Executing command '{}', params: {}, args: {}, version: {}",
-                cmd.name,
+                "Command starts executing, params: {}, args: {}, version: {}",
                 {
                     **ctx.parent.params,
                     **ctx.params,
@@ -49,11 +51,9 @@ class Chadmin(cloup.Group):
 
             try:
                 cmd_callback(*a, **kw)
-                logging.debug("Command '{}' completed", cmd.name)
+                logging.debug("Command completed")
             except Exception:
-                logging.exception(
-                    "Command '{}' failed with error:", cmd.name, short_stdout=True
-                )
+                logging.exception("Command failed with error:", short_stdout=True)
 
         cmd.callback = wrapper
         super().add_command(

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -146,7 +146,7 @@ DEFAULT_CONFIG = {
     },
     "loguru": {
         "formatters": {
-            "default": "{time:YYYY-MM-DD HH:mm:ss,SSS} {process.name:11} {process.id:5} [{level:8}] {extra[logger_name]}: {extra[cmd_name]}: {message}",
+            "default": "{time:YYYY-MM-DD HH:mm:ss,SSS} {process.name:11} {process.id:5} [{level:8}] {extra[logger_name]} {extra[cmd_name]}: {message}",
         },
         "handlers": {
             "chadmin": {

--- a/ch_tools/common/utils.py
+++ b/ch_tools/common/utils.py
@@ -3,6 +3,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from click import Context
+
 
 def version_ge(version1, version2):
     """
@@ -81,3 +83,15 @@ def first_key(mapping):
 
 def first_value(mapping):
     return next(iter(mapping.values()))
+
+
+def get_full_command_name(ctx: Context) -> str:
+    """
+    Return full command name (with names of groups).
+    """
+    if ctx.parent is None:
+        return ""
+
+    cmd_name = ctx.command.name or "unknown"
+    parent_cmd_name = get_full_command_name(ctx.parent)
+    return f"{parent_cmd_name} {cmd_name}" if parent_cmd_name else cmd_name

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -11,6 +11,7 @@ from cloup import group, option, pass_context, version_option
 
 from ch_tools.common import logging
 from ch_tools.common.config import CH_MONITORING_LOG_FILE, load_config
+from ch_tools.common.utils import get_full_command_name
 
 warnings.filterwarnings(action="ignore", message="Python 3.6 is no longer supported")
 
@@ -66,12 +67,13 @@ class MonrunChecks(cloup.Group):
         @pass_context
         def callback_wrapper(ctx, *args, **kwargs):
             logging.configure(
-                ctx.obj["config"]["loguru"], "ch-monitoring", {"cmd_name": cmd.name}
+                ctx.obj["config"]["loguru"],
+                "ch-monitoring",
+                {"cmd_name": get_full_command_name(ctx)},
             )
 
             logging.debug(
-                "Executing command '{}', params: {}, args: {}, version: {}",
-                cmd.name,
+                "Command starts executing, params: {}, args: {}, version: {}",
                 {
                     **ctx.parent.params,
                     **ctx.params,

--- a/ch_tools/monrun_checks_keeper/main.py
+++ b/ch_tools/monrun_checks_keeper/main.py
@@ -5,6 +5,8 @@ from typing import Optional
 import click
 import cloup
 
+from ch_tools.common.utils import get_full_command_name
+
 warnings.filterwarnings(action="ignore", message="Python 3.6 is no longer supported")
 
 # pylint: disable=wrong-import-position
@@ -55,12 +57,13 @@ class KeeperChecks(cloup.Group):
         @cloup.pass_context
         def wrapper(ctx, *a, **kw):
             logging.configure(
-                ctx.obj["config"]["loguru"], "keeper-monitoring", {"cmd_name": cmd.name}
+                ctx.obj["config"]["loguru"],
+                "keeper-monitoring",
+                {"cmd_name": get_full_command_name(ctx)},
             )
 
             logging.debug(
-                "Executing command '{}', params: {}, args: {}, version: {}",
-                cmd.name,
+                "Command starts executing, params: {}, args: {}, version: {}",
                 {
                     **ctx.parent.params,
                     **ctx.params,


### PR DESCRIPTION
Previously command names are logged without names of groups and it was hard to determine what exact command got executed. Now it's fixed and it's logged full command names.

_Without changes_
```
2024-11-29 00:25:43,242 MainProcess 4132615 [DEBUG   ] chadmin: cleanup: Executing command 'cleanup', params: {'keep_going': True, 'dry_run': False}, args: [], version: 1.0.0
2024-11-29 00:25:49,379 MainProcess 4132615 [DEBUG   ] chadmin: cleanup: Command 'cleanup' completed
```

_With changes_
```
2024-11-29 12:16:28,484 MainProcess 422985 [DEBUG   ] chadmin chs3-backup cleanup: Command starts executing, params: {'keep_going': False, 'dry_run': False}, args: [], version: 2.556.267758743
2024-11-29 12:16:32,058 MainProcess 422985 [DEBUG   ] chadmin chs3-backup cleanup: Command completed
```
