### PR TITLE
Create zero copy locks command

### DIFF
--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -381,10 +381,10 @@ def detect_broken_partitions(
 ) -> None:
     ch_config = get_clickhouse_config(ctx)
 
-    disk_conf: S3DiskConfiguration = (
-        ch_config.storage_configuration.s3_disk_configuration(
-            "object_storage", ctx.obj["config"]["object_storage"]["bucket_name_prefix"]
-        )
+    disk_conf = S3DiskConfiguration.from_config(
+        ch_config.storage_configuration,
+        "object_storage",
+        ctx.obj["config"]["object_storage"]["bucket_name_prefix"],
     )
     s3_client = boto3.client(
         "s3",

--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -16,6 +16,7 @@ from ch_tools.chadmin.internal.zookeeper import (
 from ch_tools.common.cli.formatting import print_response
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.config import get_clickhouse_config
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
 from ch_tools.common.commands.clean_object_storage import (
     DEFAULT_GUARD_INTERVAL,
     CleanScope,
@@ -42,10 +43,10 @@ DEFAULT_CLUSTER_NAME = "{cluster}"
 def object_storage_group(ctx: Context, disk_name: str) -> None:
     """Commands to manage S3 objects and their metadata."""
     ch_config = get_clickhouse_config(ctx)
-    ctx.obj["disk_configuration"] = (
-        ch_config.storage_configuration.s3_disk_configuration(
-            disk_name, ctx.obj["config"]["object_storage"]["bucket_name_prefix"]
-        )
+    ctx.obj["disk_configuration"] = S3DiskConfiguration.from_config(
+        ch_config.storage_configuration,
+        disk_name,
+        ctx.obj["config"]["object_storage"]["bucket_name_prefix"],
     )
 
 

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -405,7 +405,7 @@ def remove_hosts_from_table(
     ),
 )
 @option(
-    "--disk_type",
+    "--disk-type",
     "disk_type",
     default="s3",
     help=(
@@ -484,12 +484,25 @@ def clean_zk_locks_command(
 
 
 @zookeeper_group.command("create-zero-copy-locks")
-@option(
-    "--disk",
-    "disk",
-    default=None,
-    required=True,
-    help=("Object storage disk from ClickHouse."),
+@option_group(
+    "Disk selection options",
+    option(
+        "--disk",
+        "disk",
+        default=None,
+        required=True,
+        help=("Object storage disk from ClickHouse."),
+    ),
+    option(
+        "--disk-type",
+        "disk_type",
+        default=None,
+        help=(
+            "Object storage disk type from ClickHouse."
+            "Examples are s3, hdfs, azure_blob_storage, local_blob_storage..."
+            "This option is required for backwards compatibility with ClickHouse older than 24.3."
+        ),
+    ),
 )
 @option_group(
     "Table selection options",
@@ -541,6 +554,7 @@ def clean_zk_locks_command(
 def create_zk_locks_command(
     ctx: Context,
     disk: str,
+    disk_type: Optional[str] = None,
     database: Optional[str] = None,
     table: Optional[str] = None,
     partition_id: Optional[str] = None,
@@ -569,5 +583,5 @@ def create_zk_locks_command(
             table_info["name"],
         )
         create_zero_copy_locks(
-            ctx, disk, table_info, partition_id, part_id, replica, dry_run
+            ctx, disk, disk_type, table_info, partition_id, part_id, replica, dry_run
         )

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -15,7 +15,7 @@ from cloup.constraints import If, IsSet, RequireAtLeast, require_all
 from kazoo.security import make_digest_acl
 
 from ch_tools.chadmin.cli.chadmin_group import Chadmin
-from ch_tools.chadmin.internal.table import get_table, list_tables
+from ch_tools.chadmin.internal.table import list_tables
 from ch_tools.chadmin.internal.table_replica import get_table_replica
 from ch_tools.chadmin.internal.zero_copy import create_zero_copy_locks
 from ch_tools.chadmin.internal.zookeeper import (
@@ -549,12 +549,9 @@ def create_zk_locks_command(
     dry_run: bool = False,
 ) -> None:
     """
-    Clean zero copy locks.
+    Create zero copy locks.
     """
-    if database and table:
-        tables = [get_table(ctx, database, table)]
-    else:
-        tables = list_tables(ctx, database_name=database, table_name=table)
+    tables = list_tables(ctx, database_name=database, table_name=table)
 
     if not replica:
         macros = get_macros(ctx)

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -37,9 +37,8 @@ from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_json, print_response
 from ch_tools.common.cli.parameters import ListParamType, StringParamType
 from ch_tools.common.clickhouse.config import get_macros
+from ch_tools.common.clickhouse.config.storage_configuration import OBJECT_STORAGE_TYPES
 from ch_tools.common.config import load_config
-
-OBJECT_STORAGE_TYPES = ["s3", "hdfs", "azure_blob_storage", "local_blob_storage", "web"]
 
 
 @group("zookeeper", cls=Chadmin)
@@ -495,18 +494,7 @@ def clean_zk_locks_command(
         "disk",
         default=None,
         required=True,
-        help=("Object storage disk from ClickHouse."),
-    ),
-    option(
-        "--disk-type",
-        "disk_type",
-        type=Choice(OBJECT_STORAGE_TYPES),
-        default=None,
-        help=(
-            "Object storage disk type from ClickHouse."
-            "Examples are s3, hdfs, azure_blob_storage, local_blob_storage..."
-            "This option is required for backwards compatibility with ClickHouse older than 24.3."
-        ),
+        help=("S3 disk from ClickHouse."),
     ),
 )
 @option_group(
@@ -562,7 +550,6 @@ def clean_zk_locks_command(
 def create_zk_locks_command(
     ctx: Context,
     disk: str,
-    disk_type: Optional[str] = None,
     database: Optional[str] = None,
     table: Optional[str] = None,
     partition_id: Optional[str] = None,
@@ -591,5 +578,5 @@ def create_zk_locks_command(
             table_info["name"],
         )
         create_zero_copy_locks(
-            ctx, disk, disk_type, table_info, partition_id, part_id, replica, dry_run
+            ctx, disk, table_info, partition_id, part_id, replica, dry_run
         )

--- a/ch_tools/chadmin/internal/table.py
+++ b/ch_tools/chadmin/internal/table.py
@@ -77,6 +77,7 @@ def list_tables(
             SELECT
                 t.database,
                 t.name,
+                t.uuid,
                 t.metadata_modification_time,
                 t.engine,
                 t.data_paths,
@@ -135,6 +136,7 @@ def list_tables(
         SELECT
             t.database,
             t.name,
+            t.uuid,
             t.engine,
             t.create_table_query,
             t.metadata_modification_time,

--- a/ch_tools/chadmin/internal/zero_copy.py
+++ b/ch_tools/chadmin/internal/zero_copy.py
@@ -1,0 +1,240 @@
+import os
+import re
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from click import Context
+from kazoo.client import KazooClient
+from kazoo.exceptions import NoNodeError, RolledBackError
+
+from ch_tools.chadmin.internal.table_replica import get_table_replica
+from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.chadmin.internal.zookeeper import zk_client
+from ch_tools.common import logging
+from ch_tools.common.clickhouse.client.retry import retry
+
+CREATE_ZERO_COPY_LOCKS_BATCH_SIZE = 1000
+
+
+def create_zero_copy_locks(
+    ctx: Context,
+    disk: str,
+    table: Dict[str, str],
+    partition_id: Optional[str],
+    part_name: Optional[str],
+    replica: str,
+    dry_run: bool = False,
+) -> None:
+    """Create missing zero-copy locks for given tables."""
+    disk_info = execute_query(
+        ctx,
+        f"SELECT path, object_storage_type FROM system.disks WHERE name = '{disk}'",
+        format_="JSON",
+    )["data"]
+    if not disk_info:
+        raise RuntimeError(f"Disk {disk} doesn't exist")
+    disk_info = disk_info[0]
+    disk_info["object_storage_type"] = disk_info["object_storage_type"].lower()
+
+    zero_copy_path = _get_zero_copy_zookeeper_path(
+        ctx, disk_info["object_storage_type"], table["uuid"]
+    )
+
+    part_info = execute_query(
+        ctx,
+        """SELECT name, path FROM system.parts
+            WHERE disk_name = '{{disk}}' AND table = '{{table_name}}'
+                AND database = '{{database_name}}'
+                {% if partition -%}
+                AND partition_id = '{{partition_id}}'
+                {% endif -%}
+                {% if part -%}
+                AND name = '{{part_name}}'
+                {% endif -%}
+        """,
+        format_="JSON",
+        disk=disk,
+        table_name=table["name"],
+        database_name=table["database"],
+        part_name=part_name,
+        partition_id=partition_id,
+    )["data"]
+
+    zero_copy_lock_paths = []
+    for part in part_info:
+        zero_copy_lock_paths.append(
+            (
+                _get_zero_copy_lock_path(
+                    ctx, zero_copy_path, table["uuid"], part, replica
+                ),
+                _get_part_path_in_zk(
+                    ctx, table["database"], table["name"], part["name"], replica
+                ),
+            )
+        )
+        if len(zero_copy_lock_paths) == CREATE_ZERO_COPY_LOCKS_BATCH_SIZE:
+            _create_zero_copy_locks(ctx, zero_copy_lock_paths, dry_run)
+            zero_copy_lock_paths.clear()
+
+    if zero_copy_lock_paths:
+        _create_zero_copy_locks(ctx, zero_copy_lock_paths, dry_run)
+
+
+def _get_zero_copy_lock_path(
+    ctx: Context,
+    zero_copy_path: str,
+    table_uuid: str,
+    part: Dict,
+    replica: str,
+) -> str:
+    checksums_path = os.path.join(part["path"], "checksums.txt")
+    metadata = _read_metadata(checksums_path)
+    blob_path = metadata["keys"][0]["key"]
+    object_storage_prefix = execute_query(
+        ctx,
+        f"SELECT remote_path FROM system.remote_data_paths WHERE remote_path LIKE '%{blob_path}'",
+        format_="JSON",
+    )["data"][0]["remote_path"].removesuffix(blob_path)
+
+    object_storage_path = os.path.join(object_storage_prefix, blob_path).replace(
+        "/", "_"
+    )
+
+    return os.path.join(
+        zero_copy_path, table_uuid, part["name"], object_storage_path, replica
+    )
+
+
+def _get_part_path_in_zk(
+    ctx: Context,
+    database: str,
+    table: str,
+    part: str,
+    replica: str,
+) -> str:
+    replica_info = get_table_replica(ctx, database, table)
+    return os.path.join(
+        replica_info["zookeeper_path"], "replicas", replica, "parts", part
+    )
+
+
+def _get_zero_copy_zookeeper_path(
+    ctx: Context, disk_type: Optional[str] = "s3", table_uuid: Optional[str] = None
+) -> str:
+    """
+    Returns ZooKeeper path for zero-copy table-independent info.
+
+    '/clickhouse/zero_copy/zero_copy_s3' is default for s3 disk.
+    """
+    disk_dir = f"zero_copy_{disk_type}"
+
+    if table_uuid:
+        get_settings_query = (
+            f"SELECT engine_full FROM system.tables WHERE uuid = '{table_uuid}'"
+        )
+        settings = execute_query(ctx, get_settings_query, format_="JSONCompact")["data"]
+        if settings:
+            match = re.search(
+                r"remote_fs_zero_copy_zookeeper_path\s*=\s*'([^']+)'", settings[0][0]
+            )
+            if match:
+                return os.path.join(match.group(1), disk_dir)
+        else:
+            logging.warning(
+                "Table with uuid {} doesn't exist. Will search for locks in default 'remote_fs_zero_copy_zookeeper_path' directory.",
+                table_uuid,
+            )
+
+    query = "SELECT value FROM system.merge_tree_settings WHERE name = 'remote_fs_zero_copy_zookeeper_path'"
+    base_path = execute_query(ctx, query, format_="JSONCompact")["data"][0][0]
+
+    return os.path.join(base_path, disk_dir)
+
+
+def _read_metadata(path: str) -> Dict:
+    res = {}
+    with open(path, encoding="utf-8") as f:
+        res["version"] = int(f.readline().strip())
+        if res["version"] < 1 or res["version"] > 5:
+            raise RuntimeError(f"Unknown metadata version: {res['version']}")
+
+        line = f.readline().strip().split("\t")
+        res["keys_count"] = int(line[0])
+        res["total_size"] = int(line[1])
+
+        res["keys"] = []
+        for _ in range(res["keys_count"]):
+            line = f.readline().strip().split("\t")
+            res["keys"].append({"size": int(line[0]), "key": line[1]})
+
+    return res
+
+
+def _create_zero_copy_locks(
+    ctx: Context,
+    paths: List[Tuple[str, str]],
+    dry_run: bool = False,
+) -> None:
+    @retry(NoNodeError, max_attempts=3, max_interval=1)
+    def _create_lock_in_transaction(
+        zk: KazooClient, lock_path: str, part_path: str, part_node_version: int
+    ) -> None:
+        parents_to_create = _get_parent_paths_to_create(zk, lock_path)
+
+        create_transaction = zk.transaction()
+        create_transaction.check(part_path, part_node_version)
+
+        for parent in parents_to_create:
+            create_transaction.create(parent)
+
+        create_transaction.create(lock_path)
+        results = create_transaction.commit()
+
+        for result in results:
+            if isinstance(result, Exception):
+                if not isinstance(result, RolledBackError):
+                    raise result
+
+    with zk_client(ctx) as zk:
+        for lock_path, part_path in paths:
+            if zk.exists(lock_path):
+                continue
+
+            part_node = zk.exists(part_path)
+            # This means part is already deleted
+            if not part_node:
+                continue
+
+            logging.info("Creating zero-copy lock at {}", lock_path)
+            if dry_run:
+                continue
+
+            try:
+                _create_lock_in_transaction(zk, lock_path, part_path, part_node.version)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to create zero-copy lock at {lock_path}, reason: {e}"
+                )
+
+            logging.info("Created zero-copy lock at {}", lock_path)
+
+
+def _get_parent_paths_to_create(zk: KazooClient, path: str) -> List[str]:
+    parents = path.split("/")[:-1]
+    parent_path = ""
+    paths_to_create = []
+
+    all_exist = True
+    for parent in parents:
+        parent_path = os.path.join(parent_path, parent)
+        if all_exist and zk.exists(parent_path):
+            continue
+
+        all_exist = False
+        paths_to_create.append(parent_path)
+
+    return paths_to_create

--- a/ch_tools/chadmin/internal/zero_copy.py
+++ b/ch_tools/chadmin/internal/zero_copy.py
@@ -47,11 +47,6 @@ def create_zero_copy_locks(
         ctx.obj["config"]["object_storage"]["bucket_name_prefix"],
     )
 
-    if not isinstance(storage_config, S3DiskConfiguration):
-        raise RuntimeError(
-            f"Trying to create locks on disk '{disk}', but only S3 type disks are supported."
-        )
-
     zero_copy_path = _get_zero_copy_zookeeper_path(ctx, "s3", table["uuid"])
     part_info = list_parts(
         ctx,

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -20,7 +20,7 @@ from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError, NotEmptyError
 from kazoo.protocol.states import ZnodeStat
 
-from ch_tools.chadmin.internal.utils import chunked, execute_query, replace_macros
+from ch_tools.chadmin.internal.utils import chunked, replace_macros
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_clickhouse_config, get_macros
 from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
@@ -374,36 +374,3 @@ def _get_zk_client(ctx: Context) -> KazooClient:
         verify_certs=verify_ssl_certs,
         randomize_hosts=zk_randomize_hosts,
     )
-
-
-def _get_zero_copy_zookeeper_path(
-    ctx: Context, disk_type: Optional[str] = "s3", table_uuid: Optional[str] = None
-) -> str:
-    """
-    Returns ZooKeeper path for zero-copy table-independent info.
-
-    '/clickhouse/zero_copy/zero_copy_s3' is default for s3 disk.
-    """
-    disk_dir = f"zero_copy_{disk_type}"
-
-    if table_uuid:
-        get_settings_query = (
-            f"SELECT engine_full FROM system.tables WHERE uuid = '{table_uuid}'"
-        )
-        settings = execute_query(ctx, get_settings_query, format_="JSONCompact")["data"]
-        if settings:
-            match = re.search(
-                r"remote_fs_zero_copy_zookeeper_path\s*=\s*'([^']+)'", settings[0][0]
-            )
-            if match:
-                return os.path.join(match.group(1), disk_dir)
-        else:
-            logging.warning(
-                "Table with uuid {} doesn't exist. Will search for locks in default 'remote_fs_zero_copy_zookeeper_path' directory.",
-                table_uuid,
-            )
-
-    query = "SELECT value FROM system.merge_tree_settings WHERE name = 'remote_fs_zero_copy_zookeeper_path'"
-    base_path = execute_query(ctx, query, format_="JSONCompact")["data"][0][0]
-
-    return os.path.join(base_path, disk_dir)

--- a/ch_tools/chadmin/internal/zookeeper_clean.py
+++ b/ch_tools/chadmin/internal/zookeeper_clean.py
@@ -36,8 +36,8 @@ from ch_tools.chadmin.internal.table_replica import (
     system_table_drop_replica_by_zk_path,
 )
 from ch_tools.chadmin.internal.utils import chunked
+from ch_tools.chadmin.internal.zero_copy import _get_zero_copy_zookeeper_path
 from ch_tools.chadmin.internal.zookeeper import (
-    _get_zero_copy_zookeeper_path,
     delete_recursive,
     delete_zk_nodes,
     escape_for_zookeeper,

--- a/ch_tools/common/clickhouse/client/retry.py
+++ b/ch_tools/common/clickhouse/client/retry.py
@@ -4,7 +4,7 @@ import tenacity
 
 
 def retry(
-    exception_types: Union[Type[BaseException], Tuple[Type[BaseException]]],
+    exception_types: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
     max_attempts: int = 5,
     max_interval: int = 5,
 ) -> Any:

--- a/ch_tools/common/clickhouse/config/storage_configuration.py
+++ b/ch_tools/common/clickhouse/config/storage_configuration.py
@@ -186,4 +186,4 @@ class ClickhouseStorageConfiguration:
     def get_disk_config(self, disk: str) -> dict:
         if not self.has_disk(disk):
             raise RuntimeError(f"Disk {disk} is not found in config.")
-        return (self._config.get("disks", {}))["disk"]
+        return (self._config.get("disks", {}))[disk]

--- a/ch_tools/common/clickhouse/config/storage_configuration.py
+++ b/ch_tools/common/clickhouse/config/storage_configuration.py
@@ -1,17 +1,175 @@
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
-# YC specific value for sanity checking
+OBJECT_STORAGE_TYPES = ["s3", "hdfs", "azure_blob_storage", "local_blob_storage", "web"]
 
 
 @dataclass
-class S3DiskConfiguration:
+class ObjectStorageDiskConfiguration:
     name: str
+
+    @staticmethod
+    def _check_type(disk_config: dict, object_storage_type: str) -> None:
+        # Since 24.1 there are two kinds of syntax in config
+        type_in_config = (
+            disk_config["object_storage_type"]
+            if "object_storage_type" in disk_config
+            else disk_config["type"]
+        )
+
+        if type_in_config not in OBJECT_STORAGE_TYPES:
+            raise RuntimeError(
+                f"Unsupported object storage type in config: '{type_in_config}'."
+            )
+        if object_storage_type != type_in_config:
+            raise RuntimeError(
+                f"Trying to load config for object storage type '{object_storage_type}', but actual type is '{type_in_config}'."
+            )
+
+    @staticmethod
+    def _get_disk_config(
+        config: "ClickhouseStorageConfiguration", name: str, object_storage_type: str
+    ) -> dict:
+        disk_config = config.get_disk_config(name)
+        ObjectStorageDiskConfiguration._check_type(disk_config, object_storage_type)
+        return disk_config
+
+
+@dataclass
+class S3DiskConfiguration(ObjectStorageDiskConfiguration):
     endpoint_url: str
     access_key_id: str
     secret_access_key: str
     bucket_name: str
     prefix: str
+    OBJECT_STORAGE_TYPE = "s3"
+
+    @staticmethod
+    def from_config(
+        config: "ClickhouseStorageConfiguration", name: str, bucket_name_prefix: str
+    ) -> "S3DiskConfiguration":
+        disk = ObjectStorageDiskConfiguration._get_disk_config(
+            config, name, S3DiskConfiguration.OBJECT_STORAGE_TYPE
+        )
+
+        access_key_id = disk["access_key_id"]
+        secret_access_key = disk["secret_access_key"]
+        endpoint: str = disk["endpoint"]
+
+        _host, bucket_name, prefix, endpoint_url = S3DiskConfiguration._parse_endpoint(
+            endpoint, bucket_name_prefix
+        )
+
+        return S3DiskConfiguration(
+            name=name,
+            endpoint_url=endpoint_url,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            bucket_name=bucket_name,
+            prefix=prefix,
+        )
+
+    @staticmethod
+    def _parse_endpoint(endpoint: str, bucket_name_prefix: str) -> tuple:
+        """
+        Parse both virtual and path style S3 endpoints url.
+        """
+        url = urlparse(endpoint)
+        if url.hostname is None:
+            raise ValueError(f"Incorrect endpoint format {endpoint}")
+
+        path = url.path[1:] if url.path.startswith("/") else url.path
+        if url.hostname.startswith(bucket_name_prefix):
+            # virtual addressing style
+            bucket_name, host = url.hostname.split(".", maxsplit=1)
+            prefix = path
+        else:
+            # path addressing style
+            host = url.hostname
+            bucket_name, prefix = path.split("/", maxsplit=1)
+            if not bucket_name.startswith(bucket_name_prefix):
+                raise ValueError(
+                    f"Unexpected bucket name `{bucket_name}`. Parser expects `{bucket_name_prefix}` prefix"
+                )
+
+        endpoint_url = f"{url.scheme}://{host}"
+        if url.port:
+            endpoint_url += f":{url.port}"
+
+        return host, bucket_name, prefix, endpoint_url
+
+
+@dataclass
+class HDFSDiskConfiguration(ObjectStorageDiskConfiguration):
+    endpoint: str
+    OBJECT_STORAGE_TYPE = "hdfs"
+
+    @staticmethod
+    def from_config(
+        config: "ClickhouseStorageConfiguration", name: str
+    ) -> "HDFSDiskConfiguration":
+        disk = ObjectStorageDiskConfiguration._get_disk_config(
+            config, name, HDFSDiskConfiguration.OBJECT_STORAGE_TYPE
+        )
+        return HDFSDiskConfiguration(name, disk["endpoint"])
+
+
+@dataclass
+class AzureDiskConfiguration(ObjectStorageDiskConfiguration):
+    storage_account_url: str
+    container_name: str
+    account_name: str
+    account_key: str
+    metadata_path: str
+    cache_path: str
+    OBJECT_STORAGE_TYPE = "azure_blob_storage"
+
+    @staticmethod
+    def from_config(
+        config: "ClickhouseStorageConfiguration", name: str
+    ) -> "AzureDiskConfiguration":
+        disk = ObjectStorageDiskConfiguration._get_disk_config(
+            config, name, AzureDiskConfiguration.OBJECT_STORAGE_TYPE
+        )
+        return AzureDiskConfiguration(
+            name,
+            disk["storage_account_url"],
+            disk["container_name"],
+            disk["account_name"],
+            disk["account_key"],
+            disk["metadata_path"],
+            disk["cache_path"],
+        )
+
+
+@dataclass
+class LocalDiskConfiguration(ObjectStorageDiskConfiguration):
+    path: str
+    OBJECT_STORAGE_TYPE = "local_blob_storage"
+
+    @staticmethod
+    def from_config(
+        config: "ClickhouseStorageConfiguration", name: str
+    ) -> "LocalDiskConfiguration":
+        disk = ObjectStorageDiskConfiguration._get_disk_config(
+            config, name, LocalDiskConfiguration.OBJECT_STORAGE_TYPE
+        )
+        return LocalDiskConfiguration(name, disk["path"])
+
+
+@dataclass
+class WebDiskConfiguration(ObjectStorageDiskConfiguration):
+    endpoint: str
+    OBJECT_STORAGE_TYPE = "web"
+
+    @staticmethod
+    def from_config(
+        config: "ClickhouseStorageConfiguration", name: str
+    ) -> "WebDiskConfiguration":
+        disk = ObjectStorageDiskConfiguration._get_disk_config(
+            config, name, WebDiskConfiguration.OBJECT_STORAGE_TYPE
+        )
+        return WebDiskConfiguration(name, disk["endpoint"])
 
 
 class ClickhouseStorageConfiguration:
@@ -25,62 +183,7 @@ class ClickhouseStorageConfiguration:
     def has_disk(self, name: str) -> bool:
         return name in self._config.get("disks", {})
 
-    def s3_disk_configuration(
-        self, name: str, bucket_name_prefix: str
-    ) -> S3DiskConfiguration:
-        if not self.has_disk(name):
-            raise RuntimeError(f"Config section for disk '{name}' is not found")
-
-        disk = self._config["disks"][name]
-
-        if disk["type"] != "s3":
-            raise TypeError(f"Unsupported object storage type {disk['type']}")
-
-        access_key_id = disk["access_key_id"]
-        secret_access_key = disk["secret_access_key"]
-        endpoint: str = disk["endpoint"]
-
-        _host, bucket_name, prefix, endpoint_url = _parse_endpoint(
-            endpoint, bucket_name_prefix
-        )
-
-        return S3DiskConfiguration(
-            name=name,
-            endpoint_url=endpoint_url,
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-            bucket_name=bucket_name,
-            prefix=prefix,
-        )
-
     def get_disk_config(self, disk: str) -> dict:
-        return (self._config.get("disks", {})).get(disk, {})
-
-
-def _parse_endpoint(endpoint: str, bucket_name_prefix: str) -> tuple:
-    """
-    Parse both virtual and path style S3 endpoints url.
-    """
-    url = urlparse(endpoint)
-    if url.hostname is None:
-        raise ValueError(f"Incorrect endpoint format {endpoint}")
-
-    path = url.path[1:] if url.path.startswith("/") else url.path
-    if url.hostname.startswith(bucket_name_prefix):
-        # virtual addressing style
-        bucket_name, host = url.hostname.split(".", maxsplit=1)
-        prefix = path
-    else:
-        # path addressing style
-        host = url.hostname
-        bucket_name, prefix = path.split("/", maxsplit=1)
-        if not bucket_name.startswith(bucket_name_prefix):
-            raise ValueError(
-                f"Unexpected bucket name `{bucket_name}`. Parser expects `{bucket_name_prefix}` prefix"
-            )
-
-    endpoint_url = f"{url.scheme}://{host}"
-    if url.port:
-        endpoint_url += f":{url.port}"
-
-    return host, bucket_name, prefix, endpoint_url
+        if not self.has_disk(disk):
+            raise RuntimeError(f"Disk {disk} is not found in config.")
+        return (self._config.get("disks", {}))["disk"]

--- a/ch_tools/common/clickhouse/config/storage_configuration.py
+++ b/ch_tools/common/clickhouse/config/storage_configuration.py
@@ -186,4 +186,4 @@ class ClickhouseStorageConfiguration:
     def get_disk_config(self, disk: str) -> dict:
         if not self.has_disk(disk):
             raise RuntimeError(f"Disk {disk} is not found in config.")
-        return (self._config.get("disks", {}))[disk]
+        return self._config["disks"][disk]

--- a/tests/features/chadmin_zero_copy.feature
+++ b/tests/features/chadmin_zero_copy.feature
@@ -38,7 +38,7 @@ Feature: chadmin zero-copy related zookeeper commands.
     """
     When we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -d test --disk object_storage --disk-type s3
+    chadmin zookeeper create-zero-copy-locks -d test --disk object_storage
     """
     And we execute command on clickhouse01
     """
@@ -82,7 +82,7 @@ Feature: chadmin zero-copy related zookeeper commands.
     """
     And we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --replica clickhouse02.ch_tools_test --disk object_storage --disk-type s3
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --replica clickhouse02.ch_tools_test --disk object_storage
     """
     And we execute command on clickhouse01
     """
@@ -98,7 +98,7 @@ Feature: chadmin zero-copy related zookeeper commands.
     """
     And we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --disk object_storage --disk-type s3
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --disk object_storage
     """
     And we execute command on clickhouse01
     """

--- a/tests/features/chadmin_zero_copy.feature
+++ b/tests/features/chadmin_zero_copy.feature
@@ -1,4 +1,4 @@
-Feature: chadmin zookeeper commands.
+Feature: chadmin zero-copy related zookeeper commands.
 
   Background:
     Given default configuration
@@ -32,7 +32,10 @@ Feature: chadmin zookeeper commands.
     """
     chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000002
     """
-    #Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001
+    """
     When we execute command on clickhouse01
     """
     chadmin zookeeper create-zero-copy-locks -d test --disk object_storage --disk-type s3

--- a/tests/features/chadmin_zero_copy.feature
+++ b/tests/features/chadmin_zero_copy.feature
@@ -35,7 +35,7 @@ Feature: chadmin zookeeper commands.
     #Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
     When we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -d test --disk object_storage
+    chadmin zookeeper create-zero-copy-locks -d test --disk object_storage --disk-type s3
     """
     And we execute command on clickhouse01
     """
@@ -62,7 +62,6 @@ Feature: chadmin zookeeper commands.
     /clickhouse01.ch_tools_test
     """
 
-
   Scenario Outline: Create zero-copy lock for part or partition
     When we execute queries on clickhouse01
     """
@@ -80,7 +79,7 @@ Feature: chadmin zookeeper commands.
     """
     And we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --replica clickhouse02.ch_tools_test --disk object_storage
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --replica clickhouse02.ch_tools_test --disk object_storage --disk-type s3
     """
     And we execute command on clickhouse01
     """
@@ -96,7 +95,7 @@ Feature: chadmin zookeeper commands.
     """
     And we execute command on clickhouse01
     """
-    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --disk object_storage
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --disk object_storage --disk-type s3
     """
     And we execute command on clickhouse01
     """
@@ -172,6 +171,7 @@ Feature: chadmin zookeeper commands.
     /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0
     """
 
+
   Scenario: Cleanup all zero-copy locks for replicas with table and part filters
     When we execute command on clickhouse01
     """
@@ -222,6 +222,7 @@ Feature: chadmin zookeeper commands.
     chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --replica replica2
     """
     Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
+
 
   Scenario: Cleanup zero-copy locks without replica filter
     When we execute command on clickhouse01
@@ -310,7 +311,7 @@ Feature: chadmin zookeeper commands.
     """
     Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/ is empty
 
-  
+
   Scenario: Cleanup zero-copy locks with invalid arguments
     When we try to execute command on clickhouse01
     """

--- a/tests/features/chadmin_zero_copy.feature
+++ b/tests/features/chadmin_zero_copy.feature
@@ -1,0 +1,346 @@
+Feature: chadmin zookeeper commands.
+
+  Background:
+    Given default configuration
+    And a working s3
+    And a working zookeeper
+    And a working clickhouse on clickhouse01
+    And a working clickhouse on clickhouse02
+
+
+  Scenario: Create zero-copy lock options for all tables in database
+    When we execute queries on clickhouse01
+    """
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 UUID '10000000-0000-0000-0000-000000000001' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_01 SELECT number FROM numbers(2);
+
+    CREATE TABLE test.table_02 UUID '10000000-0000-0000-0000-000000000002' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_02', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_02 SELECT number FROM numbers(2);
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id 0_0_0_0 --replica clickhouse01.ch_tools_test
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000002
+    """
+    #Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper create-zero-copy-locks -d test --disk object_storage
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper list $(chadmin zookeeper list /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/)
+    """
+    Then we get response contains
+    """
+    /clickhouse01.ch_tools_test
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper list $(chadmin zookeeper list /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/1_0_0_0/)
+    """
+    Then we get response contains
+    """
+    /clickhouse01.ch_tools_test
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper list $(chadmin zookeeper list /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000002/0_0_0_0/)
+    """
+    Then we get response contains
+    """
+    /clickhouse01.ch_tools_test
+    """
+
+
+  Scenario Outline: Create zero-copy lock for part or partition
+    When we execute queries on clickhouse01
+    """
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 UUID '10000000-0000-0000-0000-000000000001' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_01 SELECT number FROM numbers(2);
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --replica clickhouse02.ch_tools_test
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --replica clickhouse02.ch_tools_test --disk object_storage
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper list $(chadmin zookeeper list /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/)
+    """
+    Then we get response contains
+    """
+    /clickhouse02.ch_tools_test
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --replica clickhouse01.ch_tools_test
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create-zero-copy-locks -t table_01 <option> --disk object_storage
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper list $(chadmin zookeeper list /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/)
+    """
+    Then we get response contains
+    """
+    /clickhouse01.ch_tools_test
+    """
+  Examples:
+      | option               |
+      | --partition-id 0     |
+      | --part-id 0_0_0_0    |
+
+
+  Scenario: Cleanup all zero-copy locks for two replicas with one lock for third replica present
+    When we execute queries on clickhouse01
+    """
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 UUID '10000000-0000-0000-0000-000000000001' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_01 SELECT number FROM numbers(2);
+
+    CREATE TABLE test.table_02 UUID '10000000-0000-0000-0000-000000000002' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_02', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_02 SELECT number FROM numbers(2);
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin wait replication-sync --total-timeout 10 --replica-timeout 3
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/blob_path/clickhouse03.ch_tools_test
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --replica clickhouse01.ch_tools_test
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --replica clickhouse01.ch_tools_test --dry-run
+    """
+    Then we get response
+    """
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --replica clickhouse02.ch_tools_test --dry-run
+    """
+    Then we get response contains 
+    """
+    clickhouse02.ch_tools_test
+    """
+    And the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/blob_path/ is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0/blob_path/clickhouse03.ch_tools_test
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --replica clickhouse02.ch_tools_test
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/ is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001
+    """
+    And the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001 is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0
+    """
+
+  Scenario: Cleanup all zero-copy locks for replicas with table and part filters
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1/replica2
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob2/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_2/blob1/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000002/0_0_0_1/blob1/replica1
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000002 --replica replica1
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/ is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id 0_0_0_2 --replica replica1
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001 is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id 0_0_0_1 --replica replica1
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1 is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1/replica2
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --replica replica2
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
+
+  Scenario: Cleanup zero-copy locks without replica filter
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob1/replica2
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1/blob2/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/all_0_0_2_1/blob1/replica1
+    """
+    And we execute command on clickhouse01
+    """
+    chadmin zookeeper create --make-parents /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000002/0_0_0_1/blob1/replica1
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000002
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/ is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id all_0_0_2_1
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001 is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_1
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id 0_0_0_1
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3 is empty
+
+  Scenario: Cleanup all zero-copy locks for table with custom zookeeper zero-copy path
+    When we execute queries on clickhouse01
+    """
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 UUID '10000000-0000-0000-0000-000000000001' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1,remote_fs_zero_copy_zookeeper_path='/custom/zero_copy/';
+    INSERT INTO test.table_01 SELECT number FROM numbers(2);
+    """
+    Then the list of children on clickhouse01 for zk node /custom/zero_copy/zero_copy_s3 is equal to
+    """
+    /custom/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001
+    """
+    Then the list of children on clickhouse01 for zk node /custom/zero_copy/zero_copy_s3 is empty
+
+
+  Scenario: Cleanup all zero-copy locks for given remote path prefix
+    When we execute queries on clickhouse01
+    """
+    DROP DATABASE IF EXISTS test ON CLUSTER 'cluster'; 
+    CREATE DATABASE test ON CLUSTER 'cluster';
+
+    CREATE TABLE test.table_01 UUID '10000000-0000-0000-0000-000000000001' ON CLUSTER 'cluster' (n Int32)
+    ENGINE = ReplicatedMergeTree('/tables/table_01', '{replica}') PARTITION BY n ORDER BY n
+    SETTINGS storage_policy='object_storage',allow_remote_fs_zero_copy_replication=1;
+    INSERT INTO test.table_01 SELECT number FROM numbers(2);
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/ is equal to
+    """
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/0_0_0_0
+    /clickhouse/zero_copy/zero_copy_s3/10000000-0000-0000-0000-000000000001/1_0_0_0
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --remote-path-prefix 'data_cluster_id'
+    """
+    Then the list of children on clickhouse01 for zk node /clickhouse/zero_copy/zero_copy_s3/ is empty
+
+  
+  Scenario: Cleanup zero-copy locks with invalid arguments
+    When we try to execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-00000asdasd
+    """
+    Then it fails with response contains
+    """
+    10000000-0000-0000-0000-00000asdasd
+    """
+    When we try to execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --table-uuid 10000000-0000-0000-0000-000000000001 --part-id all_0_all_all
+    """
+    Then it fails with response contains
+    """
+    all_0_all_all
+    """
+    When we try to execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --zero-copy-path /clickhouse/tables --replica r1
+    """
+    Then it fails with response contains
+    """
+    /clickhouse/tables
+    """
+    When we try to execute command on clickhouse01
+    """
+    chadmin zookeeper cleanup-zero-copy-locks --remote-path-prefix cloud_storage/shard1/
+    """
+    Then it fails with response contains
+    """
+    cloud_storage/shard1/
+    """


### PR DESCRIPTION
## Summary by Sourcery

Implement a new CLI command to generate zero-copy locks in ZooKeeper and add supporting internal modules and tests

New Features:
- Add create-zero-copy-locks command to the CLI for generating missing zero-copy locks
- Introduce zero_copy.py internal module with logic to compute and batch-create ZooKeeper lock nodes
- Extend list_tables to include table UUID for zero-copy lock operations

Enhancements:
- Remove deprecated zero-copy path helper from existing zookeeper module

Tests:
- Add feature tests covering zero-copy lock creation and cleanup scenarios across tables, partitions, and replicas