### PR TITLE
Restore python requests timeout for antijoin query

### DIFF
--- a/ch_tools/common/commands/clean_object_storage.py
+++ b/ch_tools/common/commands/clean_object_storage.py
@@ -345,6 +345,7 @@ def _clean_object_storage(
     execute_query(
         ctx,
         antijoin_query,
+        timeout=timeout,
         settings=query_settings,
     )
     orphaned_objects_iterator = _object_list_generator(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reintroduce the timeout argument when calling execute_query for the antijoin query