### PR TITLE
Sanity check before cleanup in object-storage clean command

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -14,6 +14,7 @@ from ch_tools.chadmin.internal.zookeeper import (
     create_zk_nodes,
     update_zk_nodes,
 )
+from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_response
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.config import get_clickhouse_config
@@ -174,6 +175,7 @@ def clean_command(
             verify_paths_regex,
         )
     except Exception as e:
+        logging.exception("Clean orphaned s3 objects have failed with: {!r}", e)
         error_msg = str(e)
         raise
     finally:

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -131,8 +131,7 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     "verify_paths_regex",
     default=None,
     help=(
-        "Begin of inspecting interval in human-friendly format. "
-        "Objects with a modification time falling interval [now - from_time, now - to_time] are considered."
+        "Regex for verifing that paths for delete and in system.remote_data_paths are ."
     ),
 )
 @pass_context

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -126,6 +126,15 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     default="",
     help=("Zookeeper node path for storage total size of orphaned objects."),
 )
+@option(
+    "--verify-paths-regex",
+    "verify_paths_regex",
+    default=None,
+    help=(
+        "Begin of inspecting interval in human-friendly format. "
+        "Objects with a modification time falling interval [now - from_time, now - to_time] are considered."
+    ),
+)
 @pass_context
 def clean_command(
     ctx: Context,
@@ -139,6 +148,7 @@ def clean_command(
     use_saved_list: bool,
     store_state_local: bool,
     store_state_zk_path: str,
+    verify_paths_regex: Optional[str],
 ) -> None:
     """
     Clean orphaned S3 objects.
@@ -162,6 +172,7 @@ def clean_command(
             dry_run,
             keep_paths,
             use_saved_list,
+            verify_paths_regex,
         )
     except Exception as e:
         error_msg = str(e)

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -131,7 +131,7 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     "verify_paths_regex",
     default=None,
     help=(
-        "Regex for verifing that paths for delete and in system.remote_data_paths are ."
+        "Regex for verifying that paths for delete and in system.remote_data_paths are ."
     ),
 )
 @pass_context

--- a/ch_tools/chadmin/internal/object_storage/obj_list_item.py
+++ b/ch_tools/chadmin/internal/object_storage/obj_list_item.py
@@ -1,5 +1,3 @@
-import os
-import uuid
 from dataclasses import dataclass
 
 
@@ -16,29 +14,3 @@ class ObjListItem:
     def from_tab_separated(cls, value: str) -> "ObjListItem":
         path, size = value.split("\t")
         return cls(path, int(size))
-
-
-class ObjListIterator:
-
-    def __init__(self, ch_client, query, timeout, settings, use_stream, tmp_dir_path):
-        os.makedirs(tmp_dir_path, exist_ok=True)
-
-        self.file_path = os.path.join(tmp_dir_path, f"object_list_{str(uuid.uuid4())}")
-        with open(self.file_path, "w", encoding="utf-8") as file:
-            with ch_client.query(
-                query,
-                timeout=timeout,
-                settings=settings,
-                stream=use_stream,
-                format_="TabSeparated",
-            ) as resp:
-                for line in resp.iter_lines():
-                    file.write(line.decode() + "\n")
-
-    def __iter__(self):
-        with open(self.file_path, "r", encoding="utf-8") as file:
-            for line in file:
-                yield ObjListItem.from_tab_separated(line)
-
-    def __del__(self):
-        os.remove(self.file_path)

--- a/ch_tools/chadmin/internal/object_storage/obj_list_item.py
+++ b/ch_tools/chadmin/internal/object_storage/obj_list_item.py
@@ -1,3 +1,5 @@
+import os
+import uuid
 from dataclasses import dataclass
 
 
@@ -14,3 +16,30 @@ class ObjListItem:
     def from_tab_separated(cls, value: str) -> "ObjListItem":
         path, size = value.split("\t")
         return cls(path, int(size))
+
+
+class ObjListIterator:
+
+    def __init__(self, ch_client, query, timeout, settings, use_stream, tmp_dir_path):
+        os.makedirs(tmp_dir_path, exist_ok=True)
+
+        self.file_path = os.path.join(tmp_dir_path, "object_list_" + str(uuid.uuid4()))
+        with open(self.file_path, "w", encoding="utf-8") as file:
+            with ch_client.query(
+                query,
+                timeout=timeout,
+                settings=settings,
+                stream=use_stream,
+                format_="TabSeparated",
+            ) as resp:
+                for line in resp.iter_lines():
+                    file.write(line.decode() + "\n")
+
+    def __iter__(self):
+        with open(self.file_path, "r", encoding="utf-8") as file:
+            for line in file:
+                yield ObjListItem.from_tab_separated(line)
+
+    def __del__(self):
+        os.remove(self.file_path)
+        pass

--- a/ch_tools/chadmin/internal/object_storage/obj_list_item.py
+++ b/ch_tools/chadmin/internal/object_storage/obj_list_item.py
@@ -23,7 +23,7 @@ class ObjListIterator:
     def __init__(self, ch_client, query, timeout, settings, use_stream, tmp_dir_path):
         os.makedirs(tmp_dir_path, exist_ok=True)
 
-        self.file_path = os.path.join(tmp_dir_path, "object_list_" + str(uuid.uuid4()))
+        self.file_path = os.path.join(tmp_dir_path, f"object_list_{str(uuid.uuid4())}")
         with open(self.file_path, "w", encoding="utf-8") as file:
             with ch_client.query(
                 query,
@@ -42,4 +42,3 @@ class ObjListIterator:
 
     def __del__(self):
         os.remove(self.file_path)
-        pass

--- a/ch_tools/common/clickhouse/client/clickhouse_client.py
+++ b/ch_tools/common/clickhouse/client/clickhouse_client.py
@@ -222,7 +222,7 @@ class ClickhouseClient:
 
     def query_json_data(
         self: Self,
-        query: str,
+        query: Union[str, Query],
         query_args: Optional[Dict[str, Any]] = None,
         compact: bool = True,
         post_data: Any = None,
@@ -252,6 +252,9 @@ class ClickhouseClient:
             settings=settings,
             port=port,
         )["data"]
+
+    def query_json_data_first_row(self, **kwargs):
+        return self.query_json_data(**kwargs)[0]
 
     def render_query(self, query, **kwargs):
         env = Environment()

--- a/ch_tools/common/commands/clean_object_storage.py
+++ b/ch_tools/common/commands/clean_object_storage.py
@@ -333,7 +333,7 @@ def _clean_object_storage(
         clean_scope,
         remote_data_paths_table,
         ctx.obj["config"]["object_storage"]["clean"]["perform_sanity_check_size"],
-        ctx.obj["config"]["object_storage"]["clean"]["perform_sanity_check_pathes"],
+        ctx.obj["config"]["object_storage"]["clean"]["perform_sanity_check_paths"],
     )
     deleted, total_size = _clean_objects(object_iterator, disk_conf, dry_run)
 

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -52,9 +52,11 @@ DEFAULT_CONFIG = {
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
             "verify": True,
-            "verify_paths_for_host_regex": r"^(\w+)/(\w+)/(\w+)/",
-            "verify_paths_for_shard_regex": r"^(\w+)/(\w+)/(\w+)/",
-            "verify_paths_for_cluster_regex": r"^(\w+)/(\w+)/",
+            "verify_paths_regex": {
+                "host": r"^(\w+)/(\w+)/(\w+)/",
+                "shard": r"^(\w+)/(\w+)/(\w+)/",
+                "cluster": r"^(\w+)/(\w+)/",
+            },
             "verify_size_error_rate_threshold_bytes": 1024 * 1024 * 1024,  ## 1 GB
         },
     },

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -52,7 +52,7 @@ DEFAULT_CONFIG = {
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
             "verify": True,
-            "verify_paths_for_hosts_regex": r"^(\w+)/(\w+)/(\w+)/",
+            "verify_paths_for_host_regex": r"^(\w+)/(\w+)/(\w+)/",
             "verify_paths_for_shard_regex": r"^(\w+)/(\w+)/(\w+)/",
             "verify_paths_for_cluster_regex": r"^(\w+)/(\w+)/",
         },

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -49,7 +49,7 @@ DEFAULT_CONFIG = {
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
             "perform_sanity_check_size": True,
-            "perform_sanity_check_pathes": True,
+            "perform_sanity_check_paths": True,
         },
     },
     "zookeeper": {

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -55,6 +55,7 @@ DEFAULT_CONFIG = {
             "verify_paths_for_host_regex": r"^(\w+)/(\w+)/(\w+)/",
             "verify_paths_for_shard_regex": r"^(\w+)/(\w+)/(\w+)/",
             "verify_paths_for_cluster_regex": r"^(\w+)/(\w+)/",
+            "verify_size_error_rate_threshold_bytes": 1024 * 1024 * 1024,  ## 1 GB
         },
     },
     "zookeeper": {

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -44,12 +44,17 @@ DEFAULT_CONFIG = {
         "bucket_name_prefix": "cloud-storage-",
         "clean": {
             "listing_table_prefix": "listing_objects_from_",
+            "orphaned_objects_table_prefix": "orphaned_objects_",
             "listing_table_database": "default",
+            "orphaned_objects_table_database": "default",
             "listing_table_zk_path_prefix": "/_system/tables",
+            "orphaned_objects_table_zk_path_prefix": "/_system/tables",
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
-            "perform_sanity_check_size": True,
-            "perform_sanity_check_paths": True,
+            "verify": True,
+            "verify_paths_for_hosts_regex": r"^(\w+)/(\w+)/(\w+)/",
+            "verify_paths_for_shard_regex": r"^(\w+)/(\w+)/(\w+)/",
+            "verify_paths_for_cluster_regex": r"^(\w+)/(\w+)/",
         },
     },
     "zookeeper": {
@@ -81,7 +86,6 @@ DEFAULT_CONFIG = {
                 "max_retries": 25,
             },
         },
-        "tmp_path": "/var/lib/clickhouse/_mdb_tmp/chadmin",
     },
     "flamegraph": {
         "clickhouse_settings_per_sample_type": {

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -48,6 +48,8 @@ DEFAULT_CONFIG = {
             "listing_table_zk_path_prefix": "/_system/tables",
             "storage_policy": "default",
             "antijoin_timeout": 10 * 60,
+            "perform_sanity_check_size": True,
+            "perform_sanity_check_pathes": True,
         },
     },
     "zookeeper": {
@@ -79,6 +81,7 @@ DEFAULT_CONFIG = {
                 "max_retries": 25,
             },
         },
+        "tmp_path": "/var/lib/clickhouse/_mdb_tmp/chadmin",
     },
     "flamegraph": {
         "clickhouse_settings_per_sample_type": {

--- a/tests/features/monrun.feature
+++ b/tests/features/monrun.feature
@@ -411,7 +411,7 @@ Feature: ch-monitoring tool
     When we put object in S3
     """
       bucket: cloud-storage-test
-      path: /data/orpaned_object.tsv
+      path: /data/cluster_id/shard_1/orpaned_object.tsv
       data: '1234567890'
     """
     When we execute command on clickhouse01
@@ -465,7 +465,7 @@ Feature: ch-monitoring tool
     When we put object in S3
     """
       bucket: cloud-storage-test
-      path: /data/orpaned_object.tsv
+      path: /data/cluster_id/shard_1/orpaned_object.tsv
       data: '1234567890'
     """
     When we execute command on clickhouse01

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -116,7 +116,7 @@ Feature: chadmin object-storage commands
     object_storage:
       clean:
         perform_sanity_check_size: False
-        perform_sanity_check_pathes: False
+        perform_sanity_check_paths: False
     """
     When we put object in S3
     """

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -115,8 +115,7 @@ Feature: chadmin object-storage commands
     """
     object_storage:
       clean:
-        perform_sanity_check_size: False
-        perform_sanity_check_paths: False
+        verify: False
     """
     When we put object in S3
     """

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -229,7 +229,7 @@ Feature: chadmin object-storage commands
       path: /unrelated_path/orpaned_object.tsv
       data: '100'
     """
-    When we execute command on clickhouse01
+    When we try to execute command on clickhouse01
     """
     chadmin --format yaml object-storage clean --dry-run --to-time 0h --prefix "unrelated_path"
     """

--- a/tests/images/clickhouse/config/config.xml
+++ b/tests/images/clickhouse/config/config.xml
@@ -42,7 +42,7 @@
             <default />
             <object_storage>
                 <type>s3</type>
-                <endpoint>{{ conf.s3.endpoint }}/{{ conf.s3.bucket }}/data/</endpoint>
+                <endpoint>{{ conf.s3.endpoint }}/{{ conf.s3.bucket }}/data/cluster_id/shard_1</endpoint>
                 <access_key_id>{{ conf.s3.access_key_id }}</access_key_id>
                 <secret_access_key>{{ conf.s3.access_secret_key }}</secret_access_key>
             </object_storage>

--- a/tests/images/clickhouse/config/config.xml
+++ b/tests/images/clickhouse/config/config.xml
@@ -42,7 +42,7 @@
             <default />
             <object_storage>
                 <type>s3</type>
-                <endpoint>{{ conf.s3.endpoint }}/{{ conf.s3.bucket }}/data/cluster_id/shard_1</endpoint>
+                <endpoint>{{ conf.s3.endpoint }}/{{ conf.s3.bucket }}/data/cluster_id/shard_1/</endpoint>
                 <access_key_id>{{ conf.s3.access_key_id }}</access_key_id>
                 <secret_access_key>{{ conf.s3.access_secret_key }}</secret_access_key>
             </object_storage>


### PR DESCRIPTION
## Summary by Sourcery

Implement a safety layer before cleaning orphaned objects by verifying path consistency and total size, refactor the cleanup command to use a streaming iterator and modular helpers, and adjust configuration and tests accordingly.

New Features:
- Add pre-cleanup sanity checks for object paths and bucket size in the object-storage clean command

Enhancements:
- Refactor clean workflow by separating listing, sanity validation, and deletion into distinct helper functions

Tests:
- Update object-storage feature tests to include shard-based paths and add a scenario for path sanity check failure

Chores:
- Add configuration flags to enable or disable sanity checks and define a temporary directory path for chadmin