### PR TITLE
Fix to determine ZK configuration on CH cluster

### DIFF
--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -14,7 +14,7 @@ from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 
 
 def has_zk() -> bool:
-    return ClickhouseConfig.load().zookeeper
+    return not ClickhouseConfig.load().zookeeper.is_empty()
 
 
 def get_zk_node(ctx, path, binary=False):

--- a/ch_tools/common/clickhouse/config/zookeeper.py
+++ b/ch_tools/common/clickhouse/config/zookeeper.py
@@ -9,6 +9,9 @@ class ClickhouseZookeeperConfig:
     def __init__(self, config: dict) -> None:
         self._config = config
 
+    def is_empty(self) -> bool:
+        return not bool(self._config)
+
     @property
     def nodes(self) -> list:
         value = self._config["node"]

--- a/tests/unit/common/clickhouse/test_config.py
+++ b/tests/unit/common/clickhouse/test_config.py
@@ -128,3 +128,51 @@ def test_config(fs, files, result):
 
     config = ClickhouseConfig.load(try_preprocessed=True)
     assert config.dump() == result
+
+
+@pytest.mark.parametrize(
+    "files,result",
+    [
+        pytest.param(
+            {
+                CLICKHOUSE_SERVER_CONFIG_PATH: """
+                    <clickhouse>
+                        <zookeeper>
+                            <node></node>
+                            <root></root>
+                        </zookeeper>
+                    </clickhouse>
+                    """,
+            },
+            False,
+            id="with ZK config",
+        ),
+        pytest.param(
+            {
+                CLICKHOUSE_SERVER_CONFIG_PATH: """
+                    <clickhouse>
+                        <path>/var/lib/clickhouse/</path>
+                    </clickhouse>
+                    """,
+            },
+            True,
+            id="without ZK config",
+        ),
+        pytest.param(
+            {
+                CLICKHOUSE_SERVER_CONFIG_PATH: """
+                    <clickhouse>
+                        <zookeeper/>
+                    </clickhouse>
+                    """,
+            },
+            True,
+            id="with empty ZK config",
+        ),
+    ],
+)
+def test_config_zookeeper(fs, files, result):
+    for file_path, contents in files.items():
+        fs.create_file(file_path, contents=contents)
+
+    assert ClickhouseConfig.load().zookeeper.is_empty() == result


### PR DESCRIPTION
It did not work correctly, because `.zookeeper` is always class instance, sometimes with `{}` config.
If it is `{}` - it is still should be considering empty config and `has_zk == False`.

---

## Summary by Sourcery

Introduce is_empty() to ClickhouseZookeeperConfig, update has_zk() to use it, and add tests to verify ZK config presence

Bug Fixes:
- Fix has_zk() to return a boolean based on the new is_empty() check

Enhancements:
- Add is_empty() method to ClickhouseZookeeperConfig to detect absence of ZK configuration

Tests:
- Add parameterized tests for zookeeper configuration detection in ClickhouseConfig

## Summary by Sourcery

Ensure empty Zookeeper configs are correctly recognized by ClickhouseConfig by adding an is_empty() method and updating has_zk() to use it, with new tests.

Bug Fixes:
- Fix has_zk() to return false when the Zookeeper configuration is empty

Enhancements:
- Add is_empty() method to ClickhouseZookeeperConfig to detect absence of Zookeeper configuration

Tests:
- Add parameterized tests for Zookeeper configuration detection in ClickhouseConfig