### PR TITLE
Сheck for presence of object_storage before _check_mutually_exclusive in orphaned objects monrun check

### DIFF
--- a/ch_tools/monrun_checks/ch_orphaned_objects.py
+++ b/ch_tools/monrun_checks/ch_orphaned_objects.py
@@ -45,10 +45,10 @@ def orphaned_objects_command(
     crit: int,
     warn: int,
 ) -> Result:
-    _check_mutually_exclusive(state_local, state_zk_path)
-
     if not ClickhouseConfig.load().storage_configuration.has_disk("object_storage"):
         return Result(OK, "Disabled")
+
+    _check_mutually_exclusive(state_local, state_zk_path)
 
     try:
         state = _get_orphaned_objects_state(ctx, state_local, state_zk_path)


### PR DESCRIPTION
Monrun check can be called without arguments if there are no object_storage