### PR TITLE
[Do not merge] Prototype for detection of zero copy locks

### DIFF
--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -32,6 +32,7 @@ from ch_tools.chadmin.internal.zookeeper import (
 from ch_tools.chadmin.internal.zookeeper_clean import (
     clean_zk_metadata_for_hosts,
     delete_zero_copy_locks,
+    find_dead_zc_locks,
 )
 from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_json, print_response
@@ -580,3 +581,17 @@ def create_zk_locks_command(
         create_zero_copy_locks(
             ctx, disk, table_info, partition_id, part_id, replica, dry_run
         )
+
+
+@zookeeper_group.command(
+    name="find-dead-zero-copy-locks",
+    help="Remove hosts from table metadata in the Zookeeper.",
+)
+@argument("zookeeper-table-path")
+@argument("shard-name")
+@argument("fqdn", type=ListParamType())
+@pass_context
+def remove_hosts_from_table(
+    ctx: Context, zookeeper_table_path: str, shard_name:str, fqdn: list,
+) -> None:
+    find_dead_zc_locks(ctx, zookeeper_table_path, shard_name, fqdn)


### PR DESCRIPTION
The prototype script that should detect dead zero copy locks. Probably will be never merged but lets keep it anyway, may be one day will be useful

## Summary by Sourcery

Introduce a prototype tool to detect dead zero-copy locks in Zookeeper by adding a scanning function and exposing it via a new CLI command

New Features:
- Add a prototype find_dead_zc_locks function to traverse zero-copy lock paths in Zookeeper and print locks missing the specified host
- Expose the detection logic through a new find-dead-zero-copy-locks command in the CLI