### PR TITLE
Сhange table engine to replicated for S3 listing table

### DIFF
--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -1,5 +1,7 @@
 import os
 import re
+from ch_tools.monrun_checks.clickhouse_info import ClickhouseInfo
+from click import Context
 from collections import deque
 from contextlib import contextmanager
 from math import sqrt
@@ -10,6 +12,10 @@ from kazoo.exceptions import NoNodeError, NotEmptyError
 from ch_tools.chadmin.internal.utils import chunked, replace_macros
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_clickhouse_config, get_macros
+
+
+def has_zk(ctx: Context) -> bool:
+    return len(ClickhouseInfo.get_replicas(ctx)) > 1
 
 
 def get_zk_node(ctx, path, binary=False):

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -45,6 +45,7 @@ DEFAULT_CONFIG = {
         "clean": {
             "listing_table_prefix": "listing_objects_from_",
             "listing_table_database": "default",
+            "listing_table_zk_path_prefix": "/_system/tables",
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
         },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use ReplicatedMergeTree with ZooKeeper path and replica settings for the S3 listing table instead of MergeTree