### PR TITLE
Add part recover-broken command for recovering parts from s3

### DIFF
--- a/ch_tools/chadmin/cli/part_group.py
+++ b/ch_tools/chadmin/cli/part_group.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from click import Context
@@ -19,11 +20,18 @@ from ch_tools.chadmin.internal.part import (
     part_has_suffix,
     remove_detached_part_prefix_on_disk,
 )
+from ch_tools.chadmin.internal.part_recovery import recover_broken_part
+from ch_tools.chadmin.internal.part_recovery.exceptions import (
+    CriticalLossError,
+)
 from ch_tools.chadmin.internal.system import match_ch_version
 from ch_tools.chadmin.internal.table import check_table
 from ch_tools.common import logging
 from ch_tools.common.cli.formatting import format_bytes, print_response
 from ch_tools.common.cli.parameters import BytesParamType
+from ch_tools.common.clickhouse.client.clickhouse_client import clickhouse_client
+from ch_tools.common.clickhouse.config import get_clickhouse_config
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
 from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
 
 FIELD_FORMATTERS = {
@@ -752,3 +760,135 @@ def check_parts_command(
             }
         )
     print_response(ctx, result, default_format="table")
+
+
+@part_group.command("recover-broken")
+@option(
+    "--part-path",
+    "part_path",
+    required=True,
+    type=str,
+    help=(
+        "Path to the detached broken part directory, e.g. "
+        "/var/lib/clickhouse/disks/<disk>/store/<uuid>/detached/broken_<name>."
+    ),
+)
+@option(
+    "--disk",
+    "disk_name",
+    default="object_storage",
+    show_default=True,
+    help="Name of the S3 disk as configured in ClickHouse (used to read S3 credentials).",
+)
+@option(
+    "--output",
+    "output_tsv",
+    required=True,
+    type=str,
+    help="Destination path for the recovered TSV file.",
+)
+@option(
+    "--tmp-dir",
+    "tmp_dir",
+    default=None,
+    type=str,
+    help="Working directory for temporary files. Defaults to a system temp directory.",
+)
+@option(
+    "--threads",
+    default=16,
+    show_default=True,
+    type=int,
+    help="Number of parallel threads for S3 operations.",
+)
+@option(
+    "-n",
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print the recovery plan without performing any actions.",
+)
+@option(
+    "--report",
+    "report_path",
+    default=None,
+    type=str,
+    help="Write a JSON recovery report to this path.",
+)
+@option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Deprecated. This option is kept for backward compatibility but has no effect.",
+)
+@pass_context
+def recover_broken_part_command(
+    ctx: Context,
+    part_path: str,
+    disk_name: str,
+    output_tsv: str,
+    tmp_dir: Optional[str],
+    threads: int,
+    dry_run: bool,
+    report_path: Optional[str],
+    force: bool,
+) -> None:
+    """
+    Recover a broken MergeTree part (Wide or Compact format) with missing S3 blobs and export data to TSV.
+
+    The command reads S3 credentials from the ClickHouse configuration and uses
+    the running ClickHouse server for the final data extraction.  The server
+    schema (system.columns) is used as the authoritative column list; columns.txt
+    from the part is used as a fallback when the source table has been dropped.
+
+    **Wide parts:** Missing data columns are replaced with NULL (\\N in TSV output).
+    **Compact parts:** All column data is stored in a single ``data.bin`` file.
+    If ``data.bin`` has missing S3 blobs, recovery fails with exit code 2.
+
+    Missing index/meta files are zero-filled or reconstructed automatically.
+
+    Exit codes:
+      0 — success (or dry-run completed)
+      1 — unrecoverable error (e.g. columns.txt missing, S3 auth failure)
+      2 — critical data loss detected (e.g. Compact part with missing data.bin blobs)
+    """
+    ch_config = get_clickhouse_config(ctx)
+    disk_conf = S3DiskConfiguration.from_config(
+        ch_config.storage_configuration,
+        disk_name,
+        ctx.obj["config"]["object_storage"]["bucket_name_prefix"],
+    )
+
+    part_path_obj = Path(part_path)
+    if not part_path_obj.is_dir():
+        ctx.fail(f"Part path does not exist or is not a directory: {part_path}")
+
+    output_tsv_path = Path(output_tsv)
+    tmp_dir_path = Path(tmp_dir) if tmp_dir else None
+    report_path_obj = Path(report_path) if report_path else None
+
+    client = clickhouse_client(ctx)
+
+    try:
+        report = recover_broken_part(
+            client=client,
+            disk_conf=disk_conf,
+            part_path=part_path_obj,
+            output_tsv=output_tsv_path,
+            tmp_dir=tmp_dir_path,
+            threads=threads,
+            dry_run=dry_run,
+            report_path=report_path_obj,
+            force=force,
+        )
+        logging.info(
+            "Recovery summary: {} files total, {} healthy, {} missing, {} broken columns.",
+            report.files_total,
+            report.files_healthy,
+            report.files_missing,
+            len(report.broken_columns),
+        )
+    except CriticalLossError as exc:
+        logging.error("Critical loss: {}", exc)
+        raise SystemExit(2) from exc

--- a/ch_tools/chadmin/cli/part_group.py
+++ b/ch_tools/chadmin/cli/part_group.py
@@ -20,9 +20,9 @@ from ch_tools.chadmin.internal.part import (
     part_has_suffix,
     remove_detached_part_prefix_on_disk,
 )
