### PR TITLE
Add missing $VERSION_FILE to makefile clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ clean: clean_debuild
 	rm -rf $(BUILD_DEB_OUTPUT_DIR)
 	rm -rf $(BUILD_PYTHON_OUTPUT_DIR)
 	rm -rf $(VENV_DIR)
+	rm -rf $(VERSION_FILE)
 	rm -rf .mypy_cache .ruff_cache tests/{.session_conf.sav,__pycache__,staging,reports}
 
 


### PR DESCRIPTION
$VERSION_FILE is a generated file. So it should be removed in `clean` target.

## Summary by Sourcery

Enhancements:
- Add $VERSION_FILE to Makefile clean recipe to remove the generated version file during cleanup.