### PR TITLE
Do not delete zero-copy locks by default

### DIFF
--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -340,10 +340,21 @@ def delete_ddl_task_command(ctx: Context, tasks: list) -> None:
     help="Perform ddl query cleanup.",
     type=bool,
 )
+@option(
+    "--delete-zero-copy-locks",
+    "delete_locks",
+    is_flag=True,
+    help="Delete zero-copy locks for removed hosts.",
+    type=bool,
+)
 @argument("fqdn", type=ListParamType())
 @pass_context
 def clickhouse_hosts_command(
-    ctx: Context, fqdn: list, clean_ddl_queue: bool, dry_run: bool
+    ctx: Context,
+    fqdn: list,
+    clean_ddl_queue: bool,
+    dry_run: bool,
+    delete_locks: bool,
 ) -> None:
     # We can't get the ddl queue path from clickhouse config,
     # because in some cases we are changing this path while performing cluster resetup.
@@ -355,12 +366,13 @@ def clickhouse_hosts_command(
         zk_ddl_query_path=config["clickhouse"]["distributed_ddl_path"],
         dry_run=dry_run,
     )
-    for replica in fqdn:
-        delete_zero_copy_locks(
-            ctx,
-            replica_name=replica,
-            dry_run=dry_run,
-        )
+    if delete_locks:
+        for replica in fqdn:
+            delete_zero_copy_locks(
+                ctx,
+                replica_name=replica,
+                dry_run=dry_run,
+            )
 
 
 @zookeeper_group.command(
@@ -374,11 +386,22 @@ def clickhouse_hosts_command(
     default=False,
     help="Enable dry run mode and do not perform any modifying actions.",
 )
+@option(
+    "--delete-zero-copy-locks",
+    "delete_locks",
+    is_flag=True,
+    help="Delete zero-copy locks for removed hosts.",
+    type=bool,
+)
 @argument("zookeeper-table-path")
 @argument("fqdn", type=ListParamType())
 @pass_context
 def remove_hosts_from_table(
-    ctx: Context, zookeeper_table_path: str, fqdn: list, dry_run: bool
+    ctx: Context,
+    zookeeper_table_path: str,
+    fqdn: list,
+    dry_run: bool,
+    delete_locks: bool,
 ) -> None:
     clean_zk_metadata_for_hosts(
         ctx,
@@ -388,12 +411,13 @@ def remove_hosts_from_table(
         cleanup_ddl_queue=False,
         dry_run=dry_run,
     )
-    for replica in fqdn:
-        delete_zero_copy_locks(
-            ctx,
-            replica_name=replica,
-            dry_run=dry_run,
-        )
+    if delete_locks:
+        for replica in fqdn:
+            delete_zero_copy_locks(
+                ctx,
+                replica_name=replica,
+                dry_run=dry_run,
+            )
 
 
 @zookeeper_group.command("cleanup-zero-copy-locks")


### PR DESCRIPTION
## Summary by Sourcery

Make zero-copy lock deletion opt-in by adding a flag and conditionally running the cleanup only when requested

Enhancements:
- Add --delete-zero-copy-locks option to clickhouse-hosts command
- Add --delete-zero-copy-locks option to remove-hosts-from-table command
- Guard delete_zero_copy_locks calls behind the new flag so locks aren’t removed by default