-from ch_tools.chadmin.internal.part_recovery import recover_broken_part
-from ch_tools.chadmin.internal.part_recovery.exceptions import (
+from ch_tools.chadmin.internal.part_recovery import (
     CriticalLossError,
+    recover_broken_part,
 )
 from ch_tools.chadmin.internal.system import get_version, match_ch_version
 from ch_tools.chadmin.internal.table import check_table
@@ -816,12 +816,6 @@ def check_parts_command(
     type=str,
     help="Write a JSON recovery report to this path.",
 )
-@option(
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Deprecated. This option is kept for backward compatibility but has no effect.",
-)
 @pass_context
 def recover_broken_part_command(
     ctx: Context,
@@ -832,7 +826,6 @@ def recover_broken_part_command(
     threads: int,
     dry_run: bool,
     report_path: Optional[str],
-    force: bool,
 ) -> None:
     """
     Recover a broken MergeTree part (Wide or Compact format) with missing S3 blobs and export data to TSV.
@@ -887,7 +880,6 @@ def recover_broken_part_command(
             threads=threads,
             dry_run=dry_run,
             report_path=report_path_obj,
-            force=force,
         )
         logging.info(
             "Recovery summary: {} files total, {} healthy, {} missing, {} broken columns.",

--- a/ch_tools/chadmin/cli/part_group.py
+++ b/ch_tools/chadmin/cli/part_group.py
@@ -24,7 +24,7 @@ from ch_tools.chadmin.internal.part_recovery import recover_broken_part
 from ch_tools.chadmin.internal.part_recovery.exceptions import (
     CriticalLossError,
 )
-from ch_tools.chadmin.internal.system import match_ch_version
+from ch_tools.chadmin.internal.system import get_version, match_ch_version
 from ch_tools.chadmin.internal.table import check_table
 from ch_tools.common import logging
 from ch_tools.common.cli.formatting import format_bytes, print_response
@@ -869,6 +869,13 @@ def recover_broken_part_command(
     report_path_obj = Path(report_path) if report_path else None
 
     client = clickhouse_client(ctx)
+
+    # Check ClickHouse version - SETTINGS disk = '...' requires 23.3+
+    if not match_ch_version(ctx, "23.3"):
+        ctx.fail(
+            "recover-broken requires ClickHouse version 23.3 or above. "
+            f"Current version: {get_version(ctx)}"
+        )
 
     try:
         report = recover_broken_part(

--- a/ch_tools/chadmin/internal/part_recovery/__init__.py
+++ b/ch_tools/chadmin/internal/part_recovery/__init__.py
@@ -1,0 +1,7 @@
+"""
+Part recovery package: recover Wide MergeTree parts with missing S3 blobs.
+"""
+
+from ch_tools.chadmin.internal.part_recovery.recover import recover_broken_part
+
+__all__ = ["recover_broken_part"]

--- a/ch_tools/chadmin/internal/part_recovery/__init__.py
+++ b/ch_tools/chadmin/internal/part_recovery/__init__.py
@@ -2,6 +2,7 @@
 Part recovery package: recover Wide MergeTree parts with missing S3 blobs.
 """
 
+from ch_tools.chadmin.internal.part_recovery.exceptions import CriticalLossError
 from ch_tools.chadmin.internal.part_recovery.recover import recover_broken_part
 
-__all__ = ["recover_broken_part"]
+__all__ = ["recover_broken_part", "CriticalLossError"]

--- a/ch_tools/chadmin/internal/part_recovery/classify.py
+++ b/ch_tools/chadmin/internal/part_recovery/classify.py
@@ -13,6 +13,7 @@ For **Wide** parts (no ``data.bin`` file), each column has its own ``.bin`` file
 and individual broken columns can be excluded from recovery.
 """
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -180,6 +181,35 @@ def _decide(
     return Decision.DROP
 
 
+def _collect_healthy_mrk2_columns(
+    all_paths: List[Path],
+    blob_status: Dict[str, bool],
+    disk_conf: Optional[S3DiskConfiguration],
+) -> set:
+    """
+    Collect column names that have at least one healthy .mrk2 file.
+
+    This is used to determine whether count.txt can be reconstructed.
+    """
+    healthy_mrk2_cols: set = set()
+    for path in all_paths:
+        match = _RE_MARK2.match(path.name)
+        if match:
+            try:
+                meta = S3ObjectLocalMetaData.from_file(path)
+                all_healthy = all(
+                    blob_status.get(
+                        _full_key(disk_conf, obj) if disk_conf else obj.key, False
+                    )
+                    for obj in meta.objects
+                )
+                if all_healthy:
+                    healthy_mrk2_cols.add(match.group("col"))
+            except (ValueError, IndexError, OSError) as exc:
+                logging.debug("Failed to parse metadata for %s: %s", path.name, exc)
+    return healthy_mrk2_cols
+
+
 def scan_blob_keys(
     part_dir: Path,
     disk_conf: Optional[S3DiskConfiguration] = None,
@@ -209,8 +239,8 @@ def scan_blob_keys(
             for obj in meta.objects:
                 full = _full_key(disk_conf, obj) if disk_conf else obj.key
                 keys[full] = path.name
-        except (ValueError, IndexError, OSError):
-            pass  # plain-text file or unrecognized format
+        except (ValueError, IndexError, OSError) as exc:
+            logging.debug("Failed to parse metadata for %s: %s", path.name, exc)
     return keys
 
 
@@ -269,24 +299,9 @@ def classify(
 
     # Determine which columns have at least one healthy .mrk2 file
     # (needed to decide whether count.txt can be reconstructed)
-    healthy_mrk2_cols: set = set()
-    for p in all_paths:
-        m = _RE_MARK2.match(p.name)
-        if m:
-            try:
-                meta = S3ObjectLocalMetaData.from_file(p)
-                all_healthy = all(
-                    blob_status.get(
-                        _full_key(disk_conf, obj) if disk_conf else obj.key, False
-                    )
-                    for obj in meta.objects
-                )
-                if all_healthy:
-                    healthy_mrk2_cols.add(m.group("col"))
-            except (ValueError, IndexError, OSError):
-                pass
-
-    has_healthy_mrk2 = len(healthy_mrk2_cols) > 0
+    has_healthy_mrk2 = (
+        len(_collect_healthy_mrk2_columns(all_paths, blob_status, disk_conf)) > 0
+    )
 
     for path in sorted(all_paths, key=lambda p: p.name):
         name = path.name

--- a/ch_tools/chadmin/internal/part_recovery/classify.py
+++ b/ch_tools/chadmin/internal/part_recovery/classify.py
@@ -1,0 +1,365 @@
+"""
+Classification of files in a MergeTree part (Wide or Compact format) stored on an S3 disk.
+
+Each file in the part directory is a local metadata file pointing to one or more
+S3 blobs.  This module inspects the file names, determines the semantic role of
+each file, and decides what to do when its S3 blobs are missing.
+
+For **Compact** parts (identified by the presence of a single ``data.bin`` file),
+all column data is stored together in that file.  If ``data.bin`` has missing blobs,
+recovery is impossible and :class:`CriticalLossError` is raised.
+
+For **Wide** parts (no ``data.bin`` file), each column has its own ``.bin`` file,
+and individual broken columns can be excluded from recovery.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
+    S3ObjectLocalInfo,
+    S3ObjectLocalMetaData,
+)
+from ch_tools.chadmin.internal.part_recovery.exceptions import (
+    CriticalLossError,
+)
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
+
+
+class FileCategory(str, Enum):
+    CRITICAL_META = "critical_meta"
+    META = "meta"
+    DATA = "data"
+    MARK = "mark"
+    SKIP_INDEX = "skip_index"
+    INDEX = "index"
+    UNKNOWN = "unknown"
+
+
+class Decision(str, Enum):
+    DOWNLOAD = "download"
+    ZERO_FILL = "zero_fill"
+    DROP = "drop"
+    RECONSTRUCT = "reconstruct"
+    MARK_BROKEN = "mark_broken"
+    KEEP = "keep"
+
+
+# Patterns for recognizing file roles by name.
+# Supports both legacy (.bin/.mrk2) and new ClickHouse formats (.cmrk2/.size.bin etc.)
+# Use non-greedy .+? so that "value.size.bin" → col="value", not "value.size".
+_RE_DATA = re.compile(r"^(?P<col>.+?)\.(bin|size\.bin)$")
+_RE_MARK2 = re.compile(r"^(?P<col>.+?)\.(mrk2|cmrk2|size\.mrk2|size\.cmrk2)$")
+_RE_MARK = re.compile(r"^(?P<col>.+?)\.mrk$")
+_RE_MINMAX = re.compile(r"^minmax_(?P<col>.+?)\.idx$")
+_RE_SKP_IDX = re.compile(r"^skp_idx_(?P<name>.+?)\.(idx|mrk2?|cmrk2|idx2)$")
+_RE_PRIMARY = re.compile(r"^primary\.(idx|cidx)$")
+_RE_COMPACT_DATA = re.compile(r"^data\.bin$")
+
+# Files that are always dropped regardless of blob health
+_ALWAYS_DROP_NAMES = {"checksums.txt"}
+_ALWAYS_DROP_CATEGORIES = {FileCategory.SKIP_INDEX}
+
+# Plain-text meta files that map to FileCategory.META
+_META_PLAIN_NAMES = {
+    "partition.dat",
+    "default_compression_codec.txt",
+    "metadata_version.txt",
+    "serialization.json",
+    "ttl.txt",
+    "uuid.txt",
+    "checksums.txt",
+}
+
+# Critical meta files.  If any of these files are backed by missing S3 blobs,
+# recovery must stop instead of creating zero-filled placeholders: ClickHouse
+# expects their contents to be semantically valid.
+_CRITICAL_META_NAMES = {"columns.txt", "count.txt", "partition.dat"}
+
+
+@dataclass
+class PartFile:
+    """Represents a single file inside a MergeTree part directory (Wide or Compact)."""
+
+    name: str
+    path: Path
+    metadata: Optional[S3ObjectLocalMetaData]
+    category: FileCategory
+    column: Optional[str]
+    healthy: bool
+    decision: Decision
+    blob_keys: List[str] = field(default_factory=list)
+    total_size: int = 0
+
+
+def _full_key(disk_conf: S3DiskConfiguration, obj: S3ObjectLocalInfo) -> str:
+    """Return the full S3 key for a blob object, prepending the disk prefix if needed."""
+    if obj.key_is_full:
+        return obj.key
+    return os.path.join(disk_conf.prefix, obj.key)
+
+
+def _categorize(name: str) -> tuple:  # pylint: disable=too-many-return-statements
+    """
+    Return (FileCategory, column_name_or_None) for a given file name.
+    """
+    # Critical meta files — check first to avoid false matches by data regexes
+    if name in _CRITICAL_META_NAMES:
+        return FileCategory.CRITICAL_META, None
+
+    # Compact part sentinel — handled separately in classify()
+    if _RE_COMPACT_DATA.match(name):
+        return FileCategory.DATA, None
+
+    if _RE_SKP_IDX.match(name):
+        return FileCategory.SKIP_INDEX, None
+
+    m = _RE_DATA.match(name)
+    if m:
+        return FileCategory.DATA, m.group("col")
+
+    m = _RE_MARK2.match(name) or _RE_MARK.match(name)
+    if m:
+        return FileCategory.MARK, m.group("col")
+
+    if _RE_MINMAX.match(name) or name in _META_PLAIN_NAMES:
+        return FileCategory.META, None
+
+    # New ClickHouse format: columns_substreams.txt
+    if name == "columns_substreams.txt":
+        return FileCategory.META, None
+
+    if _RE_PRIMARY.match(name):
+        return FileCategory.INDEX, None
+
+    return FileCategory.UNKNOWN, None
+
+
+def _decide(
+    category: FileCategory,
+    name: str,
+    healthy: bool,
+    has_healthy_mrk2: bool,
+    has_metadata: bool = True,
+) -> Decision:
+    """
+    Determine what to do with a file given its category and blob health.
+
+    Parameters
+    ----------
+    has_metadata:
+        True if the file is an S3 metadata file (has blobs to download).
+        False if it is a plain-text local file (already on disk, no S3 blobs).
+    """
+    # Always drop skip-indexes and checksums.txt regardless of health
+    if category in _ALWAYS_DROP_CATEGORIES or name in _ALWAYS_DROP_NAMES:
+        return Decision.DROP
+
+    if healthy:
+        # Plain-text local files (no S3 metadata) are kept as-is — nothing to download.
+        # S3 metadata files must be downloaded even for CRITICAL_META (count.txt, columns.txt).
+        return Decision.DOWNLOAD if has_metadata else Decision.KEEP
+
+    # Blob(s) missing — decide by category:
+    if category == FileCategory.CRITICAL_META:
+        if name == "count.txt" and has_healthy_mrk2:
+            return Decision.RECONSTRUCT
+        # columns.txt missing → unrecoverable (CriticalLossError raised by caller)
+        return Decision.MARK_BROKEN
+
+    if category in (FileCategory.META, FileCategory.INDEX):
+        return Decision.ZERO_FILL
+
+    if category in (FileCategory.DATA, FileCategory.MARK):
+        return Decision.MARK_BROKEN
+
+    return Decision.DROP
+
+
+def scan_blob_keys(
+    part_dir: Path,
+    disk_conf: Optional[S3DiskConfiguration] = None,
+) -> Dict[str, str]:
+    """
+    Scan *part_dir* and return a mapping ``{full_blob_key: file_name}`` for
+    every S3 blob referenced by any metadata file in the directory.
+
+    This is a lightweight scan that does **not** validate blob health or raise
+    any exceptions — it is used to collect the set of keys to check before
+    calling :func:`classify`.
+
+    Parameters
+    ----------
+    part_dir:
+        Path to the detached part directory.
+    disk_conf:
+        S3 disk configuration used to resolve relative blob keys to full keys.
+        May be ``None`` in unit tests that supply full keys directly.
+    """
+    keys: Dict[str, str] = {}
+    for path in part_dir.iterdir():
+        if not path.is_file():
+            continue
+        try:
+            meta = S3ObjectLocalMetaData.from_file(path)
+            for obj in meta.objects:
+                full = _full_key(disk_conf, obj) if disk_conf else obj.key
+                keys[full] = path.name
+        except (ValueError, IndexError, OSError):
+            pass  # plain-text file or unrecognized format
+    return keys
+
+
+def classify(
+    part_dir: Path,
+    blob_status: Dict[str, bool],
+    disk_conf: Optional[S3DiskConfiguration] = None,
+    force: bool = False,  # pylint: disable=unused-argument
+) -> List[PartFile]:
+    """
+    Scan *part_dir* and classify every file.
+
+    Supports both **Wide** and **Compact** MergeTree part formats.
+
+    - **Compact** parts are identified by the presence of a ``data.bin`` file.
+      All column data is stored in this single file. If ``data.bin`` has missing
+      S3 blobs, recovery is impossible and :class:`CriticalLossError` is raised.
+    - **Wide** parts have per-column ``.bin`` files. Individual broken columns
+      can be excluded from recovery.
+
+    Parameters
+    ----------
+    part_dir:
+        Path to the detached part directory (e.g. ``detached/broken_<name>``).
+    blob_status:
+        Mapping from **full** S3 blob key → True (healthy) / False (missing).
+        Keys that are absent from the dict are treated as missing.
+        Full keys are built by prepending ``disk_conf.prefix`` for metadata
+        versions 1–4 (where ``obj.key_is_full`` is False).
+    disk_conf:
+        S3 disk configuration used to resolve relative blob keys to full keys.
+        Required when *blob_status* contains full keys (i.e. always in
+        production).  May be ``None`` only in unit tests that already supply
+        full keys directly.
+    force:
+        Deprecated. This parameter is kept for backward compatibility but has no effect.
+
+    Returns
+    -------
+    List of :class:`PartFile` objects, one per file in the directory.
+
+    Raises
+    ------
+    CriticalLossError:
+        If the part is in Compact format and ``data.bin`` has missing S3 blobs,
+        or if any critical metadata file (e.g. ``columns.txt``) has missing blobs.
+    """
+    files: List[PartFile] = []
+
+    # Detect Compact vs Wide format
+    compact_data = part_dir / "data.bin"
+    is_compact = compact_data.exists()
+
+    # Collect all files
+    all_paths = [p for p in part_dir.iterdir() if p.is_file()]
+
+    # Determine which columns have at least one healthy .mrk2 file
+    # (needed to decide whether count.txt can be reconstructed)
+    healthy_mrk2_cols: set = set()
+    for p in all_paths:
+        m = _RE_MARK2.match(p.name)
+        if m:
+            try:
+                meta = S3ObjectLocalMetaData.from_file(p)
+                all_healthy = all(
+                    blob_status.get(
+                        _full_key(disk_conf, obj) if disk_conf else obj.key, False
+                    )
+                    for obj in meta.objects
+                )
+                if all_healthy:
+                    healthy_mrk2_cols.add(m.group("col"))
+            except (ValueError, IndexError, OSError):
+                pass
+
+    has_healthy_mrk2 = len(healthy_mrk2_cols) > 0
+
+    for path in sorted(all_paths, key=lambda p: p.name):
+        name = path.name
+        category, column = _categorize(name)
+
+        # Try to parse as S3 metadata
+        metadata: Optional[S3ObjectLocalMetaData] = None
+        blob_keys: List[str] = []
+        total_size = 0
+
+        try:
+            metadata = S3ObjectLocalMetaData.from_file(path)
+            # Store full keys so callers can look them up in blob_status directly
+            blob_keys = [
+                _full_key(disk_conf, obj) if disk_conf else obj.key
+                for obj in metadata.objects
+            ]
+            total_size = metadata.total_size
+        except (ValueError, IndexError, OSError):
+            # Plain text file (columns.txt, count.txt, checksums.txt, …)
+            # or unrecognized binary — treat as locally present, no S3 blobs.
+            metadata = None
+
+        if metadata is not None:
+            healthy = all(blob_status.get(k, False) for k in blob_keys)
+        else:
+            # Local plain-text file — always "healthy" (present on disk)
+            healthy = True
+
+        decision = _decide(
+            category, name, healthy, has_healthy_mrk2, has_metadata=metadata is not None
+        )
+
+        files.append(
+            PartFile(
+                name=name,
+                path=path,
+                metadata=metadata,
+                category=category,
+                column=column,
+                healthy=healthy,
+                decision=decision,
+                blob_keys=blob_keys,
+                total_size=total_size,
+            )
+        )
+
+    # Validate: columns.txt must be present locally (it's a plain-text file)
+    col_file = part_dir / "columns.txt"
+    if not col_file.exists():
+        raise CriticalLossError(
+            f"columns.txt is missing from {part_dir}. "
+            "Cannot determine table schema — recovery is impossible."
+        )
+
+    # Validate: any MARK_BROKEN on a CRITICAL_META file → fail
+    for pf in files:
+        if (
+            pf.category == FileCategory.CRITICAL_META
+            and pf.decision == Decision.MARK_BROKEN
+        ):
+            raise CriticalLossError(
+                f"Critical metadata file '{pf.name}' has missing S3 blobs "
+                "and cannot be reconstructed. Recovery is impossible."
+            )
+
+    # Compact part validation: data.bin must be healthy
+    if is_compact:
+        compact_file = next((pf for pf in files if pf.name == "data.bin"), None)
+        if compact_file and not compact_file.healthy:
+            raise CriticalLossError(
+                f"Compact part at {part_dir} has missing S3 blobs in data.bin. "
+                "All column data is stored in a single file; recovery is impossible."
+            )
+
+    return files

--- a/ch_tools/chadmin/internal/part_recovery/classify.py
+++ b/ch_tools/chadmin/internal/part_recovery/classify.py
@@ -5,12 +5,7 @@ Each file in the part directory is a local metadata file pointing to one or more
 S3 blobs.  This module inspects the file names, determines the semantic role of
 each file, and decides what to do when its S3 blobs are missing.
 
-For **Compact** parts (identified by the presence of a single ``data.bin`` file),
-all column data is stored together in that file.  If ``data.bin`` has missing blobs,
-recovery is impossible and :class:`CriticalLossError` is raised.
-
-For **Wide** parts (no ``data.bin`` file), each column has its own ``.bin`` file,
-and individual broken columns can be excluded from recovery.
+For details on Compact vs Wide part handling, see :func:`classify`.
 """
 
 import logging
@@ -32,7 +27,7 @@ from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfig
 
 
 class FileCategory(str, Enum):
-    CRITICAL_META = "critical_meta"
+    REQUIRED_META = "required_meta"  # columns.txt, count.txt, partition.dat
     META = "meta"
     DATA = "data"
     MARK = "mark"
@@ -76,10 +71,12 @@ _META_PLAIN_NAMES = {
     "checksums.txt",
 }
 
-# Critical meta files.  If any of these files are backed by missing S3 blobs,
-# recovery must stop instead of creating zero-filled placeholders: ClickHouse
-# expects their contents to be semantically valid.
-_CRITICAL_META_NAMES = {"columns.txt", "count.txt", "partition.dat"}
+# Required meta files that cannot be zero-filled if their S3 blobs are missing.
+# These are handled specially by the orchestrator (e.g. columns.txt reconstruction).
+# - columns.txt: can be reconstructed from another part or system.columns
+# - partition.dat: plain-text file (no S3 blobs), must exist locally
+# - count.txt: can be reconstructed from healthy .mrk2 files
+_REQUIRED_META_NAMES = {"columns.txt", "count.txt", "partition.dat"}
 
 
 @dataclass
@@ -108,9 +105,9 @@ def _categorize(name: str) -> tuple:  # pylint: disable=too-many-return-statemen
     """
     Return (FileCategory, column_name_or_None) for a given file name.
     """
-    # Critical meta files — check first to avoid false matches by data regexes
-    if name in _CRITICAL_META_NAMES:
-        return FileCategory.CRITICAL_META, None
+    # Required meta files — check first to avoid false matches by data regexes
+    if name in _REQUIRED_META_NAMES:
+        return FileCategory.REQUIRED_META, None
 
     # Compact part sentinel — handled separately in classify()
     if _RE_COMPACT_DATA.match(name):
@@ -166,7 +163,7 @@ def _decide(
         return Decision.DOWNLOAD if has_metadata else Decision.KEEP
 
     # Blob(s) missing — decide by category:
-    if category == FileCategory.CRITICAL_META:
+    if category == FileCategory.REQUIRED_META:
         if name == "count.txt" and has_healthy_mrk2:
             return Decision.RECONSTRUCT
         # columns.txt missing → unrecoverable (CriticalLossError raised by caller)
@@ -221,14 +218,6 @@ def scan_blob_keys(
     This is a lightweight scan that does **not** validate blob health or raise
     any exceptions — it is used to collect the set of keys to check before
     calling :func:`classify`.
-
-    Parameters
-    ----------
-    part_dir:
-        Path to the detached part directory.
-    disk_conf:
-        S3 disk configuration used to resolve relative blob keys to full keys.
-        May be ``None`` in unit tests that supply full keys directly.
     """
     keys: Dict[str, str] = {}
     for path in part_dir.iterdir():
@@ -248,7 +237,6 @@ def classify(
     part_dir: Path,
     blob_status: Dict[str, bool],
     disk_conf: Optional[S3DiskConfiguration] = None,
-    force: bool = False,  # pylint: disable=unused-argument
 ) -> List[PartFile]:
     """
     Scan *part_dir* and classify every file.
@@ -260,34 +248,16 @@ def classify(
       S3 blobs, recovery is impossible and :class:`CriticalLossError` is raised.
     - **Wide** parts have per-column ``.bin`` files. Individual broken columns
       can be excluded from recovery.
-
-    Parameters
-    ----------
-    part_dir:
-        Path to the detached part directory (e.g. ``detached/broken_<name>``).
-    blob_status:
-        Mapping from **full** S3 blob key → True (healthy) / False (missing).
-        Keys that are absent from the dict are treated as missing.
-        Full keys are built by prepending ``disk_conf.prefix`` for metadata
-        versions 1–4 (where ``obj.key_is_full`` is False).
-    disk_conf:
-        S3 disk configuration used to resolve relative blob keys to full keys.
-        Required when *blob_status* contains full keys (i.e. always in
-        production).  May be ``None`` only in unit tests that already supply
-        full keys directly.
-    force:
-        Deprecated. This parameter is kept for backward compatibility but has no effect.
-
-    Returns
-    -------
-    List of :class:`PartFile` objects, one per file in the directory.
+    - ``columns.txt`` may be missing — it will be reconstructed later by the orchestrator
+      from another part or from ``system.columns``.
 
     Raises
     ------
     CriticalLossError:
         If the part is in Compact format and ``data.bin`` has missing S3 blobs,
-        or if any critical metadata file (e.g. ``columns.txt``) has missing blobs.
+        or if any required metadata file (e.g. ``partition.dat``) has missing blobs.
     """
+
     files: List[PartFile] = []
 
     # Detect Compact vs Wide format
@@ -349,18 +319,13 @@ def classify(
             )
         )
 
