### PR TITLE
Set timeout for reading orpahed object table

### DIFF
--- a/ch_tools/common/commands/clean_object_storage.py
+++ b/ch_tools/common/commands/clean_object_storage.py
@@ -143,6 +143,7 @@ def _object_list_generator(
     ch_client: ClickhouseClient,
     table_name: str,
     query_settings: Dict[str, Any],
+    timeout: Optional[int] = None,
     chunk_size: int = 10 * 1024 * 1024,
 ) -> Callable:
 
@@ -150,6 +151,7 @@ def _object_list_generator(
         with ch_client.query(
             f"SELECT obj_path, obj_size FROM {table_name}",
             format_="TabSeparated",
+            timeout=timeout,
             settings=query_settings,
             stream=True,
         ) as resp:
@@ -334,9 +336,7 @@ def _clean_object_storage(
         settings=query_settings,
     )
     orphaned_objects_iterator = _object_list_generator(
-        ch_client,
-        orphaned_objects_table,
-        query_settings,
+        ch_client, orphaned_objects_table, query_settings, timeout
     )
     listing_size_in_bucket = int(
         ch_client.query_json_data_first_row(


### PR DESCRIPTION
## Summary by Sourcery

Add optional timeout for reading orphaned object table queries and propagate it through the object list generator

Enhancements:
- Add optional timeout parameter to _object_list_generator
- Pass timeout option into ch_client.query when streaming object list
- Update invocation of _object_list_generator to include timeout argument