### PR TITLE
Log exception while clean orphaned objects

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -177,7 +177,7 @@ def clean_command(
             _store_state_local_save(ctx, state)
 
         if error_msg:
-            logging.exception("Cleaning faiiled with error: {error_msg}")
+            logging.exception(f"Cleaning failed with error: {error_msg}")
             sys.exit(1)
 
     _print_response(ctx, dry_run, deleted, total_size)


### PR DESCRIPTION
Log  exception explicitly.
Otherwise command's error message is available only in written state (ZK or local file).

## Summary by Sourcery

Enhancements:
- Log exception details explicitly when cleaning orphaned objects fails

## Summary by Sourcery

Enhancements:
- Log exception details explicitly when cleaning orphaned objects fails