### PR TITLE
Fix has zk in ch config

### DIFF
--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -14,7 +14,7 @@ from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 
 
 def has_zk() -> bool:
-    return ClickhouseConfig.load().zookeeper
+    return not ClickhouseConfig.load().zookeeper.is_empty()
 
 
 def get_zk_node(ctx, path, binary=False):

--- a/ch_tools/common/clickhouse/config/zookeeper.py
+++ b/ch_tools/common/clickhouse/config/zookeeper.py
@@ -9,6 +9,9 @@ class ClickhouseZookeeperConfig:
     def __init__(self, config: dict) -> None:
         self._config = config
 
+    def is_empty(self) -> bool:
+        return not bool(self._config)
+
     @property
     def nodes(self) -> list:
         value = self._config["node"]

--- a/ch_tools/common/commands/clean_object_storage.py
+++ b/ch_tools/common/commands/clean_object_storage.py
@@ -123,7 +123,7 @@ def _clean_object_storage(
     prefix = object_name_prefix or _get_default_object_name_prefix(
         clean_scope, disk_conf
     )
-    prefix = os.path.join(prefix, "")
+    prefix = os.path.join(prefix, '')
 
     if not use_saved_list:
         logging.info(

--- a/tests/unit/common/clickhouse/test_config.py
+++ b/tests/unit/common/clickhouse/test_config.py
@@ -128,3 +128,40 @@ def test_config(fs, files, result):
 
     config = ClickhouseConfig.load(try_preprocessed=True)
     assert config.dump() == result
+
+
+@pytest.mark.parametrize(
+    "files,result",
+    [
+        pytest.param(
+            {
+                CLICKHOUSE_SERVER_CONFIG_PATH: """
+                    <clickhouse>
+                        <zookeeper>
+                            <node></node>
+                            <root></root>
+                        </zookeeper>
+                    </clickhouse>
+                    """,
+            },
+            False,
+            id="with ZK config",
+        ),
+        pytest.param(
+            {
+                CLICKHOUSE_SERVER_CONFIG_PATH: """
+                    <clickhouse>
+                        <path>/var/lib/clickhouse/</path>
+                    </clickhouse>
+                    """,
+            },
+            True,
+            id="without ZK config",
+        ),
+    ],
+)
+def test_config_zookeeper(fs, files, result):
+    for file_path, contents in files.items():
+        fs.create_file(file_path, contents=contents)
+
+    assert ClickhouseConfig.load().zookeeper.is_empty() == result


### PR DESCRIPTION
## Summary by Sourcery

Add a method to detect empty zookeeper configs, use it to fix has_zk logic, and cover the behavior with new unit tests

Bug Fixes:
- Correct the has_zk function to return a boolean based on the updated is_empty method rather than the config object

Enhancements:
- Introduce ClickhouseZookeeperConfig.is_empty() to detect empty ZK configurations

Tests:
- Add parametrized tests to verify zookeeper config presence and absence

Chores:
- Normalize string quoting in os.path.join call