### PR TITLE
Add cli parameter for wait replica retry backoff and increase defaults

### DIFF
--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -86,6 +86,8 @@ DEFAULT_CONFIG = {
                 "warn": 300,
                 "mcrit": 90.0,
                 "mwarn": 50.0,
+                "sync_query_max_retries": 10,
+                "sync_query_max_backoff": 10,
             },
         },
         "zookeeper": {


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable retry backoff for replication sync by adding a new CLI option, raising the default retry count, and removing the hardcoded backoff constant.

New Features:
- Add CLI parameter '--sync-query-max-backoff' to configure retry backoff interval

Enhancements:
- Increase default '--sync-query-max-retries' from 5 to 10
- Replace fixed backoff constant with configurable backoff value passed to wait_random_exponential