### PR TITLE
Add tcp mem check

### DIFF
--- a/ch_tools/monrun_checks/ch_tcp_mem.py
+++ b/ch_tools/monrun_checks/ch_tcp_mem.py
@@ -5,11 +5,11 @@ import click
 
 from ch_tools.common.result import CRIT, OK, WARNING, Result
 
-
 SOCKSTAT_PATH = Path("/proc/net/sockstat")
 
-GIB = 1024 ** 3
+GIB = 1024**3
 DEFAULT_CRIT_BYTES = 10 * GIB
+
 
 @click.command("tcp-mem")
 @click.option(
@@ -52,6 +52,7 @@ def tcp_mem_command(
 
     return Result(OK)
 
+
 def _get_tcp_mem_bytes() -> int:
     """
     Return current TCP memory usage from /proc/net/sockstat in bytes.
@@ -61,6 +62,7 @@ def _get_tcp_mem_bytes() -> int:
 
     return mem_pages * page_size
 
+
 def _get_tcp_mem_pages() -> int:
     """
     Return current TCP memory usage from /proc/net/sockstat in memory pages.
@@ -68,7 +70,7 @@ def _get_tcp_mem_pages() -> int:
         TCP: inuse 37 orphan 0 tw 12 alloc 42 mem 8
     The "mem" value is reported in pages.
     """
-    for line in SOCKSTAT_PATH.read_text().splitlines():
+    for line in SOCKSTAT_PATH.read_text(encoding="utf-8").splitlines():
         if not line.startswith("TCP:"):
             continue
 

--- a/ch_tools/monrun_checks/ch_tcp_mem.py
+++ b/ch_tools/monrun_checks/ch_tcp_mem.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+
+import click
+
+from ch_tools.common.result import CRIT, OK, WARNING, Result
+
+
+SOCKSTAT_PATH = Path("/proc/net/sockstat")
+
+GIB = 1024 ** 3
+DEFAULT_CRIT_BYTES = 10 * GIB
+
+@click.command("tcp-mem")
+@click.option(
+    "-c",
+    "--critical",
+    "crit",
+    type=int,
+    default=DEFAULT_CRIT_BYTES,
+    show_default=True,
+    help="Critical threshold in bytes.",
+)
+@click.option(
+    "-w",
+    "--warning",
+    "warn",
+    type=int,
+    default=None,
+    help="Warning threshold in bytes. Defaults to half of critical threshold.",
+)
+def tcp_mem_command(
+    crit: int,
+    warn: int,
+) -> Result:
+    """
+    Check TCP memory usage from /proc/net/sockstat.
+    """
+    if warn is None:
+        warn = crit // 2
+
+    try:
+        value = _get_tcp_mem_bytes()
+    except Exception as e:
+        return Result(CRIT, f"Failed to get TCP memory usage: {e}")
+
+    if value > crit:
+        return Result(CRIT, f"tcp_mem_bytes, crit = {crit}, count = {value}")
+
+    if value > warn:
+        return Result(WARNING, f"tcp_mem_bytes, warn = {warn}, count = {value}")
+
+    return Result(OK)
+
+def _get_tcp_mem_bytes() -> int:
+    """
+    Return current TCP memory usage from /proc/net/sockstat in bytes.
+    """
+    mem_pages = _get_tcp_mem_pages()
+    page_size = os.sysconf("SC_PAGE_SIZE")
+
+    return mem_pages * page_size
+
+def _get_tcp_mem_pages() -> int:
+    """
+    Return current TCP memory usage from /proc/net/sockstat in memory pages.
+    Example TCP line:
+        TCP: inuse 37 orphan 0 tw 12 alloc 42 mem 8
+    The "mem" value is reported in pages.
+    """
+    for line in SOCKSTAT_PATH.read_text().splitlines():
+        if not line.startswith("TCP:"):
+            continue
+
+        parts = line.split()
+
+        try:
+            mem_index = parts.index("mem")
+            return int(parts[mem_index + 1])
+        except ValueError:
+            raise RuntimeError("TCP mem field is missing or invalid")
+        except IndexError:
+            raise RuntimeError("TCP mem value is missing")
+
+    raise RuntimeError("TCP line not found in /proc/net/sockstat")

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -43,6 +43,7 @@ from ch_tools.monrun_checks.ch_tls import tls_command
 from ch_tools.monrun_checks.dns import dns_command
 from ch_tools.monrun_checks.exceptions import translate_to_status
 from ch_tools.monrun_checks.status import status_command
+from ch_tools.monrun_checks.ch_tcp_mem import tcp_mem_command
 
 DEFAULT_USER = "monitor"
 
@@ -173,6 +174,7 @@ CLI_COMMANDS = [
     dns_command,
     orphaned_objects_command,
     system_metrics_command,
+    tcp_mem_command,
 ]
 
 cli.add_command(status_command(CLI_COMMANDS))

--- a/ch_tools/monrun_checks/main.py
+++ b/ch_tools/monrun_checks/main.py
@@ -39,11 +39,11 @@ from ch_tools.monrun_checks.ch_s3_credentials_config import (
 )
 from ch_tools.monrun_checks.ch_system_metrics import system_metrics_command
 from ch_tools.monrun_checks.ch_system_queues import system_queues_command
+from ch_tools.monrun_checks.ch_tcp_mem import tcp_mem_command
 from ch_tools.monrun_checks.ch_tls import tls_command
 from ch_tools.monrun_checks.dns import dns_command
 from ch_tools.monrun_checks.exceptions import translate_to_status
 from ch_tools.monrun_checks.status import status_command
-from ch_tools.monrun_checks.ch_tcp_mem import tcp_mem_command
 
 DEFAULT_USER = "monitor"
 

--- a/tests/features/monrun.feature
+++ b/tests/features/monrun.feature
@@ -583,3 +583,23 @@ Feature: ch-monitoring tool
     """
     2;Metric not available
     """
+
+  Scenario: Check TCP memory sockstat with default thresholds
+    When we execute command on clickhouse01
+    """
+    ch-monitoring tcp-mem
+    """
+    Then we get response
+    """
+    0;OK
+    """
+
+  Scenario: Check TCP memory sockstat with critical threshold
+    When we execute command on clickhouse01
+    """
+    ch-monitoring tcp-mem -w 0 -c -1
+    """
+    Then we get response contains
+    """
+    2;tcp_mem_bytes, crit = -1, count =
+    """


### PR DESCRIPTION
## Summary by Sourcery

Add a monrun check for TCP memory usage based on /proc/net/sockstat and register it in the ch-monitoring CLI.

New Features:
- Introduce a tcp-mem monrun check command to report TCP memory usage and evaluate it against configurable warning and critical thresholds.

Tests:
- Add feature tests covering the tcp-mem check for default thresholds and critical threshold behavior.