### PR TITLE
Add space-usage human readable format

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -23,7 +23,7 @@ from ch_tools.chadmin.internal.zookeeper import (
     create_zk_nodes,
     update_zk_nodes,
 )
-from ch_tools.common.cli.formatting import print_response
+from ch_tools.common.cli.formatting import format_bytes, print_response
 from ch_tools.common.cli.parameters import TimeSpanParamType
 from ch_tools.common.clickhouse.config import get_clickhouse_config
 from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
@@ -295,18 +295,32 @@ def collect_info_command(
     type=Choice(["shard", "cluster"]),
     help="Get info for shard or cluster.",
 )
+@option(
+    "--human-readable",
+    "human_readable",
+    is_flag=True,
+    default=False,
+    help="Output size in human readable format",
+)
 @pass_context
 def space_usage_command(
-    ctx: Context,
-    cluster_name: str,
-    scope: str,
+    ctx: Context, cluster_name: str, scope: str, human_readable: bool
 ) -> None:
     """
     Return object storage memory usage info from cluster.
     """
     result = get_object_storage_space_usage(ctx, cluster_name, Scope(scope))
 
-    print_response(ctx, result)
+    field_formatters = {
+        "active": format_bytes,
+        "unique_frozen": format_bytes,
+        "unique_detached": format_bytes,
+        "orphaned": format_bytes,
+    }
+
+    print_response(
+        ctx, result, field_formatters=field_formatters if human_readable else None
+    )
 
 
 def _store_state_zk_save(ctx: Context, path: str, state: OrphanedObjectsState) -> None:


### PR DESCRIPTION
Example:
```
$ sudo chadmin object-storage space-usage --scope shard --human-readable 
{
  "active": "20.66 TiB",
  "unique_frozen": "5.77 TiB",
  "unique_detached": "9.47 GiB",
  "orphaned": "24.27 TiB"
}
```

## Summary by Sourcery

Add a --human-readable flag to the object storage space-usage command to output sizes in human-readable units

Enhancements:
- Introduce a human_readable option for the space-usage command
- Apply byte formatting to active, unique_frozen, unique_detached, and orphaned fields when human-readable output is enabled