### PR TITLE
Drop orphaned ZK paths for listing_objects_ table

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -188,7 +188,6 @@ def clean_command(
             _store_state_local_save(ctx, state)
 
         if error_msg:
-            logging.exception(f"Cleaning failed with error: {error_msg}")
             sys.exit(1)
 
     _print_response(ctx, dry_run, deleted, total_size)

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -33,7 +33,7 @@ Feature: chadmin object-storage commands
     """
     - WouldDelete: <WouldDelete>
       TotalSize: <TotalSize>
-    """  
+    """
   Examples:
     | scope   | WouldDelete | TotalSize   |
     | host    | [1-9][0-9]* | [1-9][0-9]* |
@@ -236,4 +236,20 @@ Feature: chadmin object-storage commands
     Then we get response contains
     """
     Sanity check not passed
+    """
+
+  Scenario: Clean orphaned objects works when orphaned ZK paths exists
+    When we execute chadmin create zk nodes on clickhouse01
+    """
+      /_system/tables/shard1/default.listing_objects_from_object_storage/replicas/clickhouse01
+      /_system/tables/shard1/default.orphaned_objects_object_storage/replicas/clickhouse01
+    """
+    When we try to execute command on clickhouse02
+    """
+    chadmin --format yaml object-storage clean --dry-run --to-time 0h
+    """
+    Then we get response matches
+    """
+    - WouldDelete: 0
+      TotalSize: 0
     """


### PR DESCRIPTION
The problem appears if we move ('resetup") CH host without tables `listing_objects_...` or `orphaned_objects_`.
Then next time while `chadmin object-storage clean` command we have error: `REPLICA_ALREADY_EXISTS`, because it has ZK path, but table does not exists on host locally.

## Summary by Sourcery

Prevent `REPLICA_ALREADY_EXISTS` errors by dropping orphaned ZooKeeper replica paths for listing_objects_ and orphaned_objects_ tables before table operations.

Bug Fixes:
- Remove stale replica ZK nodes when the corresponding table is absent on a host to avoid replica-exists errors.

Enhancements:
- Introduce `try_query_json_data_first_row` helper to safely fetch an optional first row.
- Refactor ClickHouse client creation into `_clickhouse_client` and add `custom_clickhouse_client` to override host.
- Implement `_clean_orphaned_zk_paths` and invoke it during object listing table setup.

Tests:
- Add a BDD scenario to verify that orphaned ZK paths are cleaned in dry-run mode.