### PR TITLE
Added retries configuration for object_storage section

### DIFF
--- a/ch_tools/chadmin/internal/object_storage/s3_iterator.py
+++ b/ch_tools/chadmin/internal/object_storage/s3_iterator.py
@@ -11,6 +11,7 @@ IGNORED_OBJECT_NAME_PREFIXES = ["operations", ".SCHEMA_VERSION"]
 
 def s3_object_storage_iterator(
     disk: S3DiskConfiguration,
+    retries_config: dict,
     *,
     object_name_prefix: str = "",
     skip_ignoring: bool = False,
@@ -20,7 +21,7 @@ def s3_object_storage_iterator(
         endpoint_url=disk.endpoint_url,
         aws_access_key_id=disk.access_key_id,
         aws_secret_access_key=disk.secret_access_key,
-        config=Config(s3={"addressing_style": "auto"}),
+        config=Config(s3={"addressing_style": "auto"}, retries=retries_config),
     )
     bucket = s3.Bucket(disk.bucket_name)
 

--- a/ch_tools/common/commands/object_storage.py
+++ b/ch_tools/common/commands/object_storage.py
@@ -987,7 +987,9 @@ def _collect_remote_blobs(
     counter = 0
     now = datetime.now(timezone.utc)
     for obj in s3_object_storage_iterator(
-        ctx.obj["disk_configuration"], object_name_prefix=prefix
+        ctx.obj["disk_configuration"],
+        ctx.obj["config"]["object_storage"]["retries"],
+        object_name_prefix=prefix,
     ):
         if obj.last_modified > now - to_time:
             continue

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -68,6 +68,8 @@ DEFAULT_CONFIG = {
                 "named_pipe_path": "/tmp/cloud-storage-metadata-pipe",
             },
         },
+        # see https://docs.aws.amazon.com/botocore/latest/reference/config.html for details
+        "retries": None,
     },
     "zookeeper": {
         "randomize_hosts": True,


### PR DESCRIPTION
Added retries configuration for object_storage section with the support to fully provide botocore's retries config dict

## Summary by Sourcery

Add support for configuring S3 object storage retries via the global object_storage configuration.

New Features:
- Allow passing object storage configuration, including retries, into the S3 iterator used for remote blob collection.

Enhancements:
- Extend default object_storage config to include a retries field aligned with botocore configuration options.