### PR TITLE
Add random-sleep parameter for cleaning orphaned objects of S3 disks

### DIFF
--- a/ch_tools/chadmin/cli/object_storage_group.py
+++ b/ch_tools/chadmin/cli/object_storage_group.py
@@ -1,3 +1,5 @@
+import random
+import time
 from datetime import timedelta
 from typing import Any, Optional
 
@@ -183,6 +185,13 @@ def object_storage_group(ctx: Context, disk_name: str) -> None:
     default=StatisticsPeriod.ALL,
     help=("Partition output stats by months or days, or return only total stats."),
 )
+@option(
+    "--max-random-sleep",
+    "max_random_sleep",
+    type=TimeSpanParamType(),
+    default=None,
+    help="Perform random sleep up to specified value before executing command.",
+)
 @pass_context
 def clean_command(
     ctx: Context,
@@ -200,10 +209,15 @@ def clean_command(
     max_size_to_delete_fraction: float,
     ignore_missing_cloud_storage_backups: bool,
     stat_by_period: StatisticsPeriod,
+    max_random_sleep: timedelta,
 ) -> None:
     """
     Clean orphaned S3 objects.
     """
+    if max_random_sleep:
+        random_sleep = random.randint(0, int(max_random_sleep.total_seconds()))
+        time.sleep(random_sleep)
+
     result_stat = ResultStat(stat_by_period)
     error_msg = ""
 

--- a/tests/features/object_storage.feature
+++ b/tests/features/object_storage.feature
@@ -155,6 +155,17 @@ Feature: chadmin object-storage commands
       TotalSize: 0
     """
 
+  Scenario: Dry-run clean with max random sleep
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml object-storage clean --dry-run --max-random-sleep 3s
+    """
+    Then we get response contains
+    """
+      WouldDelete: 0
+      TotalSize: 0
+    """
+
   Scenario: Clean orphaned objects
     When we put object in S3
     """


### PR DESCRIPTION
## Summary by Sourcery

Add optional randomized pre-execution delay to the object-storage clean command and cover it with a basic dry-run test.

New Features:
- Introduce a --max-random-sleep parameter to the object-storage clean command to sleep a random duration up to the specified value before running.

Tests:
- Add a feature test verifying that object-storage clean accepts --max-random-sleep in dry-run mode and still reports no deletions.