### PR TITLE
Wait replication-sync: exit with error code 1 when CH returns error

### DIFF
--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -142,8 +142,9 @@ def wait_replication_sync_command(
     except ClickhouseError as e:
         if "TIMEOUT_EXCEEDED" in str(e):
             logging.error("Timeout while running query.")
-            sys.exit(1)
-        raise
+        else:
+            logging.error(f"Clickhouse error while running query: {e}")
+        sys.exit(1)
 
     if lightweight:
         sys.exit(0)


### PR DESCRIPTION
Not exiting with `1` on CH error leads to `0` exit-code because [of this](https://github.com/yandex/ch-tools/blob/main/ch_tools/chadmin/cli/chadmin_group.py#L56).
We are exiting with `1` in all bad cases in current function except this one.
