### PR TITLE
Fixes for reading from named pipe

### DIFF
--- a/ch_tools/chadmin/internal/utils.py
+++ b/ch_tools/chadmin/internal/utils.py
@@ -5,6 +5,7 @@ Utility functions.
 import os
 import re
 import shutil
+import threading
 from enum import Enum
 from itertools import islice
 from typing import Any, Iterable, Iterator, Optional
@@ -17,6 +18,24 @@ from ch_tools.common.clickhouse.config.clickhouse import ClickhousePort
 from ch_tools.monrun_checks.clickhouse_info import ClickhouseInfo
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class RaisingThread(threading.Thread):
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._exc: Optional[BaseException] = None
+
+    def run(self) -> None:
+        try:
+            super().run()
+        except BaseException as e:
+            self._exc = e
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        super().join(timeout)
+        if self._exc is not None:
+            raise self._exc
 
 
 class Scope(str, Enum):

--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -516,6 +516,9 @@ def _insert_missing_s3_backups_blobs(
             with open(pipe_path, "rb") as pipe:
                 with tarfile.open(fileobj=pipe, mode="r|*") as tar:
                     for member in tar:
+                        # Old backups may have revision.txt file in tar, it should not be parsed
+                        if member.name == "revision.txt":
+                            continue
                         file = tar.extractfile(member)
                         if file:
                             data = file.read().decode("utf-8")

--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -2,9 +2,9 @@ import os
 import re
 import subprocess
 import tarfile
-import threading
 import uuid
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -545,52 +545,51 @@ def _insert_missing_s3_backups_blobs(
 
     missing_backups = get_missing_chs3_backups(disk_conf.name)
 
-    for backup in missing_backups:
-        logging.info(
-            f"Downloading cloud storage metadata from missing backup '{backup}'"
-        )
-
-        config = ctx.obj["config"]["object_storage"]["space_usage"][
-            "download_missing_cloud_storage_backups"
-        ]
-        pipe_path = config["named_pipe_path"]
-        timeout = config["timeout"]
-        if os.path.exists(pipe_path):
-            raise RuntimeError(f"Pipe at {pipe_path} already exists")
-
-        with _missing_backups_named_pipe(pipe_path):
-            parse_thread = threading.Thread(
-                target=_insert_blobs_from_tar, args=(pipe_path,), daemon=True
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        for backup in missing_backups:
+            logging.info(
+                f"Downloading cloud storage metadata from missing backup '{backup}'"
             )
-            parse_thread.start()
 
-            cmd = [
-                "ch-backup",
-                "get-cloud-storage-metadata",
-                "--disk",
-                disk_conf.name,
-                "--local-path",
-                pipe_path,
-                backup,
+            config = ctx.obj["config"]["object_storage"]["space_usage"][
+                "download_missing_cloud_storage_backups"
             ]
-            proc = subprocess.Popen(
-                cmd,
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            _, stderr = proc.communicate(timeout)
-            if proc.returncode:
-                assert proc.stderr
-                raise RuntimeError(
-                    f"Downloading cloud storage metadata command has failed: retcode {proc.returncode}, stderr: {stderr.decode('utf-8')}"
-                )
+            pipe_path = config["named_pipe_path"]
+            timeout = config["timeout"]
+            if os.path.exists(pipe_path):
+                raise RuntimeError(f"Pipe at {pipe_path} already exists")
 
-            parse_thread.join(timeout)
-            if parse_thread.is_alive():
-                raise RuntimeError(
-                    "Downloading cloud storage metadata command has failed: Timeout exceeded, metadata reading thread is probably locked"
+            with _missing_backups_named_pipe(pipe_path):
+                future = executor.submit(_insert_blobs_from_tar, pipe_path)
+
+                cmd = [
+                    "ch-backup",
+                    "get-cloud-storage-metadata",
+                    "--disk",
+                    disk_conf.name,
+                    "--local-path",
+                    pipe_path,
+                    backup,
+                ]
+                proc = subprocess.Popen(
+                    cmd,
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                 )
+                _, stderr = proc.communicate(timeout=timeout)
+                if proc.returncode:
+                    assert proc.stderr
+                    raise RuntimeError(
+                        f"Downloading cloud storage metadata command has failed: retcode {proc.returncode}, stderr: {stderr.decode('utf-8')}"
+                    )
+
+                try:
+                    future.result(timeout)
+                except TimeoutError:
+                    raise RuntimeError(
+                        "Downloading cloud storage metadata command has failed: Timeout exceeded, metadata reading thread is probably locked"
+                    )
 
 
 @contextmanager

--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -4,7 +4,6 @@ import subprocess
 import tarfile
 import uuid
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -35,6 +34,7 @@ from ch_tools.chadmin.internal.table import (
 )
 from ch_tools.chadmin.internal.utils import (
     DATETIME_FORMAT,
+    RaisingThread,
     Scope,
     assert_equal_table_schema_on_cluster,
     chunked,
@@ -548,51 +548,58 @@ def _insert_missing_s3_backups_blobs(
 
     missing_backups = get_missing_chs3_backups(disk_conf.name)
 
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        for backup in missing_backups:
-            logging.info(
-                f"Downloading cloud storage metadata from missing backup '{backup}'"
+    for backup in missing_backups:
+        logging.info(
+            f"Downloading cloud storage metadata from missing backup '{backup}'"
+        )
+
+        config = ctx.obj["config"]["object_storage"]["space_usage"][
+            "download_missing_cloud_storage_backups"
+        ]
+        pipe_path = config["named_pipe_path"]
+        timeout = config["timeout"]
+        if os.path.exists(pipe_path):
+            raise RuntimeError(f"Pipe at {pipe_path} already exists")
+
+        with _missing_backups_named_pipe(pipe_path):
+            parse_thread = RaisingThread(
+                target=_insert_blobs_from_tar, args=(pipe_path,), daemon=True
             )
+            parse_thread.start()
 
-            config = ctx.obj["config"]["object_storage"]["space_usage"][
-                "download_missing_cloud_storage_backups"
+            cmd = [
+                "ch-backup",
+                "get-cloud-storage-metadata",
+                "--disk",
+                disk_conf.name,
+                "--local-path",
+                pipe_path,
+                backup,
             ]
-            pipe_path = config["named_pipe_path"]
-            timeout = config["timeout"]
-            if os.path.exists(pipe_path):
-                raise RuntimeError(f"Pipe at {pipe_path} already exists")
-
-            with _missing_backups_named_pipe(pipe_path):
-                future = executor.submit(_insert_blobs_from_tar, pipe_path)
-
-                cmd = [
-                    "ch-backup",
-                    "get-cloud-storage-metadata",
-                    "--disk",
-                    disk_conf.name,
-                    "--local-path",
-                    pipe_path,
-                    backup,
-                ]
-                proc = subprocess.Popen(
-                    cmd,
-                    shell=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+            proc = subprocess.Popen(
+                cmd,
+                shell=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            _, stderr = proc.communicate(timeout=timeout)
+            if proc.returncode:
+                assert proc.stderr
+                raise RuntimeError(
+                    f"Downloading cloud storage metadata command has failed: retcode {proc.returncode}, stderr: {stderr.decode('utf-8')}"
                 )
-                _, stderr = proc.communicate(timeout=timeout)
-                if proc.returncode:
-                    assert proc.stderr
-                    raise RuntimeError(
-                        f"Downloading cloud storage metadata command has failed: retcode {proc.returncode}, stderr: {stderr.decode('utf-8')}"
-                    )
 
-                try:
-                    future.result(timeout)
-                except TimeoutError:
-                    raise RuntimeError(
-                        "Downloading cloud storage metadata command has failed: Timeout exceeded, metadata reading thread is probably locked"
-                    )
+            try:
+                parse_thread.join(timeout)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Error from parsing cloud storage metadata thread: {e}"
+                ) from e
+
+            if parse_thread.is_alive():
+                raise RuntimeError(
+                    "Downloading cloud storage metadata command has failed: Timeout exceeded, metadata reading thread is probably locked"
+                )
 
 
 @contextmanager

--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -517,7 +517,10 @@ def _insert_missing_s3_backups_blobs(
                 with tarfile.open(fileobj=pipe, mode="r|*") as tar:
                     for member in tar:
                         # Old backups may have revision.txt file in tar, it should not be parsed
-                        if member.name == "revision.txt":
+                        # frozen_metadata.txt should not be uploaded to backup, ignore it just in case
+                        if member.name.endswith("revision.txt") or member.name.endswith(
+                            "frozen_metadata.txt"
+                        ):
                             continue
                         file = tar.extractfile(member)
                         if file:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent potential deadlocks when reading backup metadata from a named pipe by replacing a raw thread with a future-based worker and enforcing timeouts on both the subprocess and the reader.