### PR TITLE
Fix undefined variable warning in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ else
 	export PYTHON_VERSION := $(shell cat .python-version)
 endif
 
+export CLICKHOUSE_VERSION ?= latest
+
 PREFIX ?= /opt/yandex/$(PROJECT_NAME)
 export BUILD_PYTHON_OUTPUT_DIR ?= dist
 export BUILD_DEB_OUTPUT_DIR ?= out


### PR DESCRIPTION
The changes fix the following warning:
```
$ make help
Makefile:291: warning: undefined variable `CLICKHOUSE_VERSION'
Targets:
  build (default)            Build Python packages (sdist and wheel).
  all                        Alias for "lint test-unit build test-integration".
...
```