### PR TITLE
Added retries config for kazoo client

### DIFF
--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -27,6 +27,7 @@ from click import Context
 from kazoo.client import KazooClient
 from kazoo.exceptions import NodeExistsError, NoNodeError, NotEmptyError
 from kazoo.protocol.states import ZnodeStat
+from kazoo.retry import KazooRetry
 
 from ch_tools.chadmin.internal.utils import chunked, replace_macros
 from ch_tools.common import logging
@@ -493,9 +494,15 @@ def _get_zk_client(ctx: Context) -> KazooClient:
     no_chroot = args.get("no_chroot", False)
     no_ch_config = args.get("no_ch_config", False)
     zk_root_path = args.get("zk_root_path", None)
-    zk_randomize_hosts = (
-        ctx.obj["config"].get("zookeeper", {}).get("randomize_hosts", True)
-    )
+    zk_config_section = ctx.obj["config"].get("zookeeper", {})
+    zk_randomize_hosts = zk_config_section.get("randomize_hosts", True)
+
+    connection_retry: KazooRetry | None = None
+    if "connection_retry" in zk_config_section:
+        connection_retry = KazooRetry(**zk_config_section["connection_retry"])
+    command_retry: KazooRetry | None = None
+    if "command_retry" in zk_config_section:
+        command_retry = KazooRetry(**zk_config_section["command_retry"])
 
     if no_ch_config:
         if not host:
@@ -525,6 +532,8 @@ def _get_zk_client(ctx: Context) -> KazooClient:
         connect_str,
         auth_data=auth_data,
         timeout=timeout,
+        connection_retry=connection_retry,
+        command_retry=command_retry,
         logger=logging.getNativeLogger("kazoo"),
         use_ssl=use_ssl,
         verify_certs=verify_ssl_certs,

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -497,12 +497,18 @@ def _get_zk_client(ctx: Context) -> KazooClient:
     zk_config_section = ctx.obj["config"].get("zookeeper", {})
     zk_randomize_hosts = zk_config_section.get("randomize_hosts", True)
 
-    connection_retry: KazooRetry | None = None
-    if "connection_retry" in zk_config_section:
-        connection_retry = KazooRetry(**zk_config_section["connection_retry"])
-    command_retry: KazooRetry | None = None
-    if "command_retry" in zk_config_section:
-        command_retry = KazooRetry(**zk_config_section["command_retry"])
+    # Only create KazooRetry when config is explicitly provided
+    # This preserves KazooClient's default behavior when not specified
+    connection_retry = (
+        KazooRetry(**zk_config_section["connection_retry"])
+        if "connection_retry" in zk_config_section
+        else None
+    )
+    command_retry = (
+        KazooRetry(**zk_config_section["command_retry"])
+        if "command_retry" in zk_config_section
+        else None
+    )
 
     if no_ch_config:
         if not host:

--- a/ch_tools/common/config.py
+++ b/ch_tools/common/config.py
@@ -75,6 +75,18 @@ DEFAULT_CONFIG = {
         "randomize_hosts": True,
         "username": None,
         "password": None,
+        "connection_retry": {
+            "max_tries": 3,
+            "delay": 0.1,
+            "backoff": 2,
+            "max_delay": 60.0,
+        },
+        "command_retry": {
+            "max_tries": 3,
+            "delay": 0.1,
+            "backoff": 2,
+            "max_delay": 60.0,
+        },
     },
     # Configuration of chadmin tool commands and options.
     "chadmin": {


### PR DESCRIPTION
## Summary by Sourcery

Configure Kazoo client to support customizable connection and command retry behavior via zookeeper configuration.

Enhancements:
- Add optional connection_retry and command_retry settings when constructing the Kazoo client, derived from the zookeeper config section.
- Extend default zookeeper configuration with sensible retry parameters for Kazoo connection and command operations.