### PR TITLE
Actualize docker compose config

### DIFF
--- a/tests/modules/compose.py
+++ b/tests/modules/compose.py
@@ -121,12 +121,10 @@ def _generate_compose_config(config: dict) -> dict:
     Create docker compose config.
     """
     compose_config: dict = {
-        "version": "2",
         "networks": {
             "test_net": {
-                "external": {
-                    "name": config["network_name"],
-                },
+                "name": config["network_name"],
+                "external": True,
             },
         },
         "services": {},


### PR DESCRIPTION
The changes fix the following docker compose warnings:
```
# make test-integration
...
WARN[0000] /home/alex-burmak/ch-tools/tests/staging/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
WARN[0000] networks.test_net: external.name is deprecated. Please set name and external: true
```

## Summary by Sourcery

Remove obsolete `version` attribute and modernize network configuration in the generated Docker Compose config to eliminate warnings.

Enhancements:
- Remove `version` field from generated compose config
- Replace network `external` block with top-level `name` and `external: True` properties