-    # Validate: columns.txt must be present locally (it's a plain-text file)
-    col_file = part_dir / "columns.txt"
-    if not col_file.exists():
-        raise CriticalLossError(
-            f"columns.txt is missing from {part_dir}. "
-            "Cannot determine table schema — recovery is impossible."
-        )
+    # Note: columns.txt may be missing — it will be reconstructed later
+    # from another part or from system.columns by the orchestrator.
 
-    # Validate: any MARK_BROKEN on a CRITICAL_META file → fail
+    # Validate: any MARK_BROKEN on a REQUIRED_META file → fail
     for pf in files:
         if (
-            pf.category == FileCategory.CRITICAL_META
+            pf.category == FileCategory.REQUIRED_META
             and pf.decision == Decision.MARK_BROKEN
         ):
             raise CriticalLossError(

--- a/ch_tools/chadmin/internal/part_recovery/exceptions.py
+++ b/ch_tools/chadmin/internal/part_recovery/exceptions.py
@@ -1,0 +1,13 @@
+"""
+Exceptions for the part recovery module.
+"""
+
+
+class CriticalLossError(RuntimeError):
+    """
+    Raised when a critical file (e.g. columns.txt) is missing and cannot be reconstructed.
+    The part cannot be recovered without it.
+
+    Also raised for Compact-format parts when the single ``data.bin`` file has missing S3 blobs,
+    since all column data is stored together and cannot be partially recovered.
+    """

--- a/ch_tools/chadmin/internal/part_recovery/reconstruct.py
+++ b/ch_tools/chadmin/internal/part_recovery/reconstruct.py
@@ -1,0 +1,105 @@
+"""
+Reconstruction helpers for missing or damaged part files.
+
+Provides:
+- :func:`count_rows_from_mrk2` — derive row count from a ``.mrk2`` file.
+- :func:`zero_fill` — create a zero-filled stub file of a given size.
+- :func:`default_compression_codec_txt` — stub content for ``default_compression_codec.txt``.
+- :func:`metadata_version_txt` — stub content for ``metadata_version.txt``.
+- :func:`write_count_txt` — write ``count.txt`` with a given row count.
+"""
+
+import struct
+from pathlib import Path
+
+# .mrk2 record layout: three UInt64 values (little-endian, 8 bytes each)
+#   offset_in_compressed_file  (8 bytes)
+#   offset_in_decompressed_block (8 bytes)
+#   number_of_rows_in_granule   (8 bytes)
+_MRK2_RECORD_SIZE = 24
+_MRK2_STRUCT = struct.Struct("<QQQ")
+
+
+def count_rows_from_mrk2(path: Path) -> int:
+    """
+    Read a ``.mrk2`` file and return the total number of rows it covers.
+
+    Each record in a ``.mrk2`` file is 24 bytes:
+    ``(offset_in_compressed, offset_in_decompressed, granule_rows)``.
+    The sum of all ``granule_rows`` values equals the total row count of the part.
+
+    Raises :class:`ValueError` if the file size is not a multiple of 24.
+    """
+    size = path.stat().st_size
+    if size % _MRK2_RECORD_SIZE != 0:
+        raise ValueError(
+            f"{path} has size {size} which is not a multiple of {_MRK2_RECORD_SIZE}. "
+            "The file may be corrupted."
+        )
+
+    total_rows = 0
+    data = path.read_bytes()
+    for offset in range(0, size, _MRK2_RECORD_SIZE):
+        _off_compressed, _off_decompressed, granule_rows = _MRK2_STRUCT.unpack_from(
+            data, offset
+        )
+        total_rows += granule_rows
+
+    return total_rows
+
+
+def zero_fill(path: Path, size: int) -> None:
+    """
+    Create (or overwrite) *path* with exactly *size* zero bytes.
+
+    This is used to create stub files for missing index/meta files so that
+    ClickHouse can still ATTACH the part (with ``force_restore_data=1``).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(b"\x00" * size)
+
+
+def default_compression_codec_txt() -> bytes:
+    """
+    Return the stub content for ``default_compression_codec.txt``.
+
+    ClickHouse writes the codec name used for the part's columns.  When the
+    file is missing we fall back to LZ4 which is the default.
+    """
+    return b"CODEC(LZ4)\n"
+
+
+def metadata_version_txt() -> bytes:
+    """
+    Return the stub content for ``metadata_version.txt``.
+
+    Version 0 is the baseline; ClickHouse will accept it during ATTACH.
+    """
+    return b"0\n"
+
+
+def write_count_txt(path: Path, row_count: int) -> None:
+    """Write *row_count* to ``count.txt`` at *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(row_count) + "\n", encoding="utf-8")
+
+
+def reconstruct_missing_meta(
+    dest_dir: Path,
+    name: str,
+    size: int,
+) -> None:
+    """
+    Write a stub for a missing meta file into *dest_dir*.
+
+    Handles ``default_compression_codec.txt``, ``metadata_version.txt``,
+    and any other meta file that should be zero-filled.
+    """
+    dest = dest_dir / name
+    if name == "default_compression_codec.txt":
+        dest.write_bytes(default_compression_codec_txt())
+    elif name == "metadata_version.txt":
+        dest.write_bytes(metadata_version_txt())
+    else:
+        zero_fill(dest, size)

--- a/ch_tools/chadmin/internal/part_recovery/recover.py
+++ b/ch_tools/chadmin/internal/part_recovery/recover.py
@@ -44,7 +44,10 @@ from ch_tools.chadmin.internal.part_recovery.s3_blobs import (
     check_blobs_parallel,
     download_part_files,
 )
-from ch_tools.chadmin.internal.part_recovery.server_runner import run_server_recovery
+from ch_tools.chadmin.internal.part_recovery.server_runner import (
+    reconstruct_columns_txt,
+    run_server_recovery,
+)
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.client.clickhouse_client import ClickhouseClient
 from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
@@ -59,7 +62,6 @@ def recover_broken_part(
     threads: int = 16,
     dry_run: bool = False,
     report_path: Optional[Path] = None,
-    force: bool = False,  # pylint: disable=unused-argument
 ) -> RecoveryReport:
     """
     Recover a broken MergeTree part (Wide or Compact format) and export readable rows to TSV.
@@ -68,59 +70,33 @@ def recover_broken_part(
       If ``data.bin`` has missing S3 blobs, :class:`CriticalLossError` is raised.
     - **Wide** parts: each column has its own ``.bin`` file. Individual broken
       columns can be excluded from recovery (replaced with NULL in output).
-
-    Parameters
-    ----------
-    client:
-        ClickHouse HTTP client connected to the running server.
-    disk_conf:
-        S3 disk configuration (endpoint, bucket, credentials).
-    part_path:
-        Path to the detached part directory (e.g. ``detached/broken_<name>``).
-    output_tsv:
-        Destination path for the recovered TSV file.
-    tmp_dir:
-        Working directory for temporary files.  A subdirectory is created
-        inside it.  If *None*, a system temp directory is used.
-    threads:
-        Number of parallel threads for S3 operations.
-    dry_run:
-        If True, only print the recovery plan without performing any actions.
-    report_path:
-        If set, write the JSON report to this path.
-    force:
-        Deprecated. This parameter is kept for backward compatibility but has no effect.
-
-    Returns
-    -------
-    :class:`RecoveryReport`
+    - ``columns.txt`` may be missing — it will be reconstructed from another part
+      or from ``system.columns``.
 
     Raises
     ------
     CriticalLossError:
         If the part is in Compact format and ``data.bin`` has missing S3 blobs,
-        or if any critical metadata file (e.g. ``columns.txt``) has missing blobs.
+        or if any required metadata file (e.g. ``partition.dat``) has missing blobs,
+        or if ``columns.txt`` cannot be reconstructed.
     """
+
     part_name = part_path.name
     logging.info("Starting recovery of part '{}' at {}", part_name, part_path)
 
     # ── Step 1: Scan part directory to collect all blob keys ──────────────────
-    # Use scan_blob_keys() (no validation) so that we can check S3 health
-    # before classify() raises CriticalLossError for missing blobs.
     logging.info("Scanning part directory for S3 blob keys …")
     all_blob_keys = set(scan_blob_keys(part_path, disk_conf=disk_conf).keys())
-    logging.info("Checking {} unique S3 blob keys …", len(all_blob_keys))
 
     # ── Step 2: Check S3 blobs in parallel ────────────────────────────────────
+    logging.info("Checking {} unique S3 blob keys …", len(all_blob_keys))
     blob_status = check_blobs_parallel(disk_conf, all_blob_keys, threads=threads)
 
     # ── Step 3: Classify files with actual blob health status ─────────────────
     logging.info("Classifying part files …")
-    part_files = classify(
-        part_path, blob_status=blob_status, disk_conf=disk_conf, force=force
-    )
+    part_files = classify(part_path, blob_status=blob_status, disk_conf=disk_conf)
 
-    # ── Step 5: Determine broken columns ─────────────────────────────────────
+    # ── Step 4: Determine broken columns ─────────────────────────────────────
     # For Compact parts, all data is in data.bin which is either fully healthy
     # or causes CriticalLossError. So broken_columns is always empty for Compact.
     is_compact = (part_path / "data.bin").exists()
