### PR TITLE
Add missing dependency for prepare-changelog Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ uninstall-logrotate:
 
 
 .PHONY: prepare-changelog
-prepare-changelog:
+prepare-changelog: setup
 	echo 'Bumping version into Debian package changelog'
 	DEBFULLNAME="Yandex LLC" DEBEMAIL="ch-tools@yandex-team.ru" dch --force-bad-version --distribution stable -v $$(cat $(VERSION_FILE)) Autobuild
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing 'setup' prerequisite to the 'prepare-changelog' target in Makefile