### PR TITLE
Added retries to `chadmin partition`

### DIFF
--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import shutil
 import subprocess
@@ -30,6 +31,7 @@ from ch_tools.common.clickhouse.client import OutputFormat
 from ch_tools.common.clickhouse.config import get_clickhouse_config
 from ch_tools.common.clickhouse.config.storage_configuration import S3DiskConfiguration
 from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
+from ch_tools.common.utils import retry_fn
 
 ATTACH_DETTACH_TIMEOUT = 5000
 ATTACH_DETACH_QUERY_RETRY = 10
@@ -514,36 +516,19 @@ def print_partitions(ctx: Context, repaired_partitions: Set[TablePartition]) -> 
     print_response(ctx, result, default_format="table")
 
 
-def query_with_retry(ctx: Context, query: str, timeout: int, retries: int) -> bool:
-    """
-    Execute clickhouse query with given number of retries.
-    """
-    logging.debug("Execute query: {}", query)
-    for retry in range(retries):
-        try:
-            res = execute_query(ctx, query, timeout=timeout)
-            if res == "":
-                break
-        except Exception as e:
-            if retry + 1 == retries:
-                logging.warning("Query {} failed  with:  {!r}\n", query, e)
-                return False
-            continue
-
-    logging.info("Query {} finished successfully", query)
-    return True
-
-
 def detach_partition(ctx: Context, table_partition: TablePartition) -> bool:
     """
     Run DETACH the partition.
     """
 
     detach_query = f"ALTER TABLE {table_partition.table} DETACH PARTITION '{table_partition.partition}'"
