### PR TITLE
Fix tests for 24.11

### DIFF
--- a/tests/modules/clickhouse.py
+++ b/tests/modules/clickhouse.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Sequence, Tuple
 
 from hamcrest import assert_that
 from requests import HTTPError
+from requests.exceptions import ChunkedEncodingError
 
 from ch_tools.chadmin.internal.clickhouse_disks import (
     CLICKHOUSE_PATH,
@@ -58,6 +59,10 @@ def get_response(context: ContextT, node: str, query: str) -> Tuple[int, str]:
         return e.response.status_code, e.response.text
     except ClickhouseError as e:
         return e.response.status_code, e.response.text
+    except ChunkedEncodingError as ex:
+        # Related PR: https://github.com/ClickHouse/ClickHouse/pull/68800
+        logging.warning(f"exception from server {ex}")
+        return None, None
 
 
 def get_version(context: ContextT, node: str) -> str:

--- a/tests/modules/clickhouse.py
+++ b/tests/modules/clickhouse.py
@@ -62,7 +62,7 @@ def get_response(context: ContextT, node: str, query: str) -> Tuple[int, str]:
     except ChunkedEncodingError as ex:
         # Related PR: https://github.com/ClickHouse/ClickHouse/pull/68800
         logging.warning(f"exception from server {ex}")
-        return None, None
+        return 408, "Workaround for in-progress op"
 
 
 def get_version(context: ContextT, node: str) -> str:


### PR DESCRIPTION

The problem is related to response for in-progress op. I suppose using header X-ClickHouse-Exception-Code for checking exception will resolve the problem. However, we are using the request lib and we cann't change internal logic. For example fixing problem here: https://github.com/ClickHouse/clickhouse-js/pull/350/files#

Related PR: https://github.com/ClickHouse/ClickHouse/pull/68800
