### PR TITLE
object-storage clean: add trailing slash in prefix

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -56,7 +56,7 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     default="",
     help=(
         "Prefix of object name used while listing bucket. By default its value is attempted to parse "
-        "from endpoint in clickhouse S3 disk config"
+        "from endpoint in clickhouse S3 disk config. If there is no trailing slash it will be added automatically."
     ),
 )
 @option(

--- a/ch_tools/common/commands/clean_object_storage.py
+++ b/ch_tools/common/commands/clean_object_storage.py
@@ -112,6 +112,7 @@ def _clean_object_storage(
     prefix = object_name_prefix or _get_default_object_name_prefix(
         clean_scope, disk_conf
     )
+    prefix = os.path.join(prefix, "")
 
     if not use_saved_list:
         logging.info(


### PR DESCRIPTION
Force to add trailing slash while object-storage clean.
Value parsed from ClickHouse config already has trailing slash.
But it is really error-prone to forget trailing slash when passing prefix explicitly (if you have paths like `/cluster/shard1` and `/cluster/shard10`), and current behavior it is not what do you want usually.

Empty path left unintended.

```
>>> os.path.join('', '')
''
>>> os.path.join('/', '')
'/'
>>> os.path.join('/cluster/shard1', '')
'/cluster/shard1/'
>>> os.path.join('/cluster/shard1/', '')
'/cluster/shard1/'
```

What do you think?