### PR TITLE
Сheck for presence of object_storage before _check_mutually_exclusive in orphaned objects monrun check

### DIFF
--- a/ch_tools/monrun_checks/ch_orphaned_objects.py
+++ b/ch_tools/monrun_checks/ch_orphaned_objects.py
@@ -45,10 +45,10 @@ def orphaned_objects_command(
     crit: int,
     warn: int,
 ) -> Result:
-    _check_mutually_exclusive(state_local, state_zk_path)
-
     if not ClickhouseConfig.load().storage_configuration.has_disk("object_storage"):
         return Result(OK, "Disabled")
+
+    _check_mutually_exclusive(state_local, state_zk_path)
 
     try:
         state = _get_orphaned_objects_state(ctx, state_local, state_zk_path)

--- a/ch_tools/monrun_checks/ch_orphaned_objects.py
+++ b/ch_tools/monrun_checks/ch_orphaned_objects.py
@@ -5,6 +5,7 @@ from ch_tools.chadmin.internal.object_storage.orphaned_objects_state import (
     OrphanedObjectsState,
 )
 from ch_tools.chadmin.internal.zookeeper import get_zk_node
+from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 from ch_tools.common.result import CRIT, OK, WARNING, Result
 
 
@@ -45,6 +46,9 @@ def orphaned_objects_command(
     warn: int,
 ) -> Result:
     _check_mutually_exclusive(state_local, state_zk_path)
+
+    if not ClickhouseConfig.load().storage_configuration.has_disk("object_storage"):
+        return Result(OK, "Disabled")
 
     try:
         state = _get_orphaned_objects_state(ctx, state_local, state_zk_path)


### PR DESCRIPTION
Monrun check can be called without arguments if there are no object_storage