### PR TITLE
Simplify size sanity check

### DIFF
--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -58,7 +58,7 @@ DEFAULT_CONFIG = {
                 "shard": r"^(\w+)/(\w+)/(\w+)/",
                 "cluster": r"^(\w+)/(\w+)/",
             },
-            "verify_size_error_rate_threshold_bytes": 1024 * 1024 * 1024,  ## 1 GB
+            "verify_size_error_rate_threshold_fraction": 0.9,
         },
     },
     "zookeeper": {


### PR DESCRIPTION
Depends from: #380

## Summary by Sourcery

Simplify the object-storage clean size sanity check to use a relative threshold instead of an absolute byte limit and update config and tests accordingly.

Enhancements:
- Replace absolute size threshold in bytes with a relative error rate threshold (fraction) in the configuration
- Remove ClickHouse remote_data_paths query and simplify size sanity check to compare deletion size against a fraction of the total bucket listing
- Update default config to use verify_size_error_rate_threshold_fraction with a default of 0.9

Tests:
- Add a BDD scenario to verify that the sanity check fails when orphaned object size exceeds the configured fraction