-    return query_with_retry(
-        ctx,
-        detach_query,
-        timeout=ATTACH_DETTACH_TIMEOUT,
+    return retry_fn(
+        functools.partial(
+            execute_query,
+            ctx,
+            detach_query,
+            timeout=ATTACH_DETTACH_TIMEOUT,
+        ),
         retries=ATTACH_DETACH_QUERY_RETRY,
     )
 
@@ -552,12 +537,14 @@ def attach_partition(ctx: Context, table_partition: TablePartition) -> bool:
     """
     Run ATTACH the partition.
     """
-
     attach_query = f"ALTER TABLE {table_partition.table} ATTACH PARTITION '{table_partition.partition}'"
     # To avoid keeping detached partitions, perform the attach query with double attempts.
-    return query_with_retry(
-        ctx,
-        attach_query,
-        timeout=ATTACH_DETTACH_TIMEOUT,
+    return retry_fn(
+        functools.partial(
+            execute_query,
+            ctx,
+            attach_query,
+            timeout=ATTACH_DETTACH_TIMEOUT,
+        ),
         retries=2 * ATTACH_DETACH_QUERY_RETRY,
     )

--- a/ch_tools/chadmin/cli/partition_group.py
+++ b/ch_tools/chadmin/cli/partition_group.py
@@ -1,4 +1,5 @@
 # pylint: disable=too-many-lines
+import functools
 import json
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
@@ -22,6 +23,7 @@ from ch_tools.common import logging
 from ch_tools.common.cli.formatting import print_response
 from ch_tools.common.cli.parameters import BytesParamType
 from ch_tools.common.process_pool import WorkerTask, execute_tasks_in_parallel
+from ch_tools.common.utils import retry_fn
 
 
 @group("partition", cls=Chadmin)
@@ -197,6 +199,9 @@ def list_partitions_command(ctx: Context, **kwargs: Any) -> None:
     default=False,
     help="Enable dry run mode and do not perform any modifying actions.",
 )
+@option(
+    "-r", "--retries", "retries", default=3, help="Amount of retries before failing"
+)
 @pass_context
 def attach_partitions_command(
     ctx: Context,
@@ -206,6 +211,7 @@ def attach_partitions_command(
     partition_id: Optional[str],
     keep_going: bool,
     dry_run: bool,
+    retries: int,
     **kwargs: Any,
 ) -> None:
     """Attach one or several partitions."""
@@ -221,13 +227,23 @@ def attach_partitions_command(
     )["data"]
     for p in partitions:
         try:
-            attach_partition(
-                ctx,
-                database=p["database"],
-                table=p["table"],
-                partition_id=p["partition_id"],
-                dry_run=dry_run,
+            ok = retry_fn(
+                functools.partial(
+                    attach_partition,
+                    ctx,
+                    database=p["database"],
+                    table=p["table"],
+                    partition_id=p["partition_id"],
+                    dry_run=dry_run,
+                ),
+                retries=retries,
             )
+
+            if not ok:
+                raise RuntimeError(
+                    f"Failed to attach partition '{p['partition_id']}' "
+                    f"in '{p['database']}.{p['table']}' after {retries} retries."
+                )
         except Exception as e:
             if keep_going:
                 logging.warning("{!r}\n", e)
@@ -333,6 +349,9 @@ def attach_partitions_command(
     default=False,
     help="Enable dry run mode and do not perform any modifying actions.",
 )
+@option(
+    "-r", "--retries", "retries", default=3, help="Amount of retries before failing"
+)
 @pass_context
 def detach_partitions_command(
     ctx: Context,
@@ -349,6 +368,7 @@ def detach_partitions_command(
     replication_task_type_pattern: Optional[str],
     keep_going: bool,
     dry_run: bool,
+    retries: int,
     use_partition_list_from_json: Optional[str],
 ) -> None:
     """Detach one or several partitions."""
@@ -369,13 +389,23 @@ def detach_partitions_command(
     )["data"]
     for p in partitions:
         try:
-            detach_partition(
-                ctx,
-                database=p["database"],
-                table=p["table"],
-                partition_id=p["partition_id"],
-                dry_run=dry_run,
+            ok = retry_fn(
+                functools.partial(
+                    detach_partition,
+                    ctx,
+                    database=p["database"],
+                    table=p["table"],
+                    partition_id=p["partition_id"],
+                    dry_run=dry_run,
+                ),
+                retries=retries,
             )
+
+            if not ok:
+                raise RuntimeError(
+                    f"Failed to attach partition '{p['partition_id']}' "
+                    f"in '{p['database']}.{p['table']}' after {retries} retries."
+                )
         except Exception as e:
             if keep_going:
                 logging.warning("{!r}\n", e)
@@ -495,6 +525,9 @@ def detach_partitions_command(
     default=False,
     help="Enable dry run mode and do not perform any modifying actions.",
 )
+@option(
+    "-r", "--retries", "retries", default=3, help="Amount of retries before failing"
+)
 @pass_context
 def reattach_partitions_command(
     ctx: Context,
@@ -515,6 +548,7 @@ def reattach_partitions_command(
     keep_going: bool,
     limit_errors: int,
     dry_run: bool,
+    retries: int,
     use_partition_list_from_json: Optional[str],
 ) -> None:
     """Perform sequential attach and detach of one or several partitions."""
@@ -551,12 +585,39 @@ def reattach_partitions_command(
     failed_partitions = []
     for p in partitions:
         try:
-            detach_partition(
-                ctx, p["database"], p["table"], p["partition_id"], dry_run=dry_run
+            detach_ok = retry_fn(
+                functools.partial(
+                    detach_partition,
+                    ctx,
+                    database=p["database"],
+                    table=p["table"],
+                    partition_id=p["partition_id"],
+                    dry_run=dry_run,
+                ),
+                retries=retries,
             )
-            attach_partition(
-                ctx, p["database"], p["table"], p["partition_id"], dry_run=dry_run
+            if not detach_ok:
+                raise RuntimeError(
+                    f"Failed to detach partition '{p['partition_id']}' "
+                    f"in '{p['database']}.{p['table']}' after {retries} retries."
+                )
+
+            attach_ok = retry_fn(
+                functools.partial(
+                    attach_partition,
+                    ctx,
+                    database=p["database"],
+                    table=p["table"],
+                    partition_id=p["partition_id"],
+                    dry_run=dry_run,
+                ),
+                retries=2 * retries,
             )
+            if not attach_ok:
+                raise RuntimeError(
+                    f"Failed to attach partition '{p['partition_id']}' "
+                    f"in '{p['database']}.{p['table']}' after {2 * retries} retries."
+                )
         except Exception:
             error_count += 1
             failed_partitions.append(p)

--- a/ch_tools/common/utils.py
+++ b/ch_tools/common/utils.py
@@ -1,10 +1,13 @@
 import os
 import re
 import subprocess
+import time
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 from click import Context
+
+from ch_tools.common import logging
 
 
 def version_ge(version1: str, version2: str) -> bool:
@@ -189,3 +192,50 @@ def update_by_key_path(object_: dict[str, Any], key_path: str, value: Any) -> No
                 _update(obj[key], path, value, current_path_str)
 
     _update(object_, key_path.split("."), value, "")
+
+
+DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_SLEEP = 0
+DEFAULT_RETRY_TIMEOUT = 300
+
+
+def retry_fn(
+    fn: Callable,
+    retries: int = DEFAULT_RETRY_COUNT,
+    sleep: int = DEFAULT_RETRY_SLEEP,
+    timeout: int = DEFAULT_RETRY_TIMEOUT,
+    *args: Any,
+    **kwargs: Any,
+) -> bool:
+    for attempt in range(retries):
+        try:
+            res = fn(*args, **kwargs)
+            if res == "":
+                break
+        except Exception as e:
+            if attempt + 1 == retries:
+                logging.warning(
+                    "Fn '{}' failed after {} attempts with: {!r}",
+                    fn.__name__ if hasattr(fn, "__name__") else repr(fn),
+                    retries,
+                    e,
+                )
+                return False
+            logging.debug(
+                "Fn '{}' failed on attempt {}/{} with: {!r}, retrying in {}s...",
+                fn.__name__ if hasattr(fn, "__name__") else repr(fn),
+                attempt + 1,
+                retries,
+                e,
+                sleep,
+            )
+            if sleep != 0:
+                time.sleep(sleep)
+            continue
+
+    logging.info(
+        "Fn '{}' finished successfully",
+        fn.__name__ if hasattr(fn, "__name__") else repr(fn),
+    )
+
+    return True


### PR DESCRIPTION
## Summary by Sourcery

Add configurable retry handling to chadmin partition operations and centralize retry logic in a shared utility.

New Features:
- Introduce a configurable --retries option for attach, detach, and reattach partition CLI commands to control how many times operations are retried before failing.

Enhancements:
- Add a generic retry_fn helper with logging, optional sleep, and timeout parameters to standardize retry behavior across operations.
- Update partition attach, detach, and reattach flows to use the shared retry helper and surface clearer error messages when retries are exhausted.