### PR TITLE
Disable use-named-expression suggestions

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,3 @@
+rule_settings:
+  disable:
+    - use-named-expression


### PR DESCRIPTION
To avoid erroneous suggestions like in https://github.com/yandex/ch-tools/pull/318#discussion_r2104195734

## Summary by Sourcery

Build:
- Disable the 'use-named-expression' rule in .sourcery.yaml