### PR TITLE
Fix "Legacy key/value format with whitespace separator should not be used"

### DIFF
--- a/tests/images/clickhouse/Dockerfile
+++ b/tests/images/clickhouse/Dockerfile
@@ -16,9 +16,9 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 # Install ClickHouse
 COPY tests/images/clickhouse/config/clickhouse-keyring.gpg /usr/share/keyrings/clickhouse-keyring.gpg

--- a/tests/images/http_mock/Dockerfile
+++ b/tests/images/http_mock/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
 RUN pip3 install flask --no-cache
-ENV FLASK_APP /service.py
+ENV FLASK_APP=/service.py
 COPY tests/images/http_mock/service.py /
 CMD ["python3", "-m", "flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/tests/images/minio/Dockerfile
+++ b/tests/images/minio/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
-ENV MINIO_ACCESS_KEY {{ conf.s3.access_key_id }}
-ENV MINIO_SECRET_KEY {{ conf.s3.access_secret_key }}
+ENV MINIO_ACCESS_KEY={{ conf.s3.access_key_id }}
+ENV MINIO_SECRET_KEY={{ conf.s3.access_secret_key }}
 
 RUN apk add --no-cache minio minio-client
 COPY tests/images/minio/config/mc.json /root/.mcli/config.json


### PR DESCRIPTION
Fix for GitHub warnings `Legacy key/value format with whitespace separator should not be used`. 

https://docs.docker.com/reference/build-checks/legacy-key-value-format/

## Summary by Sourcery

Update Dockerfiles to use the modern ENV key=value syntax to remove legacy whitespace-separated declarations and silence build warnings

Bug Fixes:
- Replace legacy whitespace-separated ENV declarations with key=value syntax in clickhouse Dockerfile
- Replace legacy whitespace-separated ENV declarations with key=value syntax in minio Dockerfile
- Replace legacy whitespace-separated ENV declarations with key=value syntax in http_mock Dockerfile