### PR TITLE
Trying to get rid of sys.exit

### DIFF
--- a/ch_tools/chadmin/cli/chadmin_group.py
+++ b/ch_tools/chadmin/cli/chadmin_group.py
@@ -1,3 +1,4 @@
+import sys
 from functools import wraps
 from typing import Optional
 
@@ -54,6 +55,7 @@ class Chadmin(cloup.Group):
                 logging.debug("Command completed")
             except Exception:
                 logging.exception("Command failed with error:", short_stdout=True)
+                sys.exit(1)
 
         cmd.callback = wrapper
         super().add_command(

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -13,7 +13,6 @@ from ch_tools.chadmin.internal.zookeeper import (
     create_zk_nodes,
     update_zk_nodes,
 )
-from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_response
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.config import get_clickhouse_config

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import timedelta
 from typing import Optional
 
@@ -164,9 +163,6 @@ def clean_command(
             keep_paths,
             use_saved_list,
         )
-    except Exception as e:
-        error_msg = str(e)
-        raise
     finally:
         state = OrphanedObjectsState(total_size, error_msg)
 
@@ -175,10 +171,6 @@ def clean_command(
 
         if store_state_local:
             _store_state_local_save(ctx, state)
-
-        if error_msg:
-            logging.exception(f"Cleaning failed with error: {error_msg}")
-            sys.exit(1)
 
     _print_response(ctx, dry_run, deleted, total_size)
 

--- a/ch_tools/chadmin/cli/s3_credentials_config_group.py
+++ b/ch_tools/chadmin/cli/s3_credentials_config_group.py
@@ -1,6 +1,5 @@
 import json
 import random
-import sys
 import time
 from xml.dom import minidom
 
@@ -68,10 +67,10 @@ def _add_xml_node(document, root, name):
 def _get_token(ctx):
     response = _request_token(ctx)
     if response.status_code != 200:
-        sys.exit(1)
+        raise RuntimeError(f"Can't get token. Response {response.status_code}")
     data = json.loads(response.content)
     if data["token_type"] != "Bearer":
-        sys.exit(1)
+        raise RuntimeError(f"Can't get token. Invalid Token type {data['token_type']}")
     return data["access_token"]
 
 

--- a/ch_tools/chadmin/cli/table_group.py
+++ b/ch_tools/chadmin/cli/table_group.py
@@ -948,7 +948,7 @@ def change_uuid_command(
             database,
             table_name,
             engine=table_info["engine"],
-            new_uuid=uuid,
+            new_local_uuid=uuid,
             old_table_uuid=old_table_uuid,
             table_local_metadata_path=table_local_metadata_path,
             attached=True,

--- a/ch_tools/chadmin/cli/table_group.py
+++ b/ch_tools/chadmin/cli/table_group.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from collections import OrderedDict
 from typing import Any
 
@@ -900,63 +899,60 @@ def set_flag_command(
 def change_uuid_command(
     ctx: Context, database: str, table: str, uuid: str, zk: bool, _all: bool
 ) -> None:
-    try:
-        if _all:
-            tables = get_tables_names_from_system_tables(ctx, database)
-        else:
-            tables = [table]
+    if _all:
+        tables = get_tables_names_from_system_tables(ctx, database)
+    else:
+        tables = [table]
 
-        logging.debug("Tables for changing uuid: {}", tables)
+    logging.info("Tables for changing uuid: {}", tables)
 
-        for table_name in tables:
-            table_info = get_info_from_system_tables(ctx, database, table_name)
+    for table_name in tables:
+        table_info = get_info_from_system_tables(ctx, database, table_name)
 
-            logging.debug("table_info={}", table_info)
+        logging.info("table_info={}", table_info)
 
-            if zk:
-                table_local_metadata_path = table_info["metadata_path"]
-                if match_str_ch_version(get_version(ctx), "25.1"):
-                    table_local_metadata_path = (
-                        f"{CLICKHOUSE_PATH}/{table_local_metadata_path}"
-                    )
-
-                metadata = parse_table_metadata(table_local_metadata_path)
-                if not metadata.table_engine.is_table_engine_replicated():
-                    logging.info(f"Table {table_name} is not replicated. Skip it.")
-                    continue
-
-                replica_path = metadata.replica_path
-
-                logging.debug(
-                    "Table {} is being changed table_shared_id {} by path {}",
-                    table_name,
-                    uuid,
-                    replica_path,
-                )
-                uuid = get_table_shared_id(ctx, replica_path)
-                logging.debug(
-                    "Table {} contains table_shared_id {} by path {}",
-                    table_name,
-                    uuid,
-                    replica_path,
-                )
-
-            old_table_uuid = table_info["uuid"]
+        if zk:
             table_local_metadata_path = table_info["metadata_path"]
+            if match_str_ch_version(get_version(ctx), "25.1"):
+                table_local_metadata_path = (
+                    f"{CLICKHOUSE_PATH}/{table_local_metadata_path}"
+                )
 
-            change_table_uuid(
-                ctx,
-                database,
+            metadata = parse_table_metadata(table_local_metadata_path)
+            if not metadata.table_engine.is_table_engine_replicated():
+                raise RuntimeError(
+                    f"Table {table_name} is not replicated. Failed get uuid from table_shared_id node."
+                )
+
+            replica_path = metadata.replica_path
+
+            logging.debug(
+                "Table {} is being changed table_shared_id {} by path {}",
                 table_name,
-                engine=table_info["engine"],
-                new_local_uuid=uuid,
-                old_table_uuid=old_table_uuid,
-                table_local_metadata_path=table_local_metadata_path,
-                attached=True,
+                uuid,
+                replica_path,
             )
-    except Exception as ex:
-        logging.error("Failed: {}", ex)
-        sys.exit(1)
+            uuid = get_table_shared_id(ctx, replica_path)
+            logging.debug(
+                "Table {} contains table_shared_id {} by path {}",
+                table_name,
+                uuid,
+                replica_path,
+            )
+
+        old_table_uuid = table_info["uuid"]
+        table_local_metadata_path = table_info["metadata_path"]
+
+        change_table_uuid(
+            ctx,
+            database,
+            table_name,
+            engine=table_info["engine"],
+            new_uuid=uuid,
+            old_table_uuid=old_table_uuid,
+            table_local_metadata_path=table_local_metadata_path,
+            attached=True,
+        )
 
 
 @table_group.command("check-uuid-equal")
@@ -968,5 +964,4 @@ def check_uuid_equal(ctx: Context, database: str, table: str) -> None:
     logging.info("Table {} has uuid: {}", table, uuids)
 
     if len(uuids) > 1:
-        logging.error("Table {} has different uuid in cluster", table)
-        sys.exit(1)
+        raise RuntimeError(f"Table {table} has different uuid in cluster")

--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import time
 
 import requests
@@ -110,8 +109,7 @@ def wait_replication_sync_command(
             )
             lightweight = False
     except Exception as e:
-        logging.error(f"Connection error while getting CH version: {e}")
-        sys.exit(1)
+        raise ConnectionError(f"Connection error while getting CH version: {e}")
 
     start_time = time.time()
     deadline = start_time + total_timeout.total_seconds()
@@ -134,30 +132,27 @@ def wait_replication_sync_command(
                 settings={"receive_timeout": time_left},
             )
     except requests.exceptions.ReadTimeout:
-        logging.error("Read timeout while running query.")
-        sys.exit(1)
+        raise ConnectionError("Read timeout while running query.")
     except requests.exceptions.ConnectionError:
-        logging.error("Connection error while running query.")
-        sys.exit(1)
+        raise ConnectionError("Connection error while running query.")
     except ClickhouseError as e:
+
         if "TIMEOUT_EXCEEDED" in str(e):
-            logging.error("Timeout while running query.")
+            error_msg = "Timeout while running query."
         else:
-            logging.error(f"Clickhouse error while running query: {e}")
-        sys.exit(1)
+            error_msg = f"Clickhouse error while running query: {e}"
+        raise RuntimeError(error_msg)
 
     if lightweight:
-        sys.exit(0)
+        return
 
     # Replication lag
     while time.time() < deadline:
         res = estimate_replication_lag(ctx, xcrit, crit, warn, mwarn, mcrit)
         if res.code <= status:
-            sys.exit(0)
+            return
         time.sleep(pause.total_seconds())
-
-    logging.error("Timeout while waiting on replication-lag command.")
-    sys.exit(1)
+    raise RuntimeError("Timeout while waiting on replication-lag command.")
 
 
 @wait_group.command("started")
@@ -187,10 +182,9 @@ def wait_started_command(ctx, timeout, quiet):
 
     if ch_is_alive:
         warmup_system_users(ctx)
-        sys.exit(0)
+        return
 
-    logging.error("ClickHouse is dead")
-    sys.exit(1)
+    raise ConnectionError("ClickHouse is dead")
 
 
 def get_timeout():

--- a/ch_tools/chadmin/internal/diagnostics/diagnose.py
+++ b/ch_tools/chadmin/internal/diagnostics/diagnose.py
@@ -12,6 +12,7 @@ from ch_tools.common.clickhouse.config import (
     ClickhouseKeeperConfig,
     ClickhouseUsersConfig,
 )
+from ch_tools.common.utils import version_ge
 
 from ..utils import clickhouse_client
 from .data import DiagnosticsData, add_command, add_query, execute_query
@@ -151,13 +152,6 @@ def diagnose(ctx: Context, output_format: str, normalize_queries: bool) -> None:
             ),
             add_query(
                 diagnostics,
-                "Moves in progress",
-                client=client,
-                query=query.SELECT_MOVES,
-                format_=OutputFormat.Vertical,
-            ),
-            add_query(
-                diagnostics,
                 "Recent data parts (modification time within last 3 minutes)",
                 client=client,
                 query=query.SELECT_RECENT_DATA_PARTS,
@@ -195,6 +189,19 @@ def diagnose(ctx: Context, output_format: str, normalize_queries: bool) -> None:
             ),
         ]
     )
+
+    if "moves" in system_tables:
+        tasks.extend(
+            [
+                add_query(
+                    diagnostics,
+                    "Moves in progress",
+                    client=client,
+                    query=query.SELECT_MOVES,
+                    format_=OutputFormat.Vertical,
+                ),
+            ]
+        )
 
     if "query_log" in system_tables:
         tasks.extend(

--- a/ch_tools/chadmin/internal/diagnostics/diagnose.py
+++ b/ch_tools/chadmin/internal/diagnostics/diagnose.py
@@ -12,7 +12,6 @@ from ch_tools.common.clickhouse.config import (
     ClickhouseKeeperConfig,
     ClickhouseUsersConfig,
 )
-from ch_tools.common.utils import version_ge
 
 from ..utils import clickhouse_client
 from .data import DiagnosticsData, add_command, add_query, execute_query

--- a/ch_tools/chadmin/internal/table.py
+++ b/ch_tools/chadmin/internal/table.py
@@ -613,7 +613,7 @@ def change_table_uuid(
         move_table_local_store(old_table_uuid, new_local_uuid)
     except Exception:
         logging.error(
-            "Failed move_table_local_store. old uuid={}, new_local_uuid={}. Need restore uuid in metadata for table={}. error={}",
+            "Failed move_table_local_store. old uuid={}, new_local_uuid={}. Need restore uuid in metadata for table={}.",
             old_table_uuid,
             new_local_uuid,
             f"{database}.{table}",

--- a/ch_tools/chadmin/internal/table.py
+++ b/ch_tools/chadmin/internal/table.py
@@ -539,20 +539,18 @@ def _verify_possible_change_uuid(
         metadata.replica_path,
     )
     if check_replica_path_contains_macros(metadata.replica_path, "uuid"):
-        logging.error(
+
+        raise ClickException(
             f"Changing uuid for ReplicatedMergeTree that contains macros uuid in replica path was not allowed. replica_path={metadata.replica_path}"
         )
-        if check_replica_path_contains_macros(metadata.replica_path, "uuid"):
-            raise ClickException(
-                f"Changing uuid for ReplicatedMergeTree that contains macros uuid in replica path was not allowed. replica_path={metadata.replica_path}"
-            )
 
     table_shared_id = get_table_shared_id(ctx, metadata.replica_path)
 
-    if dst_uuid != table_shared_id:
-        raise ClickException(
-            f"Changing uuid for ReplicatedMergeTree that different from table_shared_id path was not allowed. replica_path={metadata.replica_path}, dst_uuid={dst_uuid}, table_shared_id={table_shared_id}"
-        )
+    logging.debug(
+        "Check that dst_uuid {} is equal with table_shared_id {} node.",
+        dst_uuid,
+        table_shared_id,
+    )
 
     if dst_uuid != table_shared_id:
         logging.warning(

--- a/ch_tools/chadmin/internal/table.py
+++ b/ch_tools/chadmin/internal/table.py
@@ -549,10 +549,10 @@ def _verify_possible_change_uuid(
 
     table_shared_id = get_table_shared_id(ctx, metadata.replica_path)
 
-        if dst_uuid != table_shared_id:
-            raise ClickException(
-                f"Changing uuid for ReplicatedMergeTree that different from table_shared_id path was not allowed. replica_path={metadata.replica_path}, dst_uuid={dst_uuid}, table_shared_id={table_shared_id}"
-            )
+    if dst_uuid != table_shared_id:
+        raise ClickException(
+            f"Changing uuid for ReplicatedMergeTree that different from table_shared_id path was not allowed. replica_path={metadata.replica_path}, dst_uuid={dst_uuid}, table_shared_id={table_shared_id}"
+        )
 
     if dst_uuid != table_shared_id:
         logging.warning(

--- a/ch_tools/chadmin/internal/table.py
+++ b/ch_tools/chadmin/internal/table.py
@@ -612,7 +612,7 @@ def change_table_uuid(
         return
 
     try:
-        move_table_local_store(old_table_uuid, new_uuid)
+        move_table_local_store(old_table_uuid, new_local_uuid)
     except Exception:
         logging.error(
             "Failed move_table_local_store. old uuid={}, new_local_uuid={}. Need restore uuid in metadata for table={}. error={}",

--- a/tests/features/database_migrate.feature
+++ b/tests/features/database_migrate.feature
@@ -1723,7 +1723,7 @@ Feature: chadmin database migrate command
     (42)
     """
 
-    When we execute command on clickhouse02
+    When we try to execute command on clickhouse02
     """
     chadmin zookeeper list /clickhouse/repl_db
     """

--- a/tests/features/database_migrate.feature
+++ b/tests/features/database_migrate.feature
@@ -1727,7 +1727,7 @@ Feature: chadmin database migrate command
     """
     chadmin zookeeper list /clickhouse/repl_db
     """
-    Then we get response contains
+    Then it fails with response contains
     """
     kazoo.exceptions.NoNodeError
     """

--- a/tests/features/table_change_uuid.feature
+++ b/tests/features/table_change_uuid.feature
@@ -223,7 +223,7 @@ Feature: chadmin table change and check-uuid-equal
     """
     INSERT INTO non_repl_db.foo VALUES (42)
     """
-    When we execute command on clickhouse01
+    When we try to execute command on clickhouse01
     """
     chadmin table change -d non_repl_db -t foo --uuid '123e4567-e89b-12d3-a456-426614174000'
     """


### PR DESCRIPTION
## Summary by Sourcery

Replace direct calls to sys.exit across CLI commands with exception raising and improve error handling and logging.

Enhancements:
- Refactor CLI commands to raise appropriate exceptions instead of exiting the process.
- Adjust logging levels and messages for change-uuid and replication wait commands.
- Conditionally include "Moves in progress" query in diagnostics only when relevant.
- Add top-level exit in command wrapper to propagate fatal errors.

Tests:
- Update feature test steps wording from "execute command" to "try to execute command".