### PR TITLE
zero-copy migration script

### DIFF
--- a/ch_tools/chadmin/chadmin_cli.py
+++ b/ch_tools/chadmin/chadmin_cli.py
@@ -44,6 +44,7 @@ from ch_tools.chadmin.cli.replica_group import replica_group
 from ch_tools.chadmin.cli.replicated_fetch_group import replicated_fetch_group
 from ch_tools.chadmin.cli.replication_queue_group import replication_queue_group
 from ch_tools.chadmin.cli.restore_replica_command import restore_replica_command
+from ch_tools.chadmin.cli.zero_copy_migration_group import zero_copy_migration_group
 from ch_tools.chadmin.cli.s3_credentials_config_group import s3_credentials_config_group
 from ch_tools.chadmin.cli.stack_trace_command import stack_trace_command
 from ch_tools.chadmin.cli.table_group import table_group
@@ -53,7 +54,6 @@ from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
 from ch_tools.common.cli.context_settings import CONTEXT_SETTINGS
 from ch_tools.common.cli.locale_resolver import LocaleResolver
 from ch_tools.common.cli.parameters import TimeSpanParamType, YamlParamType
-
 
 @cloup.group(
     "chadmin",
@@ -142,6 +142,7 @@ groups: List[Any] = [
     wait_group,
     zookeeper_group,
     flamegraph_group,
+    zero_copy_migration_group,
 ]
 
 section = cloup.Section("Commands")

--- a/ch_tools/chadmin/cli/zero_copy_migration_group.py
+++ b/ch_tools/chadmin/cli/zero_copy_migration_group.py
@@ -1,0 +1,246 @@
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Set, Tuple
+
+import yaml
+from click import Context, group, option, pass_context
+from cloup.constraints import AcceptAtMost, constraint
+
+from ch_tools.chadmin.cli.chadmin_group import Chadmin
+from ch_tools.chadmin.cli.wait_group import is_clickhouse_alive
+from ch_tools.chadmin.internal.system import get_version
+from ch_tools.chadmin.internal.table_replica import restore_replica
+from ch_tools.chadmin.internal.utils import execute_query, remove_from_disk
+from ch_tools.chadmin.internal.zookeeper import delete_zk_nodes
+from ch_tools.common import logging
+from ch_tools.common.cli.formatting import print_response
+from ch_tools.common.clickhouse.client import OutputFormat
+from ch_tools.common.clickhouse.config import get_clickhouse_config
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
+from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
+
+
+class TablePartition(NamedTuple):
+    table: str
+    partition: str
+
+
+@group("zero-copy-migration", cls=Chadmin)
+def zero_copy_migration_group():
+    """
+    Commands for manipulating data stored by ClickHouse.
+    """
+    pass
+
+
+DEFAULT_STATUS_PATH = "/tmp/zc-migration-file.yaml"
+QUERY_TIMEOUT = 7200
+RETRY_COUNT = 10
+
+
+class STATUS(Enum):
+    INIT = 1
+    DETACHED = 2
+    ZK_CLEANED = 3
+    RESTORED = 4
+
+
+@dataclass
+class TableMeta:
+    db: str
+    table: str
+    status: STATUS
+    zk_path: str
+
+
+def meta_to_dict(meta):
+    return {
+        "db": meta.db,
+        "table": meta.table,
+        "status": meta.status.value,
+        "zk_path": meta.zk_path,
+    }
+
+
+def dict_to_meta(d):
+    return TableMeta(d["db"], d["table"], STATUS(d["status"]), d["zk_path"])
+
+
+def update_status_file(status_file_path, tables_stats):
+    with open(status_file_path, "w") as file:
+        meta = [meta_to_dict(x) for x in tables_stats]
+        file.write(yaml.dump(meta))
+
+
+@zero_copy_migration_group.command("migrate")
+@pass_context
+@option(
+    "--status-file-path",
+    "status_file_path",
+    default=DEFAULT_STATUS_PATH,
+    help="Additional check: specified COLUMN name should exists in data to be removed. Example: `initial_query_start_time_microseconds.bin` for `query_log`-table.",
+)
+@option(
+    "--not-dry-run",
+    "dry_run",
+    is_flag=True,
+    default=True,
+    help="Get merges from all hosts in the cluster.",
+)
+def migrate(ctx, status_file_path, dry_run):
+    print(Path(status_file_path).exists())
+    if not Path(status_file_path).exists():
+        generate_status_file(ctx, status_file_path)
+
+    tables_stat = load_statuses(ctx, status_file_path)
+    print(tables_stat)
+
+    detach_tables(ctx, tables_stat, status_file_path, dry_run)
+    tables_stat = load_statuses(ctx, status_file_path)
+    print(tables_stat)
+
+    remove_zk_nodes(ctx, tables_stat, status_file_path, dry_run)
+    tables_stat = load_statuses(ctx, status_file_path)
+    print(tables_stat)
+    restart_clickhouse_server(ctx, tables_stat, dry_run)
+
+    restore_replica_step(ctx, tables_stat, status_file_path, dry_run)
+    tables_stat = load_statuses(ctx, status_file_path)
+    print(tables_stat)
+
+
+def generate_status_file(ctx, status_file_path):
+    logging.info("Generate status file")
+
+    tables_to_migrage_query = """
+        WITH obj AS
+        (
+            SELECT
+                `table`,
+                database
+            FROM system.parts
+            WHERE disk_name = 'object_storage'
+            GROUP BY
+                `database`,
+                `table`
+        )
+        SELECT
+            database,
+            name
+        FROM system.tables
+        INNER JOIN obj USING (`table`)
+        WHERE engine ILIKE '%replicated%'
+    """
+
+    resp = execute_query(
+        ctx,
+        tables_to_migrage_query,
+        format_=OutputFormat.JSON,
+    )["data"]
+    print(resp)
+
+    statuses_list = []
+    for value in resp:
+        database = value["database"]
+        table = value["name"]
+        status = STATUS.INIT
+        get_zk_query = f"""
+            SELECT zookeeper_path
+            FROM system.replicas
+            WHERE (database = '{database}') AND (`table` = '{table}')
+        """
+        zk_path = execute_query(ctx, get_zk_query, format_=OutputFormat.JSON)["data"][
+            0
+        ]["zookeeper_path"]
+        statuses_list.append(TableMeta(database, table, status, zk_path))
+
+    update_status_file(status_file_path, statuses_list)
+
+
+def load_statuses(ctx, status_file_path):
+    logging.info("Load status file")
+
+    with open(status_file_path, "r") as file:
+        loaded = yaml.load(file, yaml.SafeLoader)
+        return [dict_to_meta(x) for x in loaded]
+
+
+def execute_query_with_retry(ctx, query, dry_run=True):
+    for _ in range(RETRY_COUNT):
+        try:
+            execute_query(
+                ctx,
+                query,
+                timeout=QUERY_TIMEOUT,
+                dry_run=dry_run,
+            )
+            return
+        except Exception:
+            pass
+
+
+def detach_tables(ctx, tables_stat, status_file_path, dry_run=True):
+    logging.info("Detach tables step")
+    for index in range(len(tables_stat)):
+        if tables_stat[index].status == STATUS.INIT:
+            execute_query_with_retry(
+                ctx,
+                query=f"DETACH TABLE `{tables_stat[index].db}`.`{tables_stat[index].table}`",
+            )
+            tables_stat[index].status = STATUS.DETACHED
+            update_status_file(status_file_path, tables_stat)
+
+
+def remove_zk_nodes(ctx, tables_stat, status_file_path, dry_run=True):
+    logging.info("Remove from zk step")
+    for index in range(len(tables_stat)):
+        if tables_stat[index].status == STATUS.DETACHED:
+            delete_zk_nodes(ctx, [tables_stat[index].zk_path], dry_run=dry_run)
+            tables_stat[index].status = STATUS.ZK_CLEANED
+            update_status_file(status_file_path, tables_stat)
+
+
+def restart_clickhouse_server(ctx, tables_stat, dry_run=True):
+    logging.info("Restart clickhouse step")
+    for table in tables_stat:
+        if table.status == STATUS.ZK_CLEANED:
+            restart_cmd = "service clickhouse-server restart"
+            logging.info(restart_cmd)
+            if dry_run:
+                return
+
+            subprocess.run(restart_cmd, shell=True)
+
+            deadline = time.time() + QUERY_TIMEOUT
+
+            ch_is_alive = False
+            while time.time() < deadline:
+                if is_clickhouse_alive():
+                    ch_is_alive = True
+                    break
+                time.sleep(1)
+            if not ch_is_alive:
+                logging.error("CH is dead")
+                exit(1)
+            return
+
+
+def restore_replica_step(ctx, tables_stat, status_file_path, dry_run=True):
+    logging.info("Remove from zk step")
+
+    for index in range(len(tables_stat)):
+        if tables_stat[index].status == STATUS.ZK_CLEANED:
+            restore_replica(
+                ctx,
+                tables_stat[index].db,
+                tables_stat[index].table,
+                cluster=None,
+                dry_run=dry_run,
+            )
+            tables_stat[index].status = STATUS.RESTORED
+            update_status_file(status_file_path, tables_stat)

--- a/ch_tools/common/process_pool.py
+++ b/ch_tools/common/process_pool.py
@@ -13,7 +13,7 @@ class WorkerTask:
 
 
 def execute_tasks_in_parallel(
-    tasks: List[WorkerTask], max_workers: int = 4, keep_going: bool = False
+    tasks: List[WorkerTask], max_workers: int = 4, keep_going: bool = False,  callback = None,
 ) -> Dict[str, Any]:
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Can't use map function here. The map method returns a generator
@@ -31,6 +31,8 @@ def execute_tasks_in_parallel(
             idf = futures_to_indedifier[future]
             try:
                 result[idf] = future.result()
+                if callback:
+                    callback(idf)
             except Exception as e:
                 if keep_going:
                     logging.warning(


### PR DESCRIPTION
Im pretty sure that the logic will be never merged but it looks like useful script to migrate cluster from one zk path to another one.

another great feature that it is resumable, so if smth goes wrong you can resume the execution.

## Summary by Sourcery

Add a zero-copy migration script to the chadmin CLI that supports detaching tables, cleaning ZooKeeper nodes, restarting ClickHouse, and restoring replicas in parallel, with progress persisted to a status file for resumability.

New Features:
- Add a zero-copy migration CLI group with a resumable “migrate” command for migrating replicated tables between ZooKeeper paths
- Persist migration progress in a YAML status file to allow interruption and resumption of the migration workflow

Enhancements:
- Extend execute_tasks_in_parallel to accept an optional callback for tracking task completion and updating migration status