### PR TITLE
Enable xml entities parsing

### DIFF
--- a/ch_tools/common/clickhouse/config/utils.py
+++ b/ch_tools/common/clickhouse/config/utils.py
@@ -50,7 +50,7 @@ def dump_config(
 
 def _load_config(config_path: str) -> Any:
     with open(config_path, "r", encoding="utf-8") as file:
-        return xmltodict.parse(file.read())
+        return xmltodict.parse(file.read(), disable_entities=False)
 
 
 def _merge_configs(main_config: Any, additional_config: Any) -> None:


### PR DESCRIPTION
Fixes CI

## Summary by Sourcery

Enable XML entity parsing in the ClickHouse config loader to fix CI failures

Bug Fixes:
- Fix CI failures caused by disabled XML entity parsing

Enhancements:
- Allow XML entities by passing disable_entities=False to xmltodict.parse