### PR TITLE
Retries for system sync replica queries

### DIFF
--- a/ch_tools/chadmin/cli/wait_group.py
+++ b/ch_tools/chadmin/cli/wait_group.py
@@ -136,7 +136,6 @@ def wait_replication_sync_command(
         # Sync tables in cycle
         for replica in list_table_replicas(ctx):
             full_name = f"`{replica['database']}`.`{replica['table']}`"
-            time_left = deadline - time.time()
 
             query = f"SYSTEM SYNC REPLICA {full_name} LIGHTWEIGHT"
             if not lightweight:
@@ -160,7 +159,7 @@ def wait_replication_sync_command(
                 query,
                 format_=None,
                 timeout=replica_timeout.total_seconds(),
-                settings={"receive_timeout": time_left},
+                receive_timeout_deadline=deadline,
             )
     except requests.exceptions.ReadTimeout:
         raise ConnectionError("Read timeout while running query.")

--- a/ch_tools/chadmin/internal/utils.py
+++ b/ch_tools/chadmin/internal/utils.py
@@ -26,7 +26,7 @@ def execute_query(
     stream: bool = False,
     settings: Optional[Any] = None,
     replica: Optional[str] = None,
-    deadline: Optional[float] = None,
+    receive_timeout_deadline: Optional[float] = None,
     **kwargs: Any,
 ) -> Any:
     """
@@ -42,8 +42,8 @@ def execute_query(
 
     settings_upd: Dict[str, Any] = dict(settings) if settings else {}
 
-    if deadline:
-        deadline_timeout = time.time() - deadline
+    if receive_timeout_deadline:
+        deadline_timeout = receive_timeout_deadline - time.time()
         if deadline_timeout <= 0:
             raise RuntimeError(f"Deadline reached for query {query}")
 


### PR DESCRIPTION
## Summary by Sourcery

Provide a retry mechanism and deadline handling for SYSTEM SYNC REPLICA queries in the chadmin CLI

New Features:
- Introduce execute_query_with_retries utility to wrap execute_query with retry logic and optional deadline
- Add sync-query-max-retries command-line option to configure retry attempts for replication sync

Enhancements:
- Update wait_replication_sync_command to use execute_query_with_retries and apply custom retriable error filtering
- Define CLICKHOUSE_TIMEOUT_EXCEEDED_MSG constant and streamline exception handling for sync queries