### PR TITLE
Fix log message for sanity check

### DIFF
--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -415,8 +415,8 @@ def _sanity_check_before_cleanup(
                 dry_run,
                 "Potentially dangerous operation: Going to remove more than {}% of bucket content. To remove {}; listing size {}".format(
                     int(size_error_rate_threshold_fraction * 100),
-                    format_size(listing_size_in_bucket),
                     format_size(size_to_delete),
+                    format_size(listing_size_in_bucket),
                 ),
             )
 

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -377,7 +377,7 @@ Feature: chadmin object-storage commands
     """
       bucket: cloud-storage-test
       path: /data/cluster_id/shard_1/orpaned_object-{}
-      data: '01234566789'
+      data: '01234567890'
     """
     When we try to execute command on clickhouse01
     """


### PR DESCRIPTION
Fix log message for sanity check

## Summary by Sourcery

Respect the max-size-to-delete arguments in the object-storage clean command's sanity checks and update tests accordingly

Enhancements:
- Honor --max-size-to-delete-bytes and --max-size-to-delete-fraction when evaluating the amount to remove in orphaned object cleanup
- Include the max size limit in the potentially dangerous operation warning message
- Refactor max_size_to_delete calculation to occur before and be passed into the sanity check

Tests:
- Add feature scenarios verifying deletion behavior under max-size-to-delete-bytes and max-size-to-delete-fraction limits