@@ -160,24 +136,34 @@ def recover_broken_part(
         # ── Step 9: Copy plain-text local files ───────────────────────────────
         _copy_local_files(assembled_dir, part_files)
 
-        # ── Step 10: Reconstruct missing meta files ───────────────────────────
+        # ── Step 9a: Reconstruct missing meta files ───────────────────────────
         reconstructed: List[str] = []
         _reconstruct_files(assembled_dir, part_files, reconstructed)
 
-        # ── Step 10b: Strip broken columns from columns.txt /
-        #             columns_substreams.txt so ATTACH PART does not look for
-        #             their (deleted) .bin/.mrk2 files.
+        # ── Step 9b: Reconstruct missing columns.txt from another part or
+        #              system.columns (both Wide and Compact formats)
+        if not (assembled_dir / "columns.txt").exists():
+            columns_txt_source = reconstruct_columns_txt(
+                client=client,
+                part_path=part_path,
+                assembled_dir=assembled_dir,
+            )
+            reconstructed.append(f"columns.txt (from {columns_txt_source})")
+
+        # ── Step 9c: Strip broken columns from columns.txt /
+        #              columns_substreams.txt so ATTACH PART does not look for
+        #              their (deleted) .bin/.mrk2 files.
         # This is only needed for Wide parts; Compact parts never have broken_columns.
         if broken_columns and not is_compact:
             _strip_broken_from_columns_files(
                 assembled_dir, broken_columns, reconstructed
             )
 
-        # ── Step 11: Determine columns.txt path ───────────────────────────────
+        # ── Step 10: Determine columns.txt path ───────────────────────────────
         columns_txt = assembled_dir / "columns.txt"
-        if not columns_txt.exists():
-            # Fall back to original part directory
-            columns_txt = part_path / "columns.txt"
+        assert (
+            columns_txt.exists()
+        ), f"columns.txt must exist after reconstruction for part {part_path.name}"
 
         # ── Step 12: Run server-side recovery ─────────────────────────────────
         logging.info("Running server-side recovery …")

--- a/ch_tools/chadmin/internal/part_recovery/recover.py
+++ b/ch_tools/chadmin/internal/part_recovery/recover.py
@@ -219,7 +219,9 @@ def recover_broken_part(
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
 
-def _log_plan(part_files: List[PartFile], broken_columns: Set[str], is_compact: bool = False) -> None:
+def _log_plan(
+    part_files: List[PartFile], broken_columns: Set[str], is_compact: bool = False
+) -> None:
     """Log a human-readable summary of the recovery plan."""
     total = len(part_files)
     healthy = sum(1 for pf in part_files if pf.healthy)
@@ -233,7 +235,9 @@ def _log_plan(part_files: List[PartFile], broken_columns: Set[str], is_compact: 
         missing,
     )
     if is_compact:
-        logging.info("Compact part: all column data is in data.bin (no per-column recovery).")
+        logging.info(
+            "Compact part: all column data is in data.bin (no per-column recovery)."
+        )
     elif broken_columns:
         logging.warning(
             "Broken columns (will be NULL in output): {}", sorted(broken_columns)

--- a/ch_tools/chadmin/internal/part_recovery/recover.py
+++ b/ch_tools/chadmin/internal/part_recovery/recover.py
@@ -1,0 +1,499 @@
+"""
+Orchestrator for recovering a broken MergeTree part (Wide or Compact format) with missing S3 blobs.
+
+High-level flow
+---------------
+1. Load S3DiskConfiguration from ClickHouse config.
+2. Scan the part directory, parse S3 metadata files, and collect full blob keys.
+3. Check all referenced S3 blobs in parallel (head_object).
+4. Classify every file and decide what to do with it.
+   - For **Compact** parts: if ``data.bin`` has missing blobs, :class:`CriticalLossError` is raised.
+   - For **Wide** parts: individual broken columns can be excluded from recovery.
+5. (dry-run) Print the plan and exit.
+6. Download healthy blobs into a temporary directory.
+7. Reconstruct missing meta files (zero-fill, stubs, count.txt).
+8. Use the running ClickHouse server to extract data:
+   a. Create a scratch table ``_chadmin_recover._recover_<rand>`` on a local disk.
+   b. Place the assembled part in the scratch table's detached/ directory.
+   c. ATTACH PART → SELECT FORMAT TSV → output file.
+   d. DROP scratch table (always, in finally).
+9. Write the JSON report.
+"""
+
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Set
+
+from ch_tools.chadmin.internal.part_recovery.classify import (
+    Decision,
+    FileCategory,
+    PartFile,
+    classify,
+    scan_blob_keys,
+)
+from ch_tools.chadmin.internal.part_recovery.reconstruct import (
+    count_rows_from_mrk2,
+    reconstruct_missing_meta,
+    write_count_txt,
+    zero_fill,
+)
+from ch_tools.chadmin.internal.part_recovery.report import RecoveryReport, build_report
+from ch_tools.chadmin.internal.part_recovery.s3_blobs import (
+    check_blobs_parallel,
+    download_part_files,
+)
+from ch_tools.chadmin.internal.part_recovery.server_runner import run_server_recovery
+from ch_tools.common import logging
+from ch_tools.common.clickhouse.client.clickhouse_client import ClickhouseClient
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
+
+
+def recover_broken_part(
+    client: ClickhouseClient,
+    disk_conf: S3DiskConfiguration,
+    part_path: Path,
+    output_tsv: Path,
+    tmp_dir: Optional[Path] = None,
+    threads: int = 16,
+    dry_run: bool = False,
+    report_path: Optional[Path] = None,
+    force: bool = False,  # pylint: disable=unused-argument
+) -> RecoveryReport:
+    """
+    Recover a broken MergeTree part (Wide or Compact format) and export readable rows to TSV.
+
+    - **Compact** parts: all column data is stored in a single ``data.bin`` file.
+      If ``data.bin`` has missing S3 blobs, :class:`CriticalLossError` is raised.
+    - **Wide** parts: each column has its own ``.bin`` file. Individual broken
+      columns can be excluded from recovery (replaced with NULL in output).
+
+    Parameters
+    ----------
+    client:
+        ClickHouse HTTP client connected to the running server.
+    disk_conf:
+        S3 disk configuration (endpoint, bucket, credentials).
+    part_path:
+        Path to the detached part directory (e.g. ``detached/broken_<name>``).
+    output_tsv:
+        Destination path for the recovered TSV file.
+    tmp_dir:
+        Working directory for temporary files.  A subdirectory is created
+        inside it.  If *None*, a system temp directory is used.
+    threads:
+        Number of parallel threads for S3 operations.
+    dry_run:
+        If True, only print the recovery plan without performing any actions.
+    report_path:
+        If set, write the JSON report to this path.
+    force:
+        Deprecated. This parameter is kept for backward compatibility but has no effect.
+
+    Returns
+    -------
+    :class:`RecoveryReport`
+
+    Raises
+    ------
+    CriticalLossError:
+        If the part is in Compact format and ``data.bin`` has missing S3 blobs,
+        or if any critical metadata file (e.g. ``columns.txt``) has missing blobs.
+    """
+    part_name = part_path.name
+    logging.info("Starting recovery of part '{}' at {}", part_name, part_path)
+
+    # ── Step 1: Scan part directory to collect all blob keys ──────────────────
+    # Use scan_blob_keys() (no validation) so that we can check S3 health
+    # before classify() raises CriticalLossError for missing blobs.
+    logging.info("Scanning part directory for S3 blob keys …")
+    all_blob_keys = set(scan_blob_keys(part_path, disk_conf=disk_conf).keys())
+    logging.info("Checking {} unique S3 blob keys …", len(all_blob_keys))
+
+    # ── Step 2: Check S3 blobs in parallel ────────────────────────────────────
+    blob_status = check_blobs_parallel(disk_conf, all_blob_keys, threads=threads)
+
+    # ── Step 3: Classify files with actual blob health status ─────────────────
+    logging.info("Classifying part files …")
+    part_files = classify(
+        part_path, blob_status=blob_status, disk_conf=disk_conf, force=force
+    )
+
+    # ── Step 5: Determine broken columns ─────────────────────────────────────
+    # For Compact parts, all data is in data.bin which is either fully healthy
+    # or causes CriticalLossError. So broken_columns is always empty for Compact.
+    is_compact = (part_path / "data.bin").exists()
+    broken_columns: Set[str] = set()
+    if not is_compact:
+        for pf in part_files:
+            if pf.decision == Decision.MARK_BROKEN and pf.column:
+                broken_columns.add(pf.column)
+
+    _log_plan(part_files, broken_columns, is_compact=is_compact)
+
+    # ── Step 6: dry-run exit ──────────────────────────────────────────────────
+    if dry_run:
+        logging.info("Dry-run mode: no files will be modified.")
+        report = build_report(part_path, part_files)
+        if report_path:
+            report.write(report_path)
+            logging.info("Report written to {}", report_path)
+        return report
+
+    # ── Step 7: Set up temporary working directory ────────────────────────────
+    own_tmp = tmp_dir is None
+    if tmp_dir is None:
+        work_dir = Path(tempfile.mkdtemp(prefix="ch-tools-recovery-"))
+    else:
+        work_dir = tmp_dir / f"recovery_{part_name}"
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        assembled_dir = work_dir / "parts" / part_name
+        assembled_dir.mkdir(parents=True, exist_ok=True)
+
+        # ── Step 8: Download healthy blobs ────────────────────────────────────
+        logging.info("Downloading healthy blobs …")
+        download_part_files(disk_conf, part_files, assembled_dir, threads=threads)
+
+        # ── Step 9: Copy plain-text local files ───────────────────────────────
+        _copy_local_files(assembled_dir, part_files)
+
+        # ── Step 10: Reconstruct missing meta files ───────────────────────────
+        reconstructed: List[str] = []
+        _reconstruct_files(assembled_dir, part_files, reconstructed)
+
+        # ── Step 10b: Strip broken columns from columns.txt /
+        #             columns_substreams.txt so ATTACH PART does not look for
+        #             their (deleted) .bin/.mrk2 files.
+        # This is only needed for Wide parts; Compact parts never have broken_columns.
+        if broken_columns and not is_compact:
+            _strip_broken_from_columns_files(
+                assembled_dir, broken_columns, reconstructed
+            )
+
+        # ── Step 11: Determine columns.txt path ───────────────────────────────
+        columns_txt = assembled_dir / "columns.txt"
+        if not columns_txt.exists():
+            # Fall back to original part directory
+            columns_txt = part_path / "columns.txt"
+
+        # ── Step 12: Run server-side recovery ─────────────────────────────────
+        logging.info("Running server-side recovery …")
+        rows, tsv_labels = run_server_recovery(
+            client=client,
+            part_path=part_path,
+            assembled_dir=assembled_dir,
+            broken_columns=broken_columns,
+            output_path=output_tsv,
+            columns_txt=columns_txt,
+        )
+
+        # ── Step 13: Build and write report ───────────────────────────────────
+        report = build_report(
+            part_path, part_files, rows_recovered=rows, tsv_columns=tsv_labels
+        )
+        report.reconstructed_files = _deduplicate_preserving_order(
+            [*report.reconstructed_files, *reconstructed]
+        )
+
+        if report_path:
+            report.write(report_path)
+            logging.info("Report written to {}", report_path)
+
+        logging.info(
+            "Recovery complete. {} rows written to {}. Broken columns: {} ({} part)",
+            rows,
+            output_tsv,
+            sorted(broken_columns) or "none",
+            "Compact" if is_compact else "Wide",
+        )
+        return report
+
+    finally:
+        if own_tmp:
+            shutil.rmtree(str(work_dir), ignore_errors=True)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _log_plan(part_files: List[PartFile], broken_columns: Set[str], is_compact: bool = False) -> None:
+    """Log a human-readable summary of the recovery plan."""
+    total = len(part_files)
+    healthy = sum(1 for pf in part_files if pf.healthy)
+    missing = total - healthy
+    part_format = "Compact" if is_compact else "Wide"
+    logging.info(
+        "Part files ({} format): {} total, {} healthy, {} with missing blobs",
+        part_format,
+        total,
+        healthy,
+        missing,
+    )
+    if is_compact:
+        logging.info("Compact part: all column data is in data.bin (no per-column recovery).")
+    elif broken_columns:
+        logging.warning(
+            "Broken columns (will be NULL in output): {}", sorted(broken_columns)
+        )
+    for pf in part_files:
+        if not pf.healthy:
+            logging.info(
+                "  {} [{}] → {}",
+                pf.name,
+                pf.category.value,
+                pf.decision.value,
+            )
+
+
+def _copy_local_files(
+    assembled_dir: Path,
+    part_files: List[PartFile],
+) -> None:
+    """
+    Copy plain-text local files (columns.txt, count.txt, etc.) that are
+    already present on disk (no S3 metadata) into the assembled directory.
+    """
+    for pf in part_files:
+        if pf.metadata is not None:
+            continue  # S3 metadata file — handled by download
+        src = pf.path
+        dst = assembled_dir / pf.name
+        if src.exists() and not dst.exists():
+            shutil.copy2(str(src), str(dst))
+
+
+def _reconstruct_files(
+    assembled_dir: Path,
+    part_files: List[PartFile],
+    reconstructed: List[str],
+) -> None:
+    """
+    Apply reconstruction decisions: zero-fill, stubs, count.txt from mrk2.
+    Also always drop checksums.txt so ClickHouse recalculates it on ATTACH.
+    """
+    # Always remove checksums.txt — ClickHouse will recalculate with force_restore_data=1
+    checksums = assembled_dir / "checksums.txt"
+    if checksums.exists():
+        checksums.unlink()
+        reconstructed.append("checksums.txt (dropped)")
+
+    for pf in part_files:
+        dest = assembled_dir / pf.name
+
+        if pf.decision == Decision.DROP:
+            if dest.exists():
+                dest.unlink()
+            reconstructed.append(f"{pf.name} (dropped)")
+            continue
+
+        if pf.decision == Decision.ZERO_FILL:
+            size = pf.total_size if pf.total_size > 0 else 0
+            zero_fill(dest, size)
+            reconstructed.append(f"{pf.name} (zero-filled, {size} bytes)")
+            continue
+
+        if pf.decision == Decision.RECONSTRUCT and pf.name == "count.txt":
+            # Find any healthy .mrk2 file in the assembled directory
+            row_count = _count_rows_from_any_mrk2(assembled_dir)
+            if row_count is not None:
+                write_count_txt(dest, row_count)
+                reconstructed.append(f"count.txt (reconstructed, {row_count} rows)")
+            else:
+                logging.warning(
+                    "Could not reconstruct count.txt: no healthy .mrk2 files found. "
+                    "Skipping — ClickHouse will handle it."
+                )
+            continue
+
+        if pf.decision == Decision.MARK_BROKEN:
+            # Data/mark file with missing blobs — drop it entirely.
+            # Zero-filled .bin files would crash ATTACH PART with
+            # UNKNOWN_CODEC because ClickHouse reads codec byte 0x00.
+            # The owning column will also be excluded from the scratch
+            # table schema, so the file will not be referenced.
+            if dest.exists():
+                dest.unlink()
+            reconstructed.append(f"{pf.name} (dropped — column marked broken)")
+            continue
+
+        # For META files that are missing and not yet handled
+        if pf.category == FileCategory.META and not dest.exists():
+            reconstruct_missing_meta(assembled_dir, pf.name, pf.total_size)
+            reconstructed.append(f"{pf.name} (stub)")
+
+
+def _strip_broken_from_columns_files(
+    assembled_dir: Path,
+    broken_columns: Set[str],
+    reconstructed: List[str],
+) -> None:
+    """
+    Rewrite ``columns.txt`` (and ``columns_substreams.txt`` if present) in
+    *assembled_dir* removing any references to *broken_columns*.
+
+    This keeps ClickHouse from looking for the corresponding ``.bin`` /
+    ``.mrk2`` files during ``ATTACH PART`` — those files have been deleted
+    by the MARK_BROKEN handler, and the owning columns are also excluded
+    from the scratch table schema.
+    """
+    columns_txt = assembled_dir / "columns.txt"
+    if columns_txt.exists():
+        _rewrite_columns_txt(columns_txt, broken_columns, reconstructed)
+
+    substreams = assembled_dir / "columns_substreams.txt"
+    if substreams.exists():
+        _rewrite_columns_substreams_txt(substreams, broken_columns, reconstructed)
+
+    # serialization.json (CH 23.x+) is an optional optimisation that lists
+    # per-column serialization info (e.g. for Sparse columns).  When we
+    # remove columns from the part, ClickHouse rejects the part with
+    # "Found unexpected column ... in serialization infos".  Dropping the
+    # file is safe — ClickHouse falls back to default serialization.
+    serialization = assembled_dir / "serialization.json"
+    if serialization.exists():
+        serialization.unlink()
+        reconstructed.append("serialization.json (dropped)")
+
+
+def _rewrite_columns_txt(
+    path: Path,
+    broken_columns: Set[str],
+    reconstructed: List[str],
+) -> None:
+    """Drop ``broken_columns`` from a ``columns.txt`` file in place."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    header: List[str] = []
+    body: List[str] = []
+    body_started = False
+    for line in lines:
+        if not body_started and re.match(r"^`", line.strip()):
+            body_started = True
+        if body_started:
+            body.append(line)
+        else:
+            header.append(line)
+
+    kept: List[str] = []
+    for line in body:
+        m = re.match(r"^\s*`(.+?)`\s+", line)
+        if m and m.group(1) in broken_columns:
+            continue
+        kept.append(line)
+
+    # Update the column-count header line ("N columns:") if it exists
+    new_header: List[str] = []
+    for line in header:
+        m = re.match(r"^\s*(\d+)\s+columns:\s*$", line)
+        if m:
+            new_header.append(f"{len(kept)} columns:")
+        else:
+            new_header.append(line)
+
+    path.write_text("\n".join(new_header + kept) + "\n", encoding="utf-8")
+    reconstructed.append(f"columns.txt (rewritten, dropped {sorted(broken_columns)})")
+
+
+def _rewrite_columns_substreams_txt(
+    path: Path,
+    broken_columns: Set[str],
+    reconstructed: List[str],
+) -> None:
+    """
+    Drop column blocks that belong to *broken_columns* from
+    ``columns_substreams.txt`` (CH 26.x).
+
+    Format::
+
+        columns substreams version: 1
+        N columns:
+        K substreams for column `name`:
+            <substream1>
+            <substream2>
+        ...
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    header: List[str] = []
+    body_blocks: List[List[str]] = []
+    current_block: List[str] = []
+    body_started = False
+
+    for line in lines:
+        m_block = re.match(
+            r"^\s*\d+\s+substreams\s+for\s+column\s+`(.+?)`\s*:\s*$", line
+        )
+        if m_block:
+            body_started = True
+            if current_block:
+                body_blocks.append(current_block)
+            current_block = [line]
+            continue
+        if not body_started:
+            header.append(line)
+        else:
+            current_block.append(line)
+    if current_block:
+        body_blocks.append(current_block)
+
+    kept_blocks: List[List[str]] = []
+    for block in body_blocks:
+        m = re.match(r"^\s*\d+\s+substreams\s+for\s+column\s+`(.+?)`\s*:\s*$", block[0])
+        col = m.group(1) if m else ""
+        if col in broken_columns:
+            continue
+        kept_blocks.append(block)
+
+    # Update the "N columns:" line in header
+    new_header: List[str] = []
+    for line in header:
+        m = re.match(r"^\s*(\d+)\s+columns:\s*$", line)
+        if m:
+            new_header.append(f"{len(kept_blocks)} columns:")
+        else:
+            new_header.append(line)
+
+    out_lines = list(new_header)
+    for block in kept_blocks:
+        out_lines.extend(block)
+
+    path.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+    reconstructed.append(
+        f"columns_substreams.txt (rewritten, dropped {sorted(broken_columns)})"
+    )
+
+
+def _deduplicate_preserving_order(items: List[str]) -> List[str]:
+    """Return *items* without duplicates, preserving the first occurrence."""
+    seen: Set[str] = set()
+    result: List[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _count_rows_from_any_mrk2(assembled_dir: Path) -> Optional[int]:
+    """
+    Try to read row count from any mark file in *assembled_dir*.
+    Returns the count from the first successfully parsed file, or None.
+    Files are sorted for deterministic selection.
+    """
+    patterns = ("*.mrk2", "*.cmrk2", "*.size.mrk2", "*.size.cmrk2")
+    candidates: List[Path] = []
+    for pattern in patterns:
+        candidates.extend(assembled_dir.glob(pattern))
+
+    for p in sorted(set(candidates)):
+        try:
+            return count_rows_from_mrk2(p)
+        except (ValueError, OSError):
+            continue
+    return None

--- a/ch_tools/chadmin/internal/part_recovery/report.py
+++ b/ch_tools/chadmin/internal/part_recovery/report.py
@@ -1,0 +1,95 @@
+"""
+Recovery report: collects statistics and writes a JSON summary.
+"""
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ch_tools.chadmin.internal.part_recovery.classify import (
+    Decision,
+    PartFile,
+)
+
+
+@dataclass
+class MissingBlobInfo:
+    file: str
+    category: str
+    decision: str
+    size: int
+    blob_keys: List[str]
+
+
+@dataclass
+class RecoveryReport:
+    part_path: str
+    files_total: int = 0
+    files_healthy: int = 0
+    files_missing: int = 0
+    missing_blobs: List[MissingBlobInfo] = field(default_factory=list)
+    broken_columns: List[str] = field(default_factory=list)
+    reconstructed_files: List[str] = field(default_factory=list)
+    dropped_files: List[str] = field(default_factory=list)
+    rows_recovered: Optional[int] = None
+    tsv_columns: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    def write(self, path: Path) -> None:
+        path.write_text(self.to_json(), encoding="utf-8")
+
+
+def build_report(
+    part_path: Path,
+    part_files: List[PartFile],
+    rows_recovered: Optional[int] = None,
+    tsv_columns: Optional[List[str]] = None,
+) -> RecoveryReport:
+    """
+    Build a :class:`RecoveryReport` from the classified *part_files*.
+    """
+    report = RecoveryReport(part_path=str(part_path))
+    report.rows_recovered = rows_recovered
+    report.tsv_columns = tsv_columns or []
+
+    for pf in part_files:
+        # Only count files that have S3 metadata (skip plain local files)
+        if pf.metadata is None:
+            continue
+
+        report.files_total += 1
+
+        if pf.healthy:
+            report.files_healthy += 1
+        else:
+            report.files_missing += 1
+            report.missing_blobs.append(
+                MissingBlobInfo(
+                    file=pf.name,
+                    category=pf.category.value,
+                    decision=pf.decision.value,
+                    size=pf.total_size,
+                    blob_keys=pf.blob_keys,
+                )
+            )
+
+        if pf.decision == Decision.MARK_BROKEN and pf.column:
+            if pf.column not in report.broken_columns:
+                report.broken_columns.append(pf.column)
+
+        if pf.decision == Decision.RECONSTRUCT:
+            report.reconstructed_files.append(pf.name)
+
+        if pf.decision == Decision.DROP:
+            report.dropped_files.append(pf.name)
+
+    # Also account for reconstructed plain-text files (count.txt, checksums.txt)
+    # that are not S3 metadata files — they are tracked separately by the orchestrator.
+
+    return report

--- a/ch_tools/chadmin/internal/part_recovery/s3_blobs.py
+++ b/ch_tools/chadmin/internal/part_recovery/s3_blobs.py
@@ -1,0 +1,197 @@
+"""
+S3 blob health-check and download helpers for part recovery.
+
+Uses boto3 via the credentials stored in :class:`S3DiskConfiguration`.
+Parallel execution is done through :func:`execute_tasks_in_parallel`.
+"""
+
+import shutil
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Set
+
+import boto3
+from botocore.exceptions import ClientError
+
+from ch_tools.chadmin.internal.part_recovery.classify import Decision, PartFile
+from ch_tools.common import logging
+from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
+from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
+
+
+class BlobStatus(str, Enum):
+    HEALTHY = "healthy"
+    MISSING = "missing"
+
+
+def _make_s3_client(disk_conf: S3DiskConfiguration) -> "boto3.client":
+    return boto3.client(
+        "s3",
+        endpoint_url=disk_conf.endpoint_url,
+        aws_access_key_id=disk_conf.access_key_id,
+        aws_secret_access_key=disk_conf.secret_access_key,
+    )
+
+
+def head_blob(
+    s3_client: "boto3.client",
+    bucket: str,
+    key: str,
+) -> BlobStatus:
+    """
+    Check whether a single S3 blob exists.
+
+    Returns :attr:`BlobStatus.HEALTHY` if the object is accessible,
+    :attr:`BlobStatus.MISSING` on 404/NoSuchKey, and re-raises on any other
+    error (403, 5xx, …) so that transient failures are not silently treated as
+    data loss.
+    """
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+        return BlobStatus.HEALTHY
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code in ("404", "NoSuchKey"):
+            return BlobStatus.MISSING
+        raise
+
+
+def check_single_blob(
+    disk_conf: S3DiskConfiguration,
+    key: str,
+) -> bool:
+    """Worker function: returns True if blob is healthy.
+
+    *key* must be a **full** S3 key (prefix already included).
+    A new boto3 client is created per call; this is intentional for
+    thread-safety in :func:`execute_tasks_in_parallel`.
+    """
+    s3_client = _make_s3_client(disk_conf)
+    status = head_blob(s3_client, disk_conf.bucket_name, key)
+    return status == BlobStatus.HEALTHY
+
+
+def check_blobs_parallel(
+    disk_conf: S3DiskConfiguration,
+    blob_keys: Set[str],
+    threads: int = 16,
+) -> Dict[str, bool]:
+    """
+    Check all S3 blobs in *blob_keys* in parallel.
+
+    *blob_keys* must contain **full** S3 keys (prefix already included).
+
+    Returns a mapping ``{full_blob_key: is_healthy}``.
+    """
+    if not blob_keys:
+        return {}
+
+    tasks: List[WorkerTask] = [
+        WorkerTask(
+            identifier=key,
+            function=check_single_blob,
+            kwargs={"disk_conf": disk_conf, "key": key},
+        )
+        for key in blob_keys
+    ]
+
+    logging.info("Checking {} S3 blobs with {} threads …", len(tasks), threads)
+    results: Dict[str, bool] = execute_tasks_in_parallel(
+        tasks, max_workers=threads, keep_going=False
+    )
+    return results
+
+
+def collect_blob_keys(
+    part_files: List[PartFile],
+) -> Set[str]:
+    """
+    Collect all unique full S3 blob keys referenced by *part_files*.
+
+    The keys stored in :attr:`PartFile.blob_keys` are already full keys
+    (built by :func:`classify` using ``disk_conf``).
+    """
+    keys: Set[str] = set()
+    for pf in part_files:
+        keys.update(pf.blob_keys)
+    return keys
+
+
+def _download_single_blob(
+    disk_conf: S3DiskConfiguration,
+    key: str,
+    dest_path: Path,
+) -> None:
+    """Worker function: download one blob to *dest_path*.
+
+    *key* must be a **full** S3 key (prefix already included).
+    """
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    s3_client = _make_s3_client(disk_conf)
+    logging.debug("Downloading s3://{}/{} → {}", disk_conf.bucket_name, key, dest_path)
+    s3_client.download_file(disk_conf.bucket_name, key, str(dest_path))
+
+
+def download_part_files(
+    disk_conf: S3DiskConfiguration,
+    part_files: List[PartFile],
+    dest_dir: Path,
+    threads: int = 16,
+) -> None:
+    """
+    Download all healthy S3 blobs for *part_files* whose decision is DOWNLOAD,
+    concatenating multi-blob files into a single local file under *dest_dir*.
+
+    For each :class:`PartFile` with ``decision == Decision.DOWNLOAD`` and
+    ``metadata is not None``, the blobs are downloaded to temporary paths and
+    then concatenated (in order) into ``dest_dir / pf.name``.
+
+    The keys in :attr:`PartFile.blob_keys` are already full S3 keys.
+    """
+    to_download = [
+        pf
+        for pf in part_files
+        if pf.decision == Decision.DOWNLOAD and pf.metadata is not None
+    ]
+
+    if not to_download:
+        return
+
+    # Build a flat list of (blob_key, tmp_path, dest_file_path, blob_index) tasks
+    tasks: List[WorkerTask] = []
+    # Map: (pf.name, blob_index) → tmp_path
+    tmp_paths: Dict[tuple, Path] = {}
+
+    for pf in to_download:
+        assert pf.metadata is not None
+        for idx, key in enumerate(pf.blob_keys):
+            tmp_path = dest_dir / f".tmp_{pf.name}.{idx}"
+            tmp_paths[(pf.name, idx)] = tmp_path
+            tasks.append(
+                WorkerTask(
+                    identifier=f"{pf.name}[{idx}]",
+                    function=_download_single_blob,
+                    kwargs={
+                        "disk_conf": disk_conf,
+                        "key": key,
+                        "dest_path": tmp_path,
+                    },
+                )
+            )
+
+    logging.info("Downloading {} blobs for {} files …", len(tasks), len(to_download))
+    execute_tasks_in_parallel(tasks, max_workers=threads, keep_going=False)
+
+    # Concatenate blobs into final files using shutil.copyfileobj to avoid
+    # loading entire blobs into memory (important for large parts).
+    for pf in to_download:
+        assert pf.metadata is not None
+        dest_file = dest_dir / pf.name
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        with dest_file.open("wb") as out:
+            for idx in range(len(pf.blob_keys)):
+                tmp = tmp_paths[(pf.name, idx)]
+                with tmp.open("rb") as src:
+                    shutil.copyfileobj(src, out, length=65536)
+                tmp.unlink()
+        logging.debug("Assembled {}", dest_file)

--- a/ch_tools/chadmin/internal/part_recovery/server_runner.py
+++ b/ch_tools/chadmin/internal/part_recovery/server_runner.py
@@ -392,7 +392,7 @@ def place_part_in_detached(
                 os.lchown(os.path.join(root, d), target_uid, target_gid)
             for f in files:
                 os.lchown(os.path.join(root, f), target_uid, target_gid)
-    except (PermissionError, OSError) as exc:
+    except (AttributeError, PermissionError, OSError) as exc:
         logging.warning(
             "Could not lchown placed part {} to ClickHouse user: {}",
             dest,
@@ -490,7 +490,10 @@ def select_to_tsv(
     """
     Execute SELECT and stream TSV output to *output_path*.
 
-    Returns the number of rows written.
+    Returns the approximate number of rows written (based on newline-delimited output).
+
+    The count may undercount the final line if the file does not end with a newline
+    and will include trailing empty lines.
     """
     sql = build_select_sql(columns, broken_columns, table_name)
     logging.debug("SELECT SQL:\n{}", sql)
@@ -500,15 +503,17 @@ def select_to_tsv(
     # Use streaming HTTP response to avoid loading all data into memory
     response = client.query(sql, stream=True)
 
-    rows = 0
+    # Approximate row count based on newline-delimited output; may undercount the final line
+    # if the file does not end with a newline and will include trailing empty lines.
+    approx_rows = 0
     with output_path.open("wb") as fh:
         for chunk in response.iter_content(chunk_size=65536):
             if chunk:
                 fh.write(chunk)
-                rows += chunk.count(b"\n")
+                approx_rows += chunk.count(b"\n")
 
-    logging.info("Wrote {} rows to {}", rows, output_path)
-    return rows
+    logging.info("Wrote {} rows to {}", approx_rows, output_path)
+    return approx_rows
 
 
 # ---------------------------------------------------------------------------

--- a/ch_tools/chadmin/internal/part_recovery/server_runner.py
+++ b/ch_tools/chadmin/internal/part_recovery/server_runner.py
@@ -23,6 +23,7 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+from ch_tools.chadmin.internal.part_recovery.exceptions import CriticalLossError
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.client.clickhouse_client import ClickhouseClient
 
@@ -124,6 +125,168 @@ def merge_schemas(
         )
 
     return from_columns_txt
+
+
+def format_columns_txt(columns: List[Tuple[str, str]]) -> str:
+    """
+    Format a list of ``(name, type)`` pairs into ``columns.txt`` content.
+
+    The format matches what ClickHouse writes::
+
+        columns format version: 1
+        N columns:
+        `col_name` TypeName
+        ...
+
+    Backticks in column names are escaped by doubling them.
+    """
+    lines = ["columns format version: 1", f"{len(columns)} columns:"]
+    for name, typ in columns:
+        # Escape backticks in column names by doubling them (ClickHouse convention)
+        escaped_name = name.replace("`", "``")
+        lines.append(f"`{escaped_name}` {typ}")
+    return "\n".join(lines) + "\n"
+
+
+def _try_read_columns_from_part(
+    part_path: str,
+    source_label: str,
+) -> Optional[List[Tuple[str, str]]]:
+    """
+    Try to read ``columns.txt`` from a single part path.
+
+    Returns parsed columns or ``None`` if reading fails.
+    """
+    columns_path = Path(part_path) / "columns.txt"
+    if not columns_path.exists():
+        return None
+    try:
+        columns = parse_columns_txt(columns_path)
+        if columns:
+            logging.info(
+                "Found columns.txt from {} part: {}",
+                source_label,
+                columns_path,
+            )
+            return columns
+    except (OSError, IOError, ValueError) as exc:
+        logging.debug("Cannot read columns.txt from {}: {}", columns_path, exc)
+    return None
+
+
+def find_columns_txt_from_other_part(
+    client: ClickhouseClient,
+    database: str,
+    table: str,
+    exclude_part_name: str,
+) -> Optional[List[Tuple[str, str]]]:
+    """
+    Try to read ``columns.txt`` from another active or detached part of the same table.
+
+    Returns parsed columns as ``[(name, type), ...]`` or ``None`` if no other part
+    with a readable ``columns.txt`` is found.
+    """
+    # Try active parts first (ORDER BY modification_time DESC for determinism)
+    db_esc = database.replace("'", "\\'")
+    tbl_esc = table.replace("'", "\\'")
+    part_esc = exclude_part_name.replace("'", "\\'")
+    rows = client.query_json_data(
+        f"SELECT path FROM system.parts "
+        f"WHERE database = '{db_esc}' AND table = '{tbl_esc}' "
+        f"AND active = 1 AND name != '{part_esc}' "
+        f"ORDER BY modification_time DESC "
+        f"LIMIT 1",
+    )
+    if rows:
+        # query_json_data returns list of lists (JSONCompact format)
+        result = _try_read_columns_from_part(rows[0][0], "active")
+        if result is not None:
+            return result
+
+    # Fallback to detached parts (ORDER BY name for determinism)
+    rows = client.query_json_data(
+        f"SELECT path FROM system.detached_parts "
+        f"WHERE database = '{db_esc}' AND table = '{tbl_esc}' "
+        f"AND name != '{part_esc}' "
+        f"ORDER BY name "
+        f"LIMIT 1",
+    )
+    if rows:
+        result = _try_read_columns_from_part(rows[0][0], "detached")
+        if result is not None:
+            return result
+
+    return None
+
+
+def reconstruct_columns_txt(
+    client: ClickhouseClient,
+    part_path: Path,
+    assembled_dir: Path,
+) -> str:
+    """
+    Reconstruct missing ``columns.txt`` in *assembled_dir*.
+
+    Strategy:
+    1. Resolve the source table (database, table) from the part path UUID.
+    2. Try to read ``columns.txt`` from another active/detached part of the same table.
+    3. Fallback to live schema from ``system.columns``.
+    4. If neither source is available, raise ``CriticalLossError``.
+
+    Returns ``source_description`` indicating where the schema was taken from
+    (e.g. "another active part", "system.columns").
+
+    Raises
+    ------
+    CriticalLossError:
+        If the source table cannot be resolved or no schema source is found.
+    """
+
+    part_name = part_path.name
+
+    # Step 1: Resolve table
+    try:
+        database, table = resolve_table_from_path(client, part_path)
+        logging.info("Resolved source table for columns.txt: {}.{}", database, table)
+    except RuntimeError as exc:
+        raise CriticalLossError(
+            f"Cannot resolve source table for part {part_name}: {exc}. "
+            "columns.txt is missing and no schema source is available."
+        ) from exc
+
+    # Step 2: Try columns.txt from another part
+    columns = find_columns_txt_from_other_part(client, database, table, part_name)
+    source = "another part"
+
+    # Step 3: Fallback to system.columns
+    if columns is None:
+        logging.warning(
+            "No columns.txt found from other parts of {}.{} — falling back to system.columns",
+            database,
+            table,
+        )
+        columns = get_live_schema(client, database, table)
+        source = "system.columns"
+
+    # Step 4: Fail if no schema
+    if not columns:
+        raise CriticalLossError(
+            f"Cannot reconstruct columns.txt for part {part_name}: "
+            f"table {database}.{table} has no schema in system.columns "
+            "and no other part with columns.txt found."
+        )
+
+    # Write columns.txt
+    columns_file = assembled_dir / "columns.txt"
+    content = format_columns_txt(columns)
+    columns_file.write_text(content, encoding="utf-8")
+    logging.info(
+        "Reconstructed columns.txt for part {} from {} ({} columns)",
+        part_name,
+        source,
+        len(columns),
+    )
+    return source
 
 
 # ---------------------------------------------------------------------------

--- a/ch_tools/chadmin/internal/part_recovery/server_runner.py
+++ b/ch_tools/chadmin/internal/part_recovery/server_runner.py
@@ -1,0 +1,647 @@
+"""
+Extract data from a recovered Wide MergeTree part using the running ClickHouse
+server instead of clickhouse-local.
+
+Flow
+----
+1. Resolve ``(database, table)`` from the part path UUID via ``system.tables``.
+2. Fetch the live schema from ``system.columns`` (fallback: ``columns.txt``).
+3. Parse ``ORDER BY`` / ``PARTITION BY`` from ``system.tables.create_table_query``.
+4. Find a local disk on the server (``system.disks WHERE type='local'``).
+5. Create a scratch table ``_chadmin_recover._recover_<rand>`` with
+   ``ENGINE=MergeTree`` on the local disk.
+6. Move the assembled part into the scratch table's ``detached/`` directory.
+7. ``ALTER TABLE _recover_<rand> ATTACH PART '<part_name>'``.
+8. ``SELECT ... FORMAT TSV`` → output file (streamed via HTTP).
+9. ``DROP TABLE _chadmin_recover._recover_<rand>`` in a ``finally`` block.
+"""
+
+import os
+import re
+import secrets
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from ch_tools.common import logging
+from ch_tools.common.clickhouse.client.clickhouse_client import ClickhouseClient
+
+# Database used for all scratch tables
+_RECOVER_DB = "_chadmin_recover"
+
+# Regex to extract ORDER BY clause from CREATE TABLE DDL
+_ORDER_BY_RE = re.compile(
+    r"\bORDER\s+BY\s+(.+?)(?=\s*(?:PARTITION\s+BY|PRIMARY\s+KEY|SAMPLE\s+BY|TTL|SETTINGS|$))",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Regex to extract PARTITION BY clause
+_PARTITION_BY_RE = re.compile(
+    r"\bPARTITION\s+BY\s+(.+?)(?=\s*(?:ORDER\s+BY|PRIMARY\s+KEY|SAMPLE\s+BY|TTL|SETTINGS|$))",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_columns_txt(columns_txt: Path) -> List[Tuple[str, str]]:
+    """
+    Parse ``columns.txt`` and return a list of ``(column_name, type_string)`` pairs.
+
+    The format written by ClickHouse is::
+
+        columns format version: 1
+        N columns:
+        `col_name` TypeName
+        ...
+    """
+    columns: List[Tuple[str, str]] = []
+    text = columns_txt.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        line = line.strip()
+        m = re.match(r"^`(.+?)`\s+(.+)$", line)
+        if m:
+            columns.append((m.group(1), m.group(2)))
+    return columns
+
+
+def get_live_schema(
+    client: ClickhouseClient, database: str, table: str
+) -> List[Tuple[str, str]]:
+    """
+    Return ``[(name, type), ...]`` from ``system.columns`` for *database*.*table*.
+
+    Returns an empty list if the table does not exist.
+    """
+    db_esc = database.replace("'", "\\'")
+    tbl_esc = table.replace("'", "\\'")
+    rows = client.query_json_data(
+        f"SELECT name, type FROM system.columns "
+        f"WHERE database = '{db_esc}' AND table = '{tbl_esc}' "
+        f"ORDER BY position",
+    )
+    return [(r[0], r[1]) for r in rows]
+
+
+def merge_schemas(
+    live: List[Tuple[str, str]],
+    from_columns_txt: List[Tuple[str, str]],
+) -> List[Tuple[str, str]]:
+    """
+    Choose the schema used for the scratch recovery table.
+
+    The detached part's physical layout corresponds to its own ``columns.txt``;
+    therefore ``columns.txt`` is authoritative for recovery.  The live schema is
+    used only as a consistency signal and to warn when the source table drifted
+    after the part was created.
+    """
+    if not from_columns_txt:
+        if not live:
+            logging.warning(
+                "Neither columns.txt nor system.columns contains schema information."
+            )
+            return []
+        logging.warning(
+            "columns.txt contains no columns — falling back to live schema from system.columns."
+        )
+        return live
+
+    if not live:
+        logging.warning(
+            "Source table not found in system.columns — using columns.txt for schema."
+        )
+        return from_columns_txt
+
+    if live != from_columns_txt:
+        logging.warning(
+            "Schema mismatch between system.columns {} and columns.txt {} — "
+            "using part schema from columns.txt.",
+            live,
+            from_columns_txt,
+        )
+
+    return from_columns_txt
+
+
+# ---------------------------------------------------------------------------
+# Table resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_table_from_path(
+    client: ClickhouseClient, part_path: Path
+) -> Tuple[str, str]:
+    """
+    Resolve ``(database, table)`` for the table that owns *part_path*.
+
+    Strategy: extract the UUID directory component from the path
+    (``store/<3-char-prefix>/<uuid>/``) and look it up in ``system.tables``.
+
+    Falls back to parsing the path components if UUID lookup fails.
+
+    Raises ``RuntimeError`` if the table cannot be resolved.
+    """
+    # Try to extract UUID from path like:
+    #   /var/lib/clickhouse/disks/object_storage/store/abc/abcdef12-..../detached/broken_...
+    #   /var/lib/clickhouse/store/abc/abcdef12-.../detached/broken_...
+    uuid_match = re.search(
+        r"/store/[0-9a-f]{3}/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/",
+        str(part_path),
+    )
+    if uuid_match:
+        uuid = uuid_match.group(1)
+        uuid_esc = uuid.replace("'", "\\'")
+        rows = client.query_json_data(
+            f"SELECT database, name FROM system.tables WHERE uuid = '{uuid_esc}'",
+        )
+        if rows:
+            return str(rows[0][0]), str(rows[0][1])
+        logging.warning(
+            "UUID {} not found in system.tables — table may have been dropped.", uuid
+        )
+
+    raise RuntimeError(
+        f"Cannot resolve (database, table) from part path: {part_path}. "
+        "The table may have been dropped. "
+        "Ensure the source table exists or provide schema via columns.txt."
+    )
+
+
+def parse_order_by(create_table_query: str) -> str:
+    """
+    Extract the ORDER BY expression from a ``CREATE TABLE`` DDL string.
+
+    Returns ``'tuple()'`` if not found.
+    """
+    m = _ORDER_BY_RE.search(create_table_query)
+    if not m:
+        return "tuple()"
+    return m.group(1).strip()
+
+
+def parse_partition_by(create_table_query: str) -> Optional[str]:
+    """
+    Extract the PARTITION BY expression from a ``CREATE TABLE`` DDL string.
+
+    Returns ``None`` if not present.
+    """
+    m = _PARTITION_BY_RE.search(create_table_query)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+# ---------------------------------------------------------------------------
+# Disk selection
+# ---------------------------------------------------------------------------
+
+
+def find_local_disk(client: ClickhouseClient) -> str:
+    """
+    Return the name of the first local (non-object-storage) disk.
+
+    ClickHouse reports local disks with type 'local' (older versions) or
+    'LocalDisk' (newer versions, e.g. 26.x).  The built-in 'default' disk
+    is always local and is used as a final fallback.
+
+    Raises ``RuntimeError`` if no local disk is found.
+    """
+    rows = client.query_json_data(
+        "SELECT name FROM system.disks "
+        "WHERE type IN ('local', 'LocalDisk') "
+        "ORDER BY name LIMIT 1"
+    )
+    if rows:
+        return str(rows[0][0])
+
+    # Fallback: check if 'default' disk exists (it is always local)
+    default_rows = client.query_json_data(
+        "SELECT name FROM system.disks WHERE name = 'default' LIMIT 1"
+    )
+    if default_rows:
+        logging.warning(
+            "No disk with type='local'/'LocalDisk' found; "
+            "falling back to 'default' disk."
+        )
+        return "default"
+
+    raise RuntimeError(
+        "No local disk found on the ClickHouse server. "
+        "The scratch recovery table requires a local disk. "
+        "Ensure at least one disk of type='local' or 'LocalDisk' is configured."
+    )
+
+
+def get_disk_data_path(client: ClickhouseClient, disk_name: str) -> str:
+    """Return the filesystem path of *disk_name* from ``system.disks``."""
+    disk_esc = disk_name.replace("'", "\\'")
+    rows = client.query_json_data(
+        f"SELECT path FROM system.disks WHERE name = '{disk_esc}'",
+    )
+    if not rows:
+        raise RuntimeError(f"Disk '{disk_name}' not found in system.disks.")
+    return str(rows[0][0]).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Scratch table lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _strip_broken_prefix(part_name: str) -> str:
+    """Remove the ``broken_`` prefix from a detached part name."""
+    prefix = "broken_"
+    if part_name.startswith(prefix):
+        return part_name[len(prefix) :]
+    return part_name
+
+
+def create_recover_db(client: ClickhouseClient) -> None:
+    """Create the ``_chadmin_recover`` database if it does not exist."""
+    client.query(f"CREATE DATABASE IF NOT EXISTS `{_RECOVER_DB}`")
+
+
+def create_recover_table(
+    client: ClickhouseClient,
+    table_name: str,
+    columns: List[Tuple[str, str]],
+    order_by: str,
+    partition_by: Optional[str],
+    disk_name: str,
+    broken_columns: Optional[Set[str]] = None,
+) -> None:
+    """
+    Create the scratch MergeTree table ``_chadmin_recover.<table_name>``.
+
+    Always uses plain ``MergeTree`` (never Replicated) on *disk_name*.
+
+    Columns listed in *broken_columns* are excluded from the schema so that
+    ``ATTACH PART`` does not try to read their (deleted) ``.bin`` / ``.mrk2``
+    files.  Such columns will be substituted with ``NULL`` in the SELECT.
+    """
+    broken_columns = broken_columns or set()
+    _validate_broken_columns_not_in_keys(order_by, partition_by, broken_columns)
+
+    healthy_columns = [(n, t) for n, t in columns if n not in broken_columns]
+    if not healthy_columns:
+        raise RuntimeError(
+            "Cannot create scratch recovery table: all columns are broken. "
+            "There is no healthy data left to attach."
+        )
+    col_defs = ",\n    ".join(f"`{name}` {typ}" for name, typ in healthy_columns)
+    partition_clause = f"\nPARTITION BY {partition_by}" if partition_by else ""
+    sql = (
+        f"CREATE TABLE `{_RECOVER_DB}`.`{table_name}` (\n"
+        f"    {col_defs}\n"
+        f")\n"
+        f"ENGINE = MergeTree\n"
+        f"ORDER BY {order_by}"
+        f"{partition_clause}\n"
+        f"SETTINGS disk = '{disk_name}'"
+    )
+    logging.debug("Creating scratch table:\n{}", sql)
+    client.query(sql)
+
+
+def _validate_broken_columns_not_in_keys(
+    order_by: str,
+    partition_by: Optional[str],
+    broken_columns: Set[str],
+) -> None:
+    """Reject recovery plans where a broken column is used by table keys."""
+    if not broken_columns:
+        return
+
+    expressions = [("ORDER BY", order_by)]
+    if partition_by:
+        expressions.append(("PARTITION BY", partition_by))
+
+    offending: List[str] = []
+    for clause_name, expression in expressions:
+        for column in sorted(broken_columns):
+            if _expression_references_column(expression, column):
+                offending.append(f"{column} in {clause_name} {expression}")
+
+    if offending:
+        raise RuntimeError(
+            "Cannot recover part because broken columns are used by table keys: "
+            + "; ".join(offending)
+        )
+
+
+def _expression_references_column(expression: str, column: str) -> bool:
+    """Return True if *expression* references *column* as an identifier."""
+    backtick_pattern = rf"`{re.escape(column)}`"
+    bare_pattern = rf"(?<![A-Za-z0-9_]){re.escape(column)}(?![A-Za-z0-9_])"
+    return bool(
+        re.search(backtick_pattern, expression) or re.search(bare_pattern, expression)
+    )
+
+
+def drop_recover_table(client: ClickhouseClient, table_name: str) -> None:
+    """Drop the scratch table ``_chadmin_recover.<table_name>`` (best-effort)."""
+    try:
+        client.query(f"DROP TABLE IF EXISTS `{_RECOVER_DB}`.`{table_name}`")
+        logging.info("Dropped scratch table {}.{}", _RECOVER_DB, table_name)
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.warning(
+            "Failed to drop scratch table {}.{}: {}", _RECOVER_DB, table_name, exc
+        )
+
+
+def place_part_in_detached(
+    assembled_dir: Path,
+    part_name: str,
+    disk_data_path: str,
+) -> Path:
+    """
+    Move the assembled part directory into the scratch table's ``detached/``
+    directory on the local disk.
+
+    *disk_data_path* is the table data path returned by
+    ``get_table_data_path()`` (i.e. already includes the UUID store path).
+
+    The placed files are chown'd to the owner of the parent ``detached/``
+    directory so that the ClickHouse server (which runs as ``clickhouse``
+    user) can read them after ``ATTACH PART``.
+
+    Returns the destination path.
+    """
+    clean_name = _strip_broken_prefix(part_name)
+    detached_dir = Path(disk_data_path) / "detached"
+    detached_dir.mkdir(parents=True, exist_ok=True)
+    dest = detached_dir / clean_name
+    if dest.exists():
+        shutil.rmtree(str(dest))
+    shutil.copytree(str(assembled_dir), str(dest))
+
+    # Lchown destination tree to match the ``detached/`` directory owner
+    # (the ClickHouse server user).  Use os.lchown (not os.chown) so that
+    # symlinks themselves are chown'd rather than their targets.
+    # If we cannot chown (non-root or platform without chown), continue
+    # silently — ClickHouse will fail later with a clear permission error.
+    try:
+        st = detached_dir.stat()
+        target_uid, target_gid = st.st_uid, st.st_gid
+        for root, dirs, files in os.walk(str(dest)):
+            os.lchown(root, target_uid, target_gid)
+            for d in dirs:
+                os.lchown(os.path.join(root, d), target_uid, target_gid)
+            for f in files:
+                os.lchown(os.path.join(root, f), target_uid, target_gid)
+    except (PermissionError, OSError) as exc:
+        logging.warning(
+            "Could not lchown placed part {} to ClickHouse user: {}",
+            dest,
+            exc,
+        )
+
+    logging.info("Placed part '{}' in detached: {}", clean_name, dest)
+    return dest
+
+
+def get_table_data_path(client: ClickhouseClient, table_name: str) -> str:
+    """
+    Return the first data path of ``_chadmin_recover.<table_name>``
+    from ``system.tables``.
+    """
+    db_esc = _RECOVER_DB.replace("'", "\\'")
+    tbl_esc = table_name.replace("'", "\\'")
+    rows = client.query_json_data(
+        f"SELECT data_paths[1] FROM system.tables "
+        f"WHERE database = '{db_esc}' AND name = '{tbl_esc}'",
+    )
+    if not rows:
+        raise RuntimeError(
+            f"Cannot find data path for {_RECOVER_DB}.{table_name} in system.tables."
+        )
+    return str(rows[0][0]).rstrip("/")
+
+
+# Regex for valid MergeTree part names: <partition>_<min>_<max>_<level>[_<mutation>]
+# Only alphanumeric characters and underscores are allowed.
+_PART_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def attach_part(client: ClickhouseClient, table_name: str, part_name: str) -> None:
+    """Run ``ALTER TABLE _recover_<rand> ATTACH PART '<part_name>'``.
+
+    *part_name* is validated against a strict regex before being embedded in
+    the SQL string to prevent SQL injection via crafted part directory names.
+    """
+    clean_name = _strip_broken_prefix(part_name)
+    if not _PART_NAME_RE.match(clean_name):
+        raise ValueError(
+            f"Part name '{clean_name}' contains unexpected characters. "
+            "Expected only alphanumeric characters and underscores."
+        )
+    # Single-quote the part name; the regex above guarantees no embedded quotes.
+    sql = f"ALTER TABLE `{_RECOVER_DB}`.`{table_name}` ATTACH PART '{clean_name}'"
+    logging.info("Attaching part '{}' to scratch table …", clean_name)
+    client.query(sql)
+
+
+# ---------------------------------------------------------------------------
+# SELECT → TSV
+# ---------------------------------------------------------------------------
+
+
+def build_select_sql(
+    columns: List[Tuple[str, str]],
+    broken_columns: Set[str],
+    table_name: str,
+) -> str:
+    """
+    Build a SELECT statement that substitutes NULL for broken columns.
+
+    Broken columns are cast to ``Nullable(<original_type>)`` so that the TSV
+    output contains ``\\N`` for those fields.
+    """
+    select_parts: List[str] = []
+    for name, typ in columns:
+        if name in broken_columns:
+            inner_type = typ
+            m = re.match(r"^Nullable\((.+)\)$", typ)
+            if m:
+                inner_type = m.group(1)
+            select_parts.append(f"CAST(NULL AS Nullable({inner_type})) AS `{name}`")
+        else:
+            select_parts.append(f"`{name}`")
+
+    select_clause = ",\n    ".join(select_parts)
+    return (
+        f"SELECT\n"
+        f"    {select_clause}\n"
+        f"FROM `{_RECOVER_DB}`.`{table_name}`\n"
+        f"FORMAT TSV"
+    )
+
+
+def select_to_tsv(
+    client: ClickhouseClient,
+    columns: List[Tuple[str, str]],
+    broken_columns: Set[str],
+    table_name: str,
+    output_path: Path,
+) -> int:
+    """
+    Execute SELECT and stream TSV output to *output_path*.
+
+    Returns the number of rows written.
+    """
+    sql = build_select_sql(columns, broken_columns, table_name)
+    logging.debug("SELECT SQL:\n{}", sql)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Use streaming HTTP response to avoid loading all data into memory
+    response = client.query(sql, stream=True)
+
+    rows = 0
+    with output_path.open("wb") as fh:
+        for chunk in response.iter_content(chunk_size=65536):
+            if chunk:
+                fh.write(chunk)
+                rows += chunk.count(b"\n")
+
+    logging.info("Wrote {} rows to {}", rows, output_path)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Column labels for report
+# ---------------------------------------------------------------------------
+
+
+def build_tsv_column_labels(
+    columns: List[Tuple[str, str]],
+    broken_columns: Set[str],
+) -> List[str]:
+    """
+    Return a list of column labels for the TSV header in the report.
+
+    Broken columns are annotated with ``(NULL)``.
+    """
+    labels: List[str] = []
+    for name, _ in columns:
+        if name in broken_columns:
+            labels.append(f"{name} (NULL)")
+        else:
+            labels.append(name)
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# High-level runner
+# ---------------------------------------------------------------------------
+
+
+def run_server_recovery(
+    client: ClickhouseClient,
+    part_path: Path,
+    assembled_dir: Path,
+    broken_columns: Set[str],
+    output_path: Path,
+    columns_txt: Path,
+) -> Tuple[int, List[str]]:
+    """
+    Full server-side recovery flow.
+
+    1. Resolve source table → live schema → merged schema.
+    2. Create scratch table on local disk.
+    3. Place assembled part in detached/.
+    4. ATTACH PART.
+    5. SELECT → TSV.
+    6. DROP scratch table (always, in finally).
+
+    Returns ``(rows_written, tsv_column_labels)``.
+    """
+    part_name = part_path.name
+
+    # ── Step 1: Resolve table and schema ─────────────────────────────────────
+    columns_from_txt = parse_columns_txt(columns_txt)
+
+    database: Optional[str] = None
+    table: Optional[str] = None
+    live_schema: List[Tuple[str, str]] = []
+
+    try:
+        database, table = resolve_table_from_path(client, part_path)
+        logging.info("Resolved source table: {}.{}", database, table)
+        live_schema = get_live_schema(client, database, table)
+    except RuntimeError as exc:
+        logging.warning("Could not resolve source table: {}. Using columns.txt.", exc)
+
+    columns = merge_schemas(live_schema, columns_from_txt)
+
+    # ── Step 2: Get ORDER BY / PARTITION BY ───────────────────────────────────
+    order_by = "tuple()"
+    partition_by: Optional[str] = None
+
+    if live_schema and database and table:
+        db_esc = database.replace("'", "\\'")
+        tbl_esc = table.replace("'", "\\'")
+        rows = client.query_json_data(
+            f"SELECT create_table_query FROM system.tables "
+            f"WHERE database = '{db_esc}' AND name = '{tbl_esc}'",
+        )
+        if rows:
+            ddl = str(rows[0][0])
+            order_by = parse_order_by(ddl)
+            partition_by = parse_partition_by(ddl)
+            logging.info(
+                "Using ORDER BY '{}', PARTITION BY '{}'", order_by, partition_by
+            )
+
+    # ── Step 3: Find local disk ───────────────────────────────────────────────
+    disk_name = find_local_disk(client)
+    logging.info("Using local disk '{}' for scratch table", disk_name)
+
+    # ── Step 4: Create scratch table ──────────────────────────────────────────
+    rand_suffix = secrets.token_hex(4)
+    scratch_table = f"_recover_{rand_suffix}"
+
+    create_recover_db(client)
+    create_recover_table(
+        client,
+        scratch_table,
+        columns,
+        order_by,
+        partition_by,
+        disk_name,
+        broken_columns=broken_columns,
+    )
+    logging.info("Created scratch table {}.{}", _RECOVER_DB, scratch_table)
+
+    try:
+        # ── Step 5: Place part in detached/ ───────────────────────────────────
+        table_data_path = get_table_data_path(client, scratch_table)
+        place_part_in_detached(assembled_dir, part_name, table_data_path)
+
+        # ── Step 6: ATTACH PART ───────────────────────────────────────────────
+        attach_part(client, scratch_table, part_name)
+
+        # ── Step 7: SELECT → TSV ──────────────────────────────────────────────
+        rows = select_to_tsv(
+            client, columns, broken_columns, scratch_table, output_path
+        )
+
+        tsv_labels = build_tsv_column_labels(columns, broken_columns)
+        return rows, tsv_labels
+
+    finally:
+        drop_recover_table(client, scratch_table)
+
+
+# ---------------------------------------------------------------------------
+# Disk-level path helpers (used by tests / integration)
+# ---------------------------------------------------------------------------
+
+
+def get_disk_names_by_type(client: ClickhouseClient) -> Dict[str, str]:
+    """Return ``{disk_name: disk_type}`` for all disks."""
+    rows = client.query_json_data("SELECT name, type FROM system.disks")
+    return {str(r[0]): str(r[1]) for r in rows}

--- a/tests/features/chadmin_part_recovery.feature
+++ b/tests/features/chadmin_part_recovery.feature
@@ -1,0 +1,239 @@
+Feature: chadmin part recover-broken
+
+  Background:
+    Given default configuration
+    And a working S3
+    And a working zookeeper
+    And a working clickhouse on clickhouse01
+
+  Scenario: Recover Wide part with one missing data column blob
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery;
+    CREATE TABLE default.test_recovery (
+        id     UInt64,
+        ts     DateTime,
+        value  String,
+        extra  UInt32
+    )
+    ENGINE = MergeTree
+    ORDER BY (id, ts)
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+    INSERT INTO default.test_recovery
+    SELECT
+        number AS id,
+        now() + number AS ts,
+        concat('val_', toString(number)) AS value,
+        toUInt32(number * 2) AS extra
+    FROM numbers(1000);
+    OPTIMIZE TABLE default.test_recovery FINAL;
+    """
+    Given we corrupt column value blobs of part of table default.test_recovery on clickhouse01
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/recovered.tsv --report /tmp/report.json 2>&1; echo "EXIT_CODE:$?"'
+    """
+    Then we get response contains
+    """
+    EXIT_CODE:0
+    """
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'wc -l < /tmp/recovered.tsv | tr -d " \n"'
+    """
+    Then we get response
+    """
+    1000
+    """
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'python3 -c "import json; d=json.load(open(\"/tmp/report.json\")); print(\"value\" in d[\"broken_columns\"])"'
+    """
+    Then we get response
+    """
+    True
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery;
+    """
+
+  Scenario: Dry-run mode does not create output file
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_dry;
+    CREATE TABLE default.test_recovery_dry (
+        id    UInt64,
+        value String
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+    INSERT INTO default.test_recovery_dry
+    SELECT number, concat('v', toString(number)) FROM numbers(100);
+    OPTIMIZE TABLE default.test_recovery_dry FINAL;
+    """
+    Given we corrupt column value blobs of part of table default.test_recovery_dry on clickhouse01
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'rm -f /tmp/dry_run_out.tsv && chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/dry_run_out.tsv --dry-run'
+    """
+    Then it completes successfully
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'test ! -f /tmp/dry_run_out.tsv && echo NOT_EXISTS || echo EXISTS'
+    """
+    Then we get response
+    """
+    NOT_EXISTS
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_dry;
+    """
+
+  Scenario: Missing columns.txt causes exit code 2
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_critical;
+    CREATE TABLE default.test_recovery_critical (
+        id    UInt64,
+        value String
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+    INSERT INTO default.test_recovery_critical
+    SELECT number, concat('v', toString(number)) FROM numbers(50);
+    OPTIMIZE TABLE default.test_recovery_critical FINAL;
+    """
+    Given we corrupt column value blobs of part of table default.test_recovery_critical on clickhouse01
+    When we execute command on clickhouse01
+    """
+    bash -c 'rm -f "$(cat /tmp/broken_part_path)/columns.txt"'
+    """
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/critical_out.tsv; echo "EXIT:$?"'
+    """
+    Then we get response contains
+    """
+    EXIT:2
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_critical;
+    """
+
+  Scenario: All blobs healthy — full recovery without NULL columns
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_full;
+    CREATE TABLE default.test_recovery_full (
+        id    UInt64,
+        value String
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+    INSERT INTO default.test_recovery_full
+    SELECT number, concat('v', toString(number)) FROM numbers(200);
+    OPTIMIZE TABLE default.test_recovery_full FINAL;
+    """
+    Given we copy part of table default.test_recovery_full to detached on clickhouse01
+    When we execute command on clickhouse01
+    """
+    bash -c 'chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/full_recovered.tsv --report /tmp/full_report.json'
+    """
+    Then it completes successfully
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'wc -l < /tmp/full_recovered.tsv | tr -d " \n"'
+    """
+    Then we get response
+    """
+    200
+    """
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'python3 -c "import json; d=json.load(open(\"/tmp/full_report.json\")); print(d[\"broken_columns\"])"'
+    """
+    Then we get response
+    """
+    []
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_recovery_full;
+    """
+
+  Scenario: Compact part with healthy data.bin — full recovery
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_compact_recovery;
+    CREATE TABLE default.test_compact_recovery (
+        id    UInt64,
+        value String
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 9223372036854775807, min_rows_for_wide_part = 9223372036854775807;
+    INSERT INTO default.test_compact_recovery
+    SELECT number, concat('v', toString(number)) FROM numbers(100);
+    OPTIMIZE TABLE default.test_compact_recovery FINAL;
+    """
+    Given we copy part of table default.test_compact_recovery to detached on clickhouse01
+    When we execute command on clickhouse01
+    """
+    bash -c 'chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/compact_recovered.tsv --report /tmp/compact_report.json'
+    """
+    Then it completes successfully
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'wc -l < /tmp/compact_recovered.tsv | tr -d " \n"'
+    """
+    Then we get response
+    """
+    100
+    """
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'python3 -c "import json; d=json.load(open(\"/tmp/compact_report.json\")); print(len(d[\"broken_columns\"]))"'
+    """
+    Then we get response
+    """
+    0
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_compact_recovery;
+    """
+
+  Scenario: Compact part with missing data.bin blobs — exit code 2
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_compact_critical;
+    CREATE TABLE default.test_compact_critical (
+        id    UInt64,
+        value String
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS storage_policy = 'object_storage', min_bytes_for_wide_part = 9223372036854775807, min_rows_for_wide_part = 9223372036854775807;
+    INSERT INTO default.test_compact_critical
+    SELECT number, concat('v', toString(number)) FROM numbers(50);
+    OPTIMIZE TABLE default.test_compact_critical FINAL;
+    """
+    Given we corrupt data.bin blobs of part of table default.test_compact_critical on clickhouse01
+    When we try to execute command on clickhouse01
+    """
+    bash -c 'chadmin part recover-broken --part-path "$(cat /tmp/broken_part_path)" --output /tmp/compact_critical.tsv; echo "EXIT:$?"'
+    """
+    Then we get response contains
+    """
+    EXIT:2
+    """
+    Given we have executed queries on clickhouse01
+    """
+    DROP TABLE IF EXISTS default.test_compact_critical;
+    """

--- a/tests/features/chadmin_part_recovery.feature
+++ b/tests/features/chadmin_part_recovery.feature
@@ -95,7 +95,7 @@ Feature: chadmin part recover-broken
     """
 
   @require_version_23.3
-  Scenario: Missing columns.txt causes exit code 2
+  Scenario: Missing columns.txt is reconstructed from system.columns
     Given we have executed queries on clickhouse01
     """
     DROP TABLE IF EXISTS default.test_recovery_critical;
@@ -121,7 +121,15 @@ Feature: chadmin part recover-broken
     """
     Then we get response contains
     """
-    EXIT:2
+    EXIT:0
+    """
+    And we get response contains
+    """
+    Reconstructed columns.txt for part
+    """
+    And we get response contains
+    """
+    system.columns
     """
     Given we have executed queries on clickhouse01
     """

--- a/tests/features/chadmin_part_recovery.feature
+++ b/tests/features/chadmin_part_recovery.feature
@@ -6,6 +6,7 @@ Feature: chadmin part recover-broken
     And a working zookeeper
     And a working clickhouse on clickhouse01
 
+  @require_version_23.3
   Scenario: Recover Wide part with one missing data column blob
     Given we have executed queries on clickhouse01
     """
@@ -58,6 +59,7 @@ Feature: chadmin part recover-broken
     DROP TABLE IF EXISTS default.test_recovery;
     """
 
+  @require_version_23.3
   Scenario: Dry-run mode does not create output file
     Given we have executed queries on clickhouse01
     """
@@ -92,6 +94,7 @@ Feature: chadmin part recover-broken
     DROP TABLE IF EXISTS default.test_recovery_dry;
     """
 
+  @require_version_23.3
   Scenario: Missing columns.txt causes exit code 2
     Given we have executed queries on clickhouse01
     """
@@ -125,6 +128,7 @@ Feature: chadmin part recover-broken
     DROP TABLE IF EXISTS default.test_recovery_critical;
     """
 
+  @require_version_23.3
   Scenario: All blobs healthy — full recovery without NULL columns
     Given we have executed queries on clickhouse01
     """
@@ -167,6 +171,7 @@ Feature: chadmin part recover-broken
     DROP TABLE IF EXISTS default.test_recovery_full;
     """
 
+  @require_version_23.3
   Scenario: Compact part with healthy data.bin — full recovery
     Given we have executed queries on clickhouse01
     """
@@ -209,6 +214,7 @@ Feature: chadmin part recover-broken
     DROP TABLE IF EXISTS default.test_compact_recovery;
     """
 
+  @require_version_23.3
   Scenario: Compact part with missing data.bin blobs — exit code 2
     Given we have executed queries on clickhouse01
     """

--- a/tests/modules/clickhouse.py
+++ b/tests/modules/clickhouse.py
@@ -3,7 +3,7 @@ ClickHouse client.
 """
 
 from http import HTTPStatus
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 from hamcrest import assert_that
 from requests import HTTPError
@@ -13,6 +13,9 @@ from ch_tools.chadmin.internal.clickhouse_disks import (
     CLICKHOUSE_PATH,
     OBJECT_STORAGE_DISK_TYPES,
     S3_PATH,
+)
+from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
+    S3ObjectLocalMetaData,
 )
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.client.clickhouse_client import (
@@ -180,3 +183,101 @@ def check_table_exists_in_uuid_dir(
     table_path = path + "/store/" + table_uuid[:3] + "/" + table_uuid
     result = container.exec_run(["bash", "-c", f"ls {table_path}"], user="root")
     return True if 0 == result.exit_code else False
+
+
+# ---------------------------------------------------------------------------
+# Part recovery helpers
+# ---------------------------------------------------------------------------
+
+
+def get_part_path(context: ContextT, node: str, db: str, table: str) -> str:
+    """Return the filesystem path of the first active part of *table* in *db*.
+
+    Uses ``system.parts`` to find the path, then strips the trailing slash.
+    """
+    query = (
+        f"SELECT path FROM system.parts "
+        f"WHERE database='{db}' AND table='{table}' AND active=1 "
+        f"ORDER BY name LIMIT 1 FORMAT TabSeparated"
+    )
+    result = execute_query(context, node, query)
+    path = str(result).strip().rstrip("/")
+    assert path, f"No active parts found for {db}.{table} on {node}"
+    return path
+
+
+def detach_part_copy_as_broken(context: ContextT, node: str, part_path: str) -> str:
+    """Copy an active part directory into the table's *detached/* folder with a
+    ``broken_`` prefix and return the path to the broken copy.
+
+    *part_path* is the absolute path returned by :func:`get_part_path`.
+    """
+    import posixpath
+
+    part_name = posixpath.basename(part_path)
+    table_dir = posixpath.dirname(part_path)
+    detached_dir = posixpath.join(table_dir, "detached")
+    broken_name = f"broken_{part_name}"
+    broken_path = posixpath.join(detached_dir, broken_name)
+
+    container = docker.get_container(context, node)
+
+    # Ensure detached/ exists
+    result = container.exec_run(["bash", "-c", f"mkdir -p {detached_dir}"], user="root")
+    assert result.exit_code == 0, f"mkdir detached failed: {result.output.decode()}"
+
+    # Copy the active part
+    result = container.exec_run(
+        ["bash", "-c", f"cp -r {part_path} {broken_path}"], user="root"
+    )
+    assert result.exit_code == 0, f"cp part failed: {result.output.decode()}"
+
+    return broken_path
+
+
+def list_column_files(
+    context: ContextT, node: str, part_path: str, column: str
+) -> List[str]:
+    """Return a list of absolute file paths inside *part_path* that belong to
+    *column* (i.e. whose basename starts with ``<column>.`` or ``<column>_``).
+    """
+    container = docker.get_container(context, node)
+    result = container.exec_run(["bash", "-c", f"ls {part_path}/"], user="root")
+    assert result.exit_code == 0, f"ls part dir failed: {result.output.decode()}"
+
+    files = []
+    for name in result.output.decode().split():
+        name = name.strip()
+        if name.startswith(f"{column}.") or name.startswith(f"{column}_"):
+            files.append(f"{part_path}/{name}")
+    return files
+
+
+def read_s3_metadata_keys(
+    context: ContextT, node: str, file_path: str, s3_prefix: str
+) -> List[str]:
+    """Read an S3 metadata file from the container and return the list of full
+    S3 object keys referenced by it.
+
+    *s3_prefix* is the path prefix to prepend for metadata versions < 5
+    (e.g. ``"data/cid1/shard_1/"``).
+    """
+    container = docker.get_container(context, node)
+    result = container.exec_run(["bash", "-c", f"cat {file_path}"], user="root")
+    if result.exit_code != 0:
+        return []
+
+    content = result.output.decode("latin-1")
+    try:
+        meta = S3ObjectLocalMetaData.from_string(content)
+    except (ValueError, IndexError):
+        # Not a metadata file (plain text like columns.txt)
+        return []
+
+    keys: List[str] = []
+    for obj in meta.objects:
+        if obj.key_is_full:
+            keys.append(obj.key)
+        else:
+            keys.append(s3_prefix.rstrip("/") + "/" + obj.key)
+    return keys

--- a/tests/steps/chadmin.py
+++ b/tests/steps/chadmin.py
@@ -2,8 +2,10 @@
 Steps for interacting with chadmin.
 """
 
-from behave import then, when
+from behave import given, then, when
 from hamcrest import assert_that, equal_to
+from modules import clickhouse as ch_module
+from modules import s3 as s3_module
 from modules.chadmin import Chadmin
 from modules.docker import get_container
 from modules.typing import ContextT
@@ -111,3 +113,122 @@ def step_check_dict_values(context: ContextT, dict_name: str, node: str) -> None
 
     if errors:
         raise AssertionError("\n".join(errors))
+
+
+@given("we corrupt column {column} blobs of part of table {db}.{table} on {node:w}")
+def step_corrupt_column_blobs(
+    context: ContextT, column: str, db: str, table: str, node: str
+) -> None:
+    """Copy the first active part of *db*.*table* into detached/broken_<part>,
+    then delete all S3 blobs referenced by files belonging to *column*.
+
+    After this step ``context.broken_part_path`` is set to the path of the
+    broken copy so that subsequent steps can pass it to ``chadmin``.
+    """
+    # S3 key prefix used by the object_storage disk (see config.xml)
+    s3_prefix = "data/cluster_id/shard_1"
+
+    # 1. Find the active part path
+    part_path = ch_module.get_part_path(context, node, db, table)
+
+    # 2. Copy it to detached/broken_<part>
+    broken_path = ch_module.detach_part_copy_as_broken(context, node, part_path)
+
+    # 3. Find all files belonging to the column inside the broken copy
+    col_files = ch_module.list_column_files(context, node, broken_path, column)
+    assert col_files, f"No files found for column '{column}' in {broken_path}"
+
+    # 4. For each file, parse S3 metadata and delete the referenced blobs
+    s3_client = s3_module.S3Client(context)
+    deleted = 0
+    for file_path in col_files:
+        keys = ch_module.read_s3_metadata_keys(context, node, file_path, s3_prefix)
+        for key in keys:
+            s3_client.delete_data(key)
+            deleted += 1
+
+    assert deleted > 0, (
+        f"No S3 blobs were deleted for column '{column}' — "
+        f"check that the files are S3 metadata files"
+    )
+
+    # 5. Store the broken part path for use in subsequent steps
+    context.broken_part_path = broken_path
+
+    # Also write it to a file inside the container so bash commands in the
+    # feature can reference it via $(cat /tmp/broken_part_path)
+    _write_broken_part_path(context, node, broken_path)
+
+
+@given("we copy part of table {db}.{table} to detached on {node:w}")
+def step_copy_part_to_detached(
+    context: ContextT, db: str, table: str, node: str
+) -> None:
+    """Copy the first active part of *db*.*table* into detached/broken_<part>
+    **without** deleting any S3 blobs.  Used to test the "all blobs healthy"
+    recovery path.
+
+    After this step ``context.broken_part_path`` is set and
+    ``/tmp/broken_part_path`` is written inside the container.
+    """
+    part_path = ch_module.get_part_path(context, node, db, table)
+    broken_path = ch_module.detach_part_copy_as_broken(context, node, part_path)
+    context.broken_part_path = broken_path
+    _write_broken_part_path(context, node, broken_path)
+
+
+@given("we corrupt data.bin blobs of part of table {db}.{table} on {node:w}")
+def step_corrupt_data_bin_blobs(
+    context: ContextT, db: str, table: str, node: str
+) -> None:
+    """Copy the first active part of *db*.*table* into detached/broken_<part>,
+    then delete all S3 blobs referenced by the ``data.bin`` file (Compact format).
+
+    After this step ``context.broken_part_path`` is set to the path of the
+    broken copy so that subsequent steps can pass it to ``chadmin``.
+    """
+    # S3 key prefix used by the object_storage disk (see config.xml)
+    s3_prefix = "data/cluster_id/shard_1"
+
+    # 1. Find the active part path
+    part_path = ch_module.get_part_path(context, node, db, table)
+
+    # 2. Copy it to detached/broken_<part>
+    broken_path = ch_module.detach_part_copy_as_broken(context, node, part_path)
+
+    # 3. Find the data.bin file inside the broken copy
+    data_bin_path = f"{broken_path}/data.bin"
+
+    # 4. Parse S3 metadata and delete the referenced blobs
+    s3_client = s3_module.S3Client(context)
+    keys = ch_module.read_s3_metadata_keys(context, node, data_bin_path, s3_prefix)
+    assert keys, f"No S3 metadata found in {data_bin_path} — check that it is a Compact part"
+
+    deleted = 0
+    for key in keys:
+        s3_client.delete_data(key)
+        deleted += 1
+
+    assert deleted > 0, (
+        f"No S3 blobs were deleted for data.bin — "
+        f"check that the file is an S3 metadata file"
+    )
+
+    # 5. Store the broken part path for use in subsequent steps
+    context.broken_part_path = broken_path
+
+    # Also write it to a file inside the container so bash commands in the
+    # feature can reference it via $(cat /tmp/broken_part_path)
+    _write_broken_part_path(context, node, broken_path)
+
+
+def _write_broken_part_path(context: ContextT, node: str, broken_path: str) -> None:
+    """Write *broken_path* to ``/tmp/broken_part_path`` inside the container."""
+    container = get_container(context, node)
+    result = container.exec_run(
+        ["bash", "-c", f"printf '%s' '{broken_path}' > /tmp/broken_part_path"],
+        user="root",
+    )
+    assert (
+        result.exit_code == 0
+    ), f"Failed to write broken_part_path to container: {result.output.decode()}"

--- a/tests/steps/chadmin.py
+++ b/tests/steps/chadmin.py
@@ -202,7 +202,9 @@ def step_corrupt_data_bin_blobs(
     # 4. Parse S3 metadata and delete the referenced blobs
     s3_client = s3_module.S3Client(context)
     keys = ch_module.read_s3_metadata_keys(context, node, data_bin_path, s3_prefix)
-    assert keys, f"No S3 metadata found in {data_bin_path} — check that it is a Compact part"
+    assert (
+        keys
+    ), f"No S3 metadata found in {data_bin_path} — check that it is a Compact part"
 
     deleted = 0
     for key in keys:
@@ -210,8 +212,8 @@ def step_corrupt_data_bin_blobs(
         deleted += 1
 
     assert deleted > 0, (
-        f"No S3 blobs were deleted for data.bin — "
-        f"check that the file is an S3 metadata file"
+        "No S3 blobs were deleted for data.bin — "
+        "check that the file is an S3 metadata file"
     )
 
     # 5. Store the broken part path for use in subsequent steps


### PR DESCRIPTION
## Summary by Sourcery

Introduce a CLI command and internal tooling to recover broken ClickHouse MergeTree parts stored on S3 and export their data to TSV, including health checks, reconstruction logic, and integration tests.

New Features:
- Add chadmin `part recover-broken` command to repair detached MergeTree parts using S3 metadata and output recovered data as TSV.
- Implement a part recovery pipeline that classifies S3-backed part files, checks blob health, reconstructs missing metadata, and uses a running ClickHouse server to read recovered data.
- Provide JSON recovery reports summarizing missing blobs, broken columns, reconstructed files, and recovered row counts.

Enhancements:
- Add helpers to resolve part ownership, build temporary scratch tables on local disks, and safely attach recovered parts for data extraction via ClickHouse.
- Extend test ClickHouse helpers and Behave steps to manipulate parts and S3 blobs for recovery scenarios, including Wide and Compact part formats.

Tests:
- Add end-to-end BDD scenarios covering wide and compact parts, dry-run mode, critical metadata loss handling, and full/partial recovery outcomes.
- Introduce test utilities for corrupting column and data.bin blobs, copying parts to detached directories, and validating recovered output and reports.