### PR TITLE
fix failed build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "tqdm",
     "xmltodict",
     "loguru",
-    "setuptools >= 71.1",  # for pkg_resources module
+    "setuptools >= 71.1, < 81",  # for pkg_resources module
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ requires-dist = [
     { name = "python-dateutil" },
     { name = "pyyaml", specifier = ">=5.4" },
     { name = "requests", specifier = ">=2.20" },
-    { name = "setuptools", specifier = ">=71.1" },
+    { name = "setuptools", specifier = ">=71.1,<81" },
     { name = "tabulate" },
     { name = "tenacity" },
     { name = "termcolor" },


### PR DESCRIPTION
```
And we do hosts cleanup on clickhouse01 with fqdn clickhouse01.ch_tools_test,clickhouse02.ch_tools_test and zk root / # steps/chadmin.py:23
    Then the list of children on clickhouse01 for zk node /tables/ are empty                                              # steps/chadmin.py:66
      Assertion Failed: 
      Expected: '\n'
           but: was '/usr/local/lib/python3.10/site-packages/ch_tools/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n  from pkg_resources import resource_string\n\n'
```

## Summary by Sourcery

Pin setuptools version to be <81 to prevent pkg_resources deprecation warnings from causing build failures.

Bug Fixes:
- Prevent build failures by avoiding deprecated pkg_resources removal in newer setuptools versions.

Build:
- Restrict setuptools dependency to versions >=71.1,<81 in pyproject.toml and update lock file.