### PR TITLE
Fix 3.12 CI and sync git_igonore with make variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ dist/
 out/
 tests/reports/
 tests/staging/
-venv/
+.venv/
 version.txt

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ install-poetry:
 	# while 'poetry publish' for version poetry 1.1.15 due to incompatibility with urllib3 >= 2.0.0
 	# https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html#importerror-cannot-import-name-gaecontrib-from-requests-toolbelt-compat
 	$(POETRY_HOME)/venv/bin/python -m pip install "urllib3<2.0.0"
+	$(POETRY_HOME)/venv/bin/python -m pip install "virtualenv>=20.30.0,<20.31.0"
 
 
 .PHONY: uninstall-poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -640,7 +640,7 @@ parse = {version = ">=1.18.0", markers = "python_version >= \"3.0\""}
 six = ">=1.15"
 
 [package.extras]
-develop = ["build (>=0.5.1)", "coverage (>=4.4)", "pylint", "pytest (<5.0)", "pytest (>=5.0)", "pytest-cov", "pytest-html (>=1.19.0)", "ruff", "setuptools", "setuptools-scm", "tox (>=2.8,<4.0)", "twine (>=1.13.0)", "virtualenv (<20.22.0)", "virtualenv (>=20.0.0)", "wheel"]
+develop = ["build (>=0.5.1)", "coverage (>=4.4)", "pylint", "pytest (<5.0)", "pytest (>=5.0)", "pytest-cov", "pytest-html (>=1.19.0)", "ruff", "setuptools", "setuptools-scm", "tox (>=2.8,<4.0)", "twine (>=1.13.0)", "virtualenv (<20.31.0)", "virtualenv (>=20.30.0)", "wheel"]
 docs = ["Sphinx (>=1.6)", "sphinx-bootstrap-theme (>=0.6.0)"]
 testing = ["pytest (<5.0)", "pytest (>=5.0)", "pytest-html (>=1.19.0)"]
 
@@ -689,7 +689,7 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.extras]
-dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx-rtd-theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx-rtd-theme", "toml-sort", "twine", "virtualenv (<20.31.0)", "vulture", "wheel"]
 test = ["pytest", "pytest-xdist", "setuptools"]
 
 [[package]]


### PR DESCRIPTION
Make file contains `VENV_DIR := .venv`. However gitignore contains env. I assume it is confusing and we should use one value.

However, The CI with python3.12 was broken. 
Links:
- https://github.com/pypa/virtualenv/issues/2487
- https://github.com/python-poetry/poetry/issues/10382
- https://github.com/python-poetry/poetry/issues/10378

So I also have prepared the fix.