### PR TITLE
Detect broken partitions

### DIFF
--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -1,11 +1,13 @@
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Set
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import boto3
 from boto3 import client as Boto3Client
+from botocore.exceptions import ClientError
 from click import Context, group, option, pass_context
 from cloup.constraints import AcceptAtMost, constraint
 
@@ -18,8 +20,11 @@ from ch_tools.chadmin.internal.clickhouse_disks import (
     make_ch_disks_config,
     remove_from_ch_disk,
 )
+from ch_tools.chadmin.internal.object_storage.part_file_classifier import (
+    UNRECOVERABLE,
+    classify_part,
+)
 from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
-    S3ObjectLocalInfo,
     S3ObjectLocalMetaData,
 )
 from ch_tools.chadmin.internal.system import get_version
@@ -372,8 +377,11 @@ def collect_orphaned_sql_objects_recursive(
 )
 @constraint(AcceptAtMost(1), ["detach", "reattach"])
 @pass_context
-def detect_broken_partitions(
-    ctx: Context, root_path: str, reattach: bool, detach: bool
+def detect_broken_partitions(  # pylint: disable=too-many-locals
+    ctx: Context,
+    root_path: str,
+    reattach: bool,
+    detach: bool,
 ) -> None:
     ch_config = get_clickhouse_config(ctx)
 
@@ -388,63 +396,100 @@ def detect_broken_partitions(
         aws_access_key_id=disk_conf.access_key_id,
         aws_secret_access_key=disk_conf.secret_access_key,
     )
-    repaired_partitions: Set[TablePartition] = set()
 
+    # Pass 1: walk the metadata tree, collect (part_path -> [(filename, key)])
+    parts: List[Tuple[str, List[Tuple[str, str]]]] = []
+    keys_to_check: Set[str] = set()
     for path, _, files in os.walk(root_path):
-        objects: List[S3ObjectLocalInfo] = []
-        logging.debug(f"Checking files from: {path}")
+        if not files:
+            continue
+        logging.debug("Checking files from: {}", path)
+        part_files: List[Tuple[str, str]] = []
         for file in files:
+            file_full_path = Path(os.path.join(path, file))
             try:
-                file_full_path = Path(os.path.join(path, file))
-                objects.extend(S3ObjectLocalMetaData.from_file(file_full_path).objects)
+                meta = S3ObjectLocalMetaData.from_file(file_full_path)
             except Exception as e:
-                logging.error("Failed to perform extend objects: {!r}", e)
-
-        for s3_object in objects:
-            if s3_object.key_is_full:
-                object_storage_key = s3_object.key
-            else:
-                object_storage_key = os.path.join(disk_conf.prefix, s3_object.key)
-
-            if check_key_in_object_storage(
-                s3_client, disk_conf.bucket_name, object_storage_key
-            ):
+                logging.error(
+                    "Failed to read S3 metadata for {}: {!r}", file_full_path, e
+                )
                 continue
-
-            logging.debug("Not found key {}", object_storage_key)
-
-            table_partition = get_partition_by_path(ctx, path)
-
-            if table_partition is None:
-                logging.warning("Skip failed path {}.", path)
-                break
-
-            if table_partition not in repaired_partitions:
-                repaired_partitions.add(table_partition)
-
-                logging.debug(
-                    "Found the partition with missing blob in the object storage: path={} table={} partition={} ",
-                    path,
-                    table_partition.table,
-                    table_partition.partition,
+            for obj in meta.objects:
+                key = (
+                    obj.key
+                    if obj.key_is_full
+                    else os.path.join(disk_conf.prefix, obj.key)
                 )
-                if detach:
-                    try_repair_partition(ctx, table_partition, False)
-                elif reattach:
-                    try_repair_partition(ctx, table_partition)
-            else:
-                logging.debug(
-                    "Partition {} for table {} was already repared. Skip.",
-                    table_partition.partition,
-                    table_partition.table,
-                )
+                rel = os.path.relpath(str(file_full_path), path)
+                part_files.append((rel, key))
+                keys_to_check.add(key)
+        if part_files:
+            parts.append((path, part_files))
 
-            break
+    # Pass 2: batch existence check for all unique keys (head_object + cache).
+    existing_keys = _check_keys_exist(s3_client, disk_conf.bucket_name, keys_to_check)
+
+    # Pass 3: per-part classification.
+    broken_parts: List[Dict[str, Any]] = []
+    for path, part_files in parts:
+        missing = [rel for rel, key in part_files if key not in existing_keys]
+        if not missing:
+            continue
+        table_partition = get_partition_by_path(ctx, path)
+        part_type = _get_part_type_by_path(ctx, path)
+        critical = _get_critical_columns(ctx, table_partition)
+        status = classify_part(missing, part_type=part_type, critical_columns=critical)
+        broken_parts.append(
+            {
+                "path": path,
+                "table": table_partition.table if table_partition else None,
+                "partition": table_partition.partition if table_partition else None,
+                "part_type": part_type,
+                "missing_files": missing,
+                "status": status,
+            }
+        )
+
+    # Pass 4: apply the requested action.
+    #   --detach   -> DETACH every broken part
+    #   --reattach -> DETACH+ATTACH only for parts that have a chance to
+    #                 be reattached cleanly. Reattaching an unrecoverable
+    #                 part just lands it in detached/broken-on-start_*.
+    repaired_partitions: Set[TablePartition] = set()
+    for part in broken_parts:
+        if part["table"] is None:
+            logging.warning("Skip failed path {}.", part["path"])
+            continue
+        table_partition = TablePartition(part["table"], part["partition"])
+        if table_partition in repaired_partitions:
+            continue
+        logging.debug(
+            "Broken part path={} table={} partition={} status={}",
+            part["path"],
+            table_partition.table,
+            table_partition.partition,
+            part["status"],
+        )
+        if detach:
+            repaired_partitions.add(table_partition)
+            try_repair_partition(ctx, table_partition, False)
+        elif reattach:
+            if part["status"] == UNRECOVERABLE:
+                logging.debug(
+                    "Skip --reattach for unrecoverable part {}.", part["path"]
+                )
+                continue
+            repaired_partitions.add(table_partition)
+            try_repair_partition(ctx, table_partition)
+        else:
+            # No flag — still surface the partition in the regular output.
+            repaired_partitions.add(table_partition)
 
     print_partitions(ctx, repaired_partitions)
 
     logging.debug(
-        "Found parts with missing s3 keys. Local paths of parts: {}",
+        "Found {} broken part(s); affected partitions: {}",
+        len(broken_parts),
         repaired_partitions,
     )
 
@@ -461,20 +506,75 @@ def try_repair_partition(
         attach_partition(ctx, table_partition)
 
 
-def check_key_in_object_storage(s3_client: Boto3Client, bucket: str, key: str) -> bool:
-    """
-    Check that object exists in s3 bucket with the specified key.
-    """
-    s3_resp = s3_client.list_objects_v2(
-        Bucket=bucket,
-        Prefix=key,
+def _check_keys_exist(s3_client: Boto3Client, bucket: str, keys: Set[str]) -> Set[str]:
+    """Return the subset of ``keys`` that actually exists in S3."""
+    existing: Set[str] = set()
+    for key in keys:
+        try:
+            s3_client.head_object(Bucket=bucket, Key=key)
+            existing.add(key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if code in ("404", "NoSuchKey", "NotFound") or status == 404:
+                continue
+            logging.warning(
+                "head_object failed for key={} bucket={}: {!r}", key, bucket, exc
+            )
+            # Treat ambiguous failures as "exists" so we don't trigger
+            # destructive actions on transient errors.
+            existing.add(key)
+    return existing
+
+
+def _get_part_type_by_path(ctx: Context, path: str) -> Optional[str]:
+    query = (
+        "SELECT part_type FROM system.parts "
+        f"WHERE path = '{path}/' AND active LIMIT 1"
     )
-    if "Contents" not in s3_resp:
-        return False
-    if len(s3_resp["Contents"]) != 1:
-        return False
-    res = s3_resp["Contents"][0]["Key"] == key
-    return res
+    res = execute_query(ctx, query, format_=OutputFormat.JSONCompact)
+    if not res.get("data"):
+        return None
+    return res["data"][0][0]
+
+
+def _get_critical_columns(
+    ctx: Context, table_partition: Optional["TablePartition"]
+) -> List[str]:
+    """Return columns participating in PARTITION BY / ORDER BY."""
+    if table_partition is None:
+        return []
+    # table_partition.table is already quoted as `db`.`name` — split it back.
+    try:
+        db, name = table_partition.table.strip("`").split("`.`")
+    except ValueError:
+        return []
+    query = (
+        "SELECT sorting_key, partition_key FROM system.tables "
+        f"WHERE database = '{db}' AND name = '{name}' LIMIT 1"
+    )
+    res = execute_query(ctx, query, format_=OutputFormat.JSONCompact)
+    if not res.get("data"):
+        return []
+    sorting_key, partition_key = res["data"][0]
+    return _extract_columns(sorting_key) + _extract_columns(partition_key)
+
+
+def _extract_columns(key_expression: str) -> List[str]:
+    """Extract bare column identifiers from a CH key expression.
+
+    Drops function names so e.g. ``cityHash64(a), b`` yields ``[a, b]``.
+    """
+    if not key_expression:
+        return []
+
+    tokens = re.findall(r"[A-Za-z_][A-Za-z0-9_]*", key_expression)
+    result: List[str] = []
+    for tok in tokens:
+        if re.search(r"\b" + re.escape(tok) + r"\s*\(", key_expression):
+            continue
+        result.append(tok)
+    return result
 
 
 def get_partition_by_path(ctx: Context, path: str) -> Optional[TablePartition]:

--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -500,6 +500,8 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals,too-many-branch
             )
             recovery_results.append(result)
             restored = result.reattached
+            if restored:
+                repaired_partitions.add(table_partition)
 
         if not restored:
             if part["status"] == UNRECOVERABLE and detach:

--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -9,7 +9,6 @@ import boto3
 from boto3 import client as Boto3Client
 from botocore.exceptions import ClientError
 from click import Context, group, option, pass_context
-from cloup.constraints import AcceptAtMost, constraint
 
 from ch_tools.chadmin.cli.chadmin_group import Chadmin
 from ch_tools.chadmin.internal.clickhouse_disks import (
@@ -21,12 +20,19 @@ from ch_tools.chadmin.internal.clickhouse_disks import (
     remove_from_ch_disk,
 )
 from ch_tools.chadmin.internal.object_storage.part_file_classifier import (
+    RECOVERABLE,
     UNRECOVERABLE,
     classify_part,
+)
+from ch_tools.chadmin.internal.object_storage.part_recovery import (
+    PartRecoveryResult,
+    get_part_recovery_context,
+    recover_part_files_locally,
 )
 from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
     S3ObjectLocalMetaData,
 )
+from ch_tools.chadmin.internal.part import attach_part, detach_part
 from ch_tools.chadmin.internal.system import get_version
 from ch_tools.chadmin.internal.utils import execute_query, remove_from_disk
 from ch_tools.common import logging
@@ -364,23 +370,28 @@ def collect_orphaned_sql_objects_recursive(
     help="Set the store subdirectory path.",
 )
 @option(
-    "--reattach",
+    "--restore-recoverable",
+    "restore_recoverable",
     is_flag=True,
     default=False,
-    help="Flag to reattach broken partitions.",
+    help=(
+        "For broken parts classified as recoverable, regenerate their "
+        "missing structural files via DETACH PART + recovery + ATTACH "
+        "PART. Compatible with --detach: unrecoverable parts are detached, "
+        "recoverable ones are restored."
+    ),
 )
 @option(
     "--detach",
     is_flag=True,
     default=False,
-    help="Flag to detach broken partitions.",
+    help="Detach unrecoverable broken parts (whole partitions).",
 )
-@constraint(AcceptAtMost(1), ["detach", "reattach"])
 @pass_context
-def detect_broken_partitions(  # pylint: disable=too-many-locals
+def detect_broken_partitions(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     ctx: Context,
     root_path: str,
-    reattach: bool,
+    restore_recoverable: bool,
     detach: bool,
 ) -> None:
     ch_config = get_clickhouse_config(ctx)
@@ -451,18 +462,19 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals
         )
 
     # Pass 4: apply the requested action.
-    #   --detach   -> DETACH every broken part
-    #   --reattach -> DETACH+ATTACH only for parts that have a chance to
-    #                 be reattached cleanly. Reattaching an unrecoverable
-    #                 part just lands it in detached/broken-on-start_*.
+    #   --restore-recoverable -> per-recoverable-part: DETACH PART, regenerate
+    #                            missing structural files, ATTACH PART.
+    #   --detach              -> DETACH (whole partition) for parts that did
+    #                            not get restored. Compatible with the flag
+    #                            above: restore is attempted first.
+    #   no flag               -> just report.
     repaired_partitions: Set[TablePartition] = set()
+    recovery_results: List[PartRecoveryResult] = []
     for part in broken_parts:
         if part["table"] is None:
             logging.warning("Skip failed path {}.", part["path"])
             continue
         table_partition = TablePartition(part["table"], part["partition"])
-        if table_partition in repaired_partitions:
-            continue
         logging.debug(
             "Broken part path={} table={} partition={} status={}",
             part["path"],
@@ -470,22 +482,37 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals
             table_partition.partition,
             part["status"],
         )
-        if detach:
-            repaired_partitions.add(table_partition)
-            try_repair_partition(ctx, table_partition, False)
-        elif reattach:
-            if part["status"] == UNRECOVERABLE:
-                logging.debug(
-                    "Skip --reattach for unrecoverable part {}.", part["path"]
-                )
-                continue
-            repaired_partitions.add(table_partition)
-            try_repair_partition(ctx, table_partition)
-        else:
-            # No flag — still surface the partition in the regular output.
-            repaired_partitions.add(table_partition)
+
+        restored = False
+        if restore_recoverable and part["status"] == RECOVERABLE:
+            result = _restore_recoverable_part(
+                ctx,
+                s3_client=s3_client,
+                bucket=disk_conf.bucket_name,
+                s3_prefix=disk_conf.prefix,
+                part_path=part["path"],
+                missing_files=part["missing_files"],
+            )
+            recovery_results.append(result)
+            restored = result.reattached
+
+        if not restored:
+            if part["status"] == UNRECOVERABLE and detach:
+                if table_partition not in repaired_partitions:
+                    repaired_partitions.add(table_partition)
+                    # Whole-partition DETACH as the last-resort fallback.
+                    # Reattach is intentionally not attempted — the part
+                    # would just land in detached/broken-on-start_* again.
+                    detach_partition(ctx, table_partition)
+            else:
+                # Still surface the partition so the operator sees it.
+                repaired_partitions.add(table_partition)
 
     print_partitions(ctx, repaired_partitions)
+
+    if recovery_results:
+        for r in recovery_results:
+            logging.info("Recovery result: {}", r.to_dict())
 
     logging.debug(
         "Found {} broken part(s); affected partitions: {}",
@@ -494,16 +521,88 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals
     )
 
 
-def try_repair_partition(
-    ctx: Context, table_partition: TablePartition, attach: bool = True
-) -> None:
-    """
-    Try to repair broken partition with DETACH and optional ATTACH.
-    """
-    detach_partition(ctx, table_partition)
+def _restore_recoverable_part(
+    ctx: Context,
+    *,
+    s3_client: Boto3Client,
+    bucket: str,
+    s3_prefix: str,
+    part_path: str,
+    missing_files: List[str],
+) -> PartRecoveryResult:
+    """DETACH PART → regenerate missing files → ATTACH PART."""
+    recovery_ctx = get_part_recovery_context(ctx, part_path)
+    result = PartRecoveryResult(
+        part_path=part_path,
+        part_name=recovery_ctx.part_name if recovery_ctx else None,
+        table=recovery_ctx.quoted_table if recovery_ctx else None,
+    )
+    if recovery_ctx is None:
+        result.error = "no recovery context (part missing in system.parts)"
+        return result
 
-    if attach:
-        attach_partition(ctx, table_partition)
+    try:
+        detach_part(
+            ctx, recovery_ctx.database, recovery_ctx.table, recovery_ctx.part_name
+        )
+        result.detached = True
+    except Exception as exc:
+        result.error = f"DETACH PART failed: {exc!r}"
+        logging.warning(
+            "DETACH PART '{}' on {} failed: {!r}",
+            recovery_ctx.part_name,
+            recovery_ctx.quoted_table,
+            exc,
+        )
+        return result
+
+    detached_part_path = _find_detached_part_path(part_path, recovery_ctx.part_name)
+    if detached_part_path is None:
+        result.error = "detached part directory not found after DETACH PART"
+        return result
+
+    result.files = recover_part_files_locally(
+        part_path=detached_part_path,
+        missing_files=missing_files,
+        recovery_ctx=recovery_ctx,
+        s3_client=s3_client,
+        bucket=bucket,
+        s3_prefix=s3_prefix,
+    )
+
+    try:
+        attach_part(
+            ctx, recovery_ctx.database, recovery_ctx.table, recovery_ctx.part_name
+        )
+        result.reattached = True
+    except Exception as exc:
+        result.error = f"ATTACH PART failed: {exc!r}"
+        logging.warning(
+            "ATTACH PART '{}' on {} failed: {!r}",
+            recovery_ctx.part_name,
+            recovery_ctx.quoted_table,
+            exc,
+        )
+    return result
+
+
+def _find_detached_part_path(active_path: str, part_name: str) -> Optional[str]:
+    """
+    Locate the directory of a part that has just been DETACHed.
+
+    The active part path looks like ``…/<table>/<part_name>``; its
+    detached counterpart sits next to it as ``…/<table>/detached/<part_name>``.
+    """
+    table_dir = os.path.dirname(active_path.rstrip("/"))
+    candidate = os.path.join(table_dir, "detached", part_name)
+    if os.path.isdir(candidate):
+        return candidate
+    logging.warning(
+        "Could not find detached part path next to {} (looked for {})",
+        active_path,
+        candidate,
+    )
+    return None
 
 
 def _check_keys_exist(s3_client: Boto3Client, bucket: str, keys: Set[str]) -> Set[str]:
@@ -645,19 +744,4 @@ def detach_partition(ctx: Context, table_partition: TablePartition) -> bool:
         detach_query,
         timeout=ATTACH_DETTACH_TIMEOUT,
         retries=ATTACH_DETACH_QUERY_RETRY,
-    )
-
-
-def attach_partition(ctx: Context, table_partition: TablePartition) -> bool:
-    """
-    Run ATTACH the partition.
-    """
-
-    attach_query = f"ALTER TABLE {table_partition.table} ATTACH PARTITION '{table_partition.partition}'"
-    # To avoid keeping detached partitions, perform the attach query with double attempts.
-    return query_with_retry(
-        ctx,
-        attach_query,
-        timeout=ATTACH_DETTACH_TIMEOUT,
-        retries=2 * ATTACH_DETACH_QUERY_RETRY,
     )

--- a/ch_tools/chadmin/cli/data_store_group.py
+++ b/ch_tools/chadmin/cli/data_store_group.py
@@ -492,6 +492,11 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals,too-many-branch
                 s3_prefix=disk_conf.prefix,
                 part_path=part["path"],
                 missing_files=part["missing_files"],
+                disk_name="object_storage",
+                disk_config=ch_config.storage_configuration.get_disk_config(
+                    "object_storage"
+                ),
+                ch_version=get_version(ctx),
             )
             recovery_results.append(result)
             restored = result.reattached
@@ -524,13 +529,21 @@ def detect_broken_partitions(  # pylint: disable=too-many-locals,too-many-branch
 def _restore_recoverable_part(
     ctx: Context,
     *,
-    s3_client: Boto3Client,
+    s3_client: "Boto3Client",
     bucket: str,
     s3_prefix: str,
     part_path: str,
     missing_files: List[str],
+    disk_name: Optional[str] = None,
+    disk_config: Optional[dict] = None,
+    ch_version: Optional[str] = None,
 ) -> PartRecoveryResult:
-    """DETACH PART → regenerate missing files → ATTACH PART."""
+    """DETACH PART → regenerate missing files → ATTACH PART.
+
+    ``disk_name``, ``disk_config``, and ``ch_version`` are forwarded to
+    :func:`recover_part_files_locally` for the ``checksums.txt`` recovery
+    path on ``ReplicatedMergeTree`` tables (via ``clickhouse-local``).
+    """
     recovery_ctx = get_part_recovery_context(ctx, part_path)
     result = PartRecoveryResult(
         part_path=part_path,
@@ -568,6 +581,10 @@ def _restore_recoverable_part(
         s3_client=s3_client,
         bucket=bucket,
         s3_prefix=s3_prefix,
+        ctx=ctx,
+        disk_name=disk_name,
+        disk_config=disk_config,
+        ch_version=ch_version,
     )
 
     try:

--- a/ch_tools/chadmin/internal/clickhouse_disks.py
+++ b/ch_tools/chadmin/internal/clickhouse_disks.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import xmltodict
 
@@ -17,9 +17,18 @@ S3_METADATA_STORE_PATH = S3_PATH + "/store"
 OBJECT_STORAGE_DISK_TYPES = ["s3", "object_storage", "ObjectStorage"]
 
 
-def make_ch_disks_config(disk: str) -> str:
-    disk_config = ClickhouseConfig.load().storage_configuration.get_disk_config(disk)
-    disk_config_path = f"/tmp/chadmin-ch-disks-{disk}.xml"
+def make_ch_disks_config(
+    disk: str,
+    output_path: Optional[str] = None,
+    disk_config: Optional[Dict] = None,
+) -> str:
+    if disk_config is None:
+        disk_config = ClickhouseConfig.load().storage_configuration.get_disk_config(
+            disk
+        )
+    if output_path is None:
+        output_path = f"/tmp/chadmin-ch-disks-{disk}.xml"
+    disk_config_path = output_path
     logging.info("Create a conf for {} disk: {}", disk, disk_config_path)
     with open(disk_config_path, "w", encoding="utf-8") as f:
         xmltodict.unparse(

--- a/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
+++ b/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
@@ -1,19 +1,15 @@
 from __future__ import annotations
 
-import os
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+from typing import List, Sequence
 
-import xmltodict
-
-from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.chadmin.internal.clickhouse_disks import make_ch_disks_config
 from ch_tools.common import logging
-
-if TYPE_CHECKING:
-    from click import Context
+from ch_tools.common.utils import atomic_write_file
 
 CLICKHOUSE_LOCAL_BIN = "clickhouse-local"
 _SUBPROCESS_TIMEOUT = 600
@@ -66,7 +62,11 @@ def recover_checksums_via_local(
             part_name=part_name,
             missing_checksums=requested_checksums,
         )
-        disk_config_path = _write_disk_config(tmp_path, disk_name, disk_config)
+        disk_config_path = make_ch_disks_config(
+            disk_name,
+            output_path=str(tmp_path / f"disk-{disk_name}.xml"),
+            disk_config=disk_config,
+        )
         sql = _build_recovery_sql(
             create_table_ddl=create_table_ddl,
             part_name=part_name,
@@ -157,99 +157,62 @@ def is_projection_checksums(filename: str) -> bool:
 
 
 def _atomic_copy(source: Path, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    tmp = destination.with_name(destination.name + ".chadmin-tmp")
-    tmp.write_bytes(source.read_bytes())
-    os.replace(tmp, destination)
+    atomic_write_file(destination, source.read_bytes())
 
 
 def _replace_create_table_name(ddl: str, table_name: str) -> str:
-    idx = _find_keyword(ddl, "CREATE", 0)
-    if idx < 0:
-        raise ValueError("CREATE keyword not found")
-    idx += len("CREATE")
-    idx = _skip_ws(ddl, idx)
-    if _keyword_at(ddl, idx, "OR"):
-        idx = _skip_ws(ddl, idx + len("OR"))
-        if not _keyword_at(ddl, idx, "REPLACE"):
-            raise ValueError("Expected REPLACE after CREATE OR")
-        idx = _skip_ws(ddl, idx + len("REPLACE"))
-    if not _keyword_at(ddl, idx, "TABLE"):
-        raise ValueError("TABLE keyword not found after CREATE")
-    idx = _skip_ws(ddl, idx + len("TABLE"))
-    if _keyword_at(ddl, idx, "IF"):
-        idx = _skip_ws(ddl, idx + len("IF"))
-        if not _keyword_at(ddl, idx, "NOT"):
-            raise ValueError("Expected NOT in IF NOT EXISTS")
-        idx = _skip_ws(ddl, idx + len("NOT"))
-        if not _keyword_at(ddl, idx, "EXISTS"):
-            raise ValueError("Expected EXISTS in IF NOT EXISTS")
-        idx = _skip_ws(ddl, idx + len("EXISTS"))
-
-    start, end = _read_table_identifier(ddl, idx)
-    return ddl[:start] + table_name + ddl[end:]
+    return re.sub(
+        r"^(CREATE\s+TABLE\s+)(?:\`?\w+\`?\.)?\`?\w+\`?",
+        rf"\1{table_name}",
+        ddl,
+        count=1,
+        flags=re.IGNORECASE,
+    )
 
 
 def _rewrite_replicated_engine(ddl: str) -> str:
-    engine_idx = _find_keyword(ddl, "ENGINE", 0)
-    if engine_idx < 0:
-        raise ValueError("ENGINE clause not found")
-    idx = _skip_ws(ddl, engine_idx + len("ENGINE"))
-    if idx < len(ddl) and ddl[idx] == "=":
-        idx = _skip_ws(ddl, idx + 1)
+    m = re.search(
+        r"ENGINE\s*=\s*(Replicated\w*MergeTree)\s*"
+        r"\(\s*'[^']*'\s*,\s*'[^']*'\s*(?:,\s*(.*?))?\s*\)",
+        ddl,
+        re.IGNORECASE,
+    )
+    if not m:
+        raise ValueError("ENGINE clause with Replicated*MergeTree not found")
 
-    name_start, name_end = _read_bare_identifier(ddl, idx)
-    engine_name = ddl[name_start:name_end]
+    engine_name = m.group(1)
     if engine_name not in _ENGINE_MAP:
         raise ValueError(f"Unsupported replicated engine: {engine_name!r}")
 
-    idx = _skip_ws(ddl, name_end)
-    args: List[str] = []
-    call_end = name_end
-    if idx < len(ddl) and ddl[idx] == "(":
-        args_text, call_end = _read_parenthesized(ddl, idx)
-        args = _split_top_level_args(args_text)
-
-    if len(args) < 2:
-        raise ValueError(f"Replicated engine {engine_name} must have at least 2 args")
     plain_engine = _ENGINE_MAP[engine_name]
-    plain_args = args[2:]
-    replacement = f"{plain_engine}({', '.join(plain_args)})"
-    return ddl[:name_start] + replacement + ddl[call_end:]
+    rest = m.group(2) or ""
+    if rest:
+        replacement = f"ENGINE = {plain_engine}({rest})"
+    else:
+        replacement = f"ENGINE = {plain_engine}"
+    return ddl[: m.start()] + replacement + ddl[m.end() :]
 
 
 def _set_disk_setting(ddl: str, disk_name: str) -> str:
-    settings_idx = _find_keyword(ddl, "SETTINGS", 0)
-    if settings_idx < 0:
+    si = ddl.lower().rfind("settings")
+    if si < 0:
         return f"{ddl.rstrip()}\nSETTINGS disk = '{disk_name}'"
 
-    disk_idx = _find_keyword(ddl, "disk", settings_idx + len("SETTINGS"))
-    if disk_idx >= 0:
-        idx = _skip_ws(ddl, disk_idx + len("disk"))
-        if idx < len(ddl) and ddl[idx] == "=":
-            value_start = _skip_ws(ddl, idx + 1)
-            value_end = _read_setting_value_end(ddl, value_start)
-            return ddl[:disk_idx] + f"disk = '{disk_name}'" + ddl[value_end:]
-
-    insert_at = settings_idx + len("SETTINGS")
-    return ddl[:insert_at] + f" disk = '{disk_name}'," + ddl[insert_at:]
-
-
-def _write_disk_config(tmp_path: Path, disk_name: str, disk_config: dict) -> Path:
-    config_path = tmp_path / f"disk-{disk_name}.xml"
-    with config_path.open("w", encoding="utf-8") as fh:
-        xmltodict.unparse(
-            {
-                "clickhouse": {
-                    "storage_configuration": {
-                        "disks": {disk_name: disk_config},
-                    }
-                }
-            },
-            fh,
-            pretty=True,
+    prefix = ddl[:si]
+    settings_text = ddl[si:]
+    m = re.search(r"\bdisk\s*=\s*'[^']*'", settings_text, re.IGNORECASE)
+    if m:
+        settings_text = (
+            settings_text[: m.start()]
+            + f"disk = '{disk_name}'"
+            + settings_text[m.end() :]
         )
-    return config_path
+    else:
+        settings_text = (
+            f"SETTINGS disk = '{disk_name}'," + settings_text[len("SETTINGS") :]
+        )
+
+    return prefix + settings_text
 
 
 def _build_recovery_sql(
@@ -308,195 +271,3 @@ def _run_clickhouse_local(
             f"stderr: {stderr}\n"
             f"sql: {sql}"
         )
-
-
-def _find_keyword(sql: str, keyword: str, start: int) -> int:
-    keyword_upper = keyword.upper()
-    idx = start
-    while idx < len(sql):
-        char = sql[idx]
-        if char == "'":
-            idx = _skip_single_quoted(sql, idx)
-            continue
-        if char == "`":
-            idx = _skip_back_quoted(sql, idx)
-            continue
-        if sql.startswith("--", idx):
-            newline = sql.find("\n", idx + 2)
-            idx = len(sql) if newline < 0 else newline + 1
-            continue
-        if sql.startswith("/*", idx):
-            end = sql.find("*/", idx + 2)
-            idx = len(sql) if end < 0 else end + 2
-            continue
-        if (
-            sql[idx : idx + len(keyword)].upper() == keyword_upper
-            and _is_boundary(sql, idx - 1)
-            and _is_boundary(sql, idx + len(keyword))
-        ):
-            return idx
-        idx += 1
-    return -1
-
-
-def _keyword_at(sql: str, idx: int, keyword: str) -> bool:
-    return (
-        sql[idx : idx + len(keyword)].upper() == keyword.upper()
-        and _is_boundary(sql, idx - 1)
-        and _is_boundary(sql, idx + len(keyword))
-    )
-
-
-def _is_boundary(sql: str, idx: int) -> bool:
-    if idx < 0 or idx >= len(sql):
-        return True
-    return not (sql[idx].isalnum() or sql[idx] == "_")
-
-
-def _skip_ws(sql: str, idx: int) -> int:
-    while idx < len(sql) and sql[idx].isspace():
-        idx += 1
-    return idx
-
-
-def _read_table_identifier(sql: str, idx: int) -> Tuple[int, int]:
-    start = idx
-    _, idx = _read_identifier(sql, idx)
-    idx = _skip_ws(sql, idx)
-    if idx < len(sql) and sql[idx] == ".":
-        idx = _skip_ws(sql, idx + 1)
-        _, idx = _read_identifier(sql, idx)
-    return start, idx
-
-
-def _read_identifier(sql: str, idx: int) -> Tuple[int, int]:
-    if idx < len(sql) and sql[idx] == "`":
-        end = _skip_back_quoted(sql, idx)
-        return idx, end
-    return _read_bare_identifier(sql, idx)
-
-
-def _read_bare_identifier(sql: str, idx: int) -> Tuple[int, int]:
-    if idx >= len(sql) or not (sql[idx].isalpha() or sql[idx] == "_"):
-        raise ValueError(f"Expected identifier at position {idx}")
-    start = idx
-    idx += 1
-    while idx < len(sql) and (sql[idx].isalnum() or sql[idx] == "_"):
-        idx += 1
-    return start, idx
-
-
-def _read_parenthesized(sql: str, idx: int) -> Tuple[str, int]:
-    if idx >= len(sql) or sql[idx] != "(":
-        raise ValueError(f"Expected '(' at position {idx}")
-    start = idx + 1
-    depth = 1
-    idx += 1
-    while idx < len(sql):
-        char = sql[idx]
-        if char == "'":
-            idx = _skip_single_quoted(sql, idx)
-            continue
-        if char == "`":
-            idx = _skip_back_quoted(sql, idx)
-            continue
-        if char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-            if depth == 0:
-                return sql[start:idx], idx + 1
-        idx += 1
-    raise ValueError("Unclosed parenthesized expression")
-
-
-def _split_top_level_args(args_text: str) -> List[str]:
-    args: List[str] = []
-    start = 0
-    idx = 0
-    depth = 0
-    while idx < len(args_text):
-        char = args_text[idx]
-        if char == "'":
-            idx = _skip_single_quoted(args_text, idx)
-            continue
-        if char == "`":
-            idx = _skip_back_quoted(args_text, idx)
-            continue
-        if char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-        elif char == "," and depth == 0:
-            args.append(args_text[start:idx].strip())
-            start = idx + 1
-        idx += 1
-    tail = args_text[start:].strip()
-    if tail:
-        args.append(tail)
-    return args
-
-
-def _read_setting_value_end(sql: str, idx: int) -> int:
-    depth = 0
-    while idx < len(sql):
-        char = sql[idx]
-        if char == "'":
-            idx = _skip_single_quoted(sql, idx)
-            continue
-        if char == "`":
-            idx = _skip_back_quoted(sql, idx)
-            continue
-        if char == "(":
-            depth += 1
-        elif char == ")" and depth > 0:
-            depth -= 1
-        elif char == "," and depth == 0:
-            return idx
-        idx += 1
-    return idx
-
-
-def _skip_single_quoted(sql: str, idx: int) -> int:
-    idx += 1
-    while idx < len(sql):
-        if sql[idx] == "\\":
-            idx += 2
-            continue
-        if sql[idx] == "'":
-            if idx + 1 < len(sql) and sql[idx + 1] == "'":
-                idx += 2
-                continue
-            return idx + 1
-        idx += 1
-    raise ValueError("Unclosed string literal")
-
-
-def _skip_back_quoted(sql: str, idx: int) -> int:
-    idx += 1
-    while idx < len(sql):
-        if sql[idx] == "\\":
-            idx += 2
-            continue
-        if sql[idx] == "`":
-            return idx + 1
-        idx += 1
-    raise ValueError("Unclosed quoted identifier")
-
-
-def get_show_create_table(
-    ctx: "Context",
-    database: str,
-    table: str,
-) -> Optional[str]:
-    query = f"SHOW CREATE TABLE `{database}`.`{table}`"
-    try:
-        result = execute_query(ctx, query, format_="TSVRaw")
-        if isinstance(result, str):
-            return result.strip() or None
-        return None
-    except Exception as exc:
-        logging.warning(
-            "SHOW CREATE TABLE `{}`.`{}` failed: {!r}", database, table, exc
-        )
-        return None

--- a/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
+++ b/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
@@ -149,8 +149,10 @@ def copy_recovered_checksums_back(
 
 def is_projection_checksums(filename: str) -> bool:
     parts = Path(filename).parts
-    return len(parts) >= 2 and parts[-1] == _CHECKSUMS_FILENAME and any(
-        part.endswith(".proj") for part in parts[:-1]
+    return (
+        len(parts) >= 2
+        and parts[-1] == _CHECKSUMS_FILENAME
+        and any(part.endswith(".proj") for part in parts[:-1])
     )
 
 
@@ -327,9 +329,11 @@ def _find_keyword(sql: str, keyword: str, start: int) -> int:
             end = sql.find("*/", idx + 2)
             idx = len(sql) if end < 0 else end + 2
             continue
-        if sql[idx : idx + len(keyword)].upper() == keyword_upper and _is_boundary(
-            sql, idx - 1
-        ) and _is_boundary(sql, idx + len(keyword)):
+        if (
+            sql[idx : idx + len(keyword)].upper() == keyword_upper
+            and _is_boundary(sql, idx - 1)
+            and _is_boundary(sql, idx + len(keyword))
+        ):
             return idx
         idx += 1
     return -1

--- a/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
+++ b/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+import xmltodict
+
+from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
+
+if TYPE_CHECKING:
+    from click import Context
+
+CLICKHOUSE_LOCAL_BIN = "clickhouse-local"
+_SUBPROCESS_TIMEOUT = 600
+
+
+def recover_checksums_via_local(
+    *,
+    detached_part_path: str,
+    part_name: str,
+    database: str,
+    table: str,
+    disk_name: str,
+    disk_config: dict,
+    create_table_ddl: str,
+    ch_version: str,
+) -> None:
+    logging.debug(
+        "recover_checksums_via_local: part_path={} part_name={} ch_version={}",
+        detached_part_path,
+        part_name,
+        ch_version,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="chadmin-recovery-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        disk_config_path = _write_disk_config(tmp_path, disk_name, disk_config)
+        sql = _build_recovery_sql(
+            create_table_ddl=create_table_ddl,
+            part_name=part_name,
+        )
+
+        _run_clickhouse_local(
+            sql=sql,
+            local_path=str(tmp_path),
+            disk_config_path=str(disk_config_path),
+            ch_version=ch_version,
+        )
+
+    logging.info(
+        "checksums_recovery_via_local: successfully regenerated checksums.txt "
+        "for part '{}' (table {}.{})",
+        part_name,
+        database,
+        table,
+    )
+
+
+def build_recovery_ddl(
+    original_ddl: str,
+    disk_name: str,
+) -> str:
+    ddl = original_ddl.strip()
+
+    ddl = re.sub(
+        r"CREATE TABLE\s+`[^`]+`\s*\.\s*`[^`]+`",
+        "CREATE TABLE recovery",
+        ddl,
+        count=1,
+    )
+    ddl = re.sub(
+        r"CREATE TABLE\s+\w+\s*\.\s*\w+",
+        "CREATE TABLE recovery",
+        ddl,
+        count=1,
+    )
+
+    ddl = re.sub(
+        r"\bReplicated(MergeTree|ReplacingMergeTree|AggregatingMergeTree"
+        r"|CollapsingMergeTree|SummingMergeTree|VersionedCollapsingMergeTree"
+        r"|GraphiteMergeTree)\s*\([^)]*\)",
+        r"\1()",
+        ddl,
+    )
+
+    if re.search(r"\bSETTINGS\b", ddl, re.IGNORECASE):
+        if re.search(r"\bdisk\s*=", ddl, re.IGNORECASE):
+            ddl = re.sub(
+                r"\bdisk\s*=\s*'[^']*'",
+                f"disk = '{disk_name}'",
+                ddl,
+            )
+        else:
+            ddl = re.sub(
+                r"(SETTINGS\b)",
+                rf"\1 disk = '{disk_name}',",
+                ddl,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+    else:
+        ddl = ddl.rstrip(";").rstrip()
+        ddl += f"\nSETTINGS disk = '{disk_name}'"
+
+    return ddl
+
+
+def _write_disk_config(tmp_path: Path, disk_name: str, disk_config: dict) -> Path:
+    config_path = tmp_path / f"disk-{disk_name}.xml"
+    with config_path.open("w", encoding="utf-8") as fh:
+        xmltodict.unparse(
+            {
+                "clickhouse": {
+                    "storage_configuration": {
+                        "disks": {disk_name: disk_config},
+                    }
+                }
+            },
+            fh,
+            pretty=True,
+        )
+    return config_path
+
+
+def _build_recovery_sql(
+    *,
+    create_table_ddl: str,
+    part_name: str,
+) -> str:
+    ddl = create_table_ddl.strip().rstrip(";") + ";"
+    attach = f"ALTER TABLE recovery ATTACH PART '{part_name}';"
+    detach = f"ALTER TABLE recovery DETACH PART '{part_name}';"
+    return "\n".join([ddl, attach, detach])
+
+
+def _run_clickhouse_local(
+    *,
+    sql: str,
+    local_path: str,
+    disk_config_path: str,
+    ch_version: str,
+) -> None:
+    logging.debug(
+        "_run_clickhouse_local: ch_version={} local_path={}", ch_version, local_path
+    )
+    cmd: List[str] = [
+        CLICKHOUSE_LOCAL_BIN,
+        "--path",
+        local_path,
+        "--config-file",
+        disk_config_path,
+        "--multiquery",
+        "--query",
+        sql,
+    ]
+
+    logging.info("Running clickhouse-local for checksums recovery: {}", " ".join(cmd))
+
+    result = subprocess.run(
+        cmd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=_SUBPROCESS_TIMEOUT,
+    )
+
+    stdout = result.stdout.decode(errors="replace").strip()
+    stderr = result.stderr.decode(errors="replace").strip()
+
+    if stdout:
+        logging.debug("clickhouse-local stdout: {}", stdout)
+    if stderr:
+        logging.debug("clickhouse-local stderr: {}", stderr)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"clickhouse-local exited with code {result.returncode}.\n"
+            f"stderr: {stderr}\n"
+            f"sql: {sql}"
+        )
+
+
+def get_show_create_table(
+    ctx: "Context",
+    database: str,
+    table: str,
+) -> Optional[str]:
+    query = f"SHOW CREATE TABLE `{database}`.`{table}`"
+    try:
+        result = execute_query(ctx, query, format_="TSVRaw")
+        if isinstance(result, str):
+            return result.strip() or None
+        return None
+    except Exception as exc:
+        logging.warning(
+            "SHOW CREATE TABLE `{}`.`{}` failed: {!r}", database, table, exc
+        )
+        return None

--- a/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
+++ b/ch_tools/chadmin/internal/object_storage/checksums_recovery_via_local.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import re
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 
 import xmltodict
 
@@ -16,6 +17,18 @@ if TYPE_CHECKING:
 
 CLICKHOUSE_LOCAL_BIN = "clickhouse-local"
 _SUBPROCESS_TIMEOUT = 600
+_RECOVERY_DATABASE = "default"
+_RECOVERY_TABLE = "recovery"
+_CHECKSUMS_FILENAME = "checksums.txt"
+_ENGINE_MAP = {
+    "ReplicatedMergeTree": "MergeTree",
+    "ReplicatedReplacingMergeTree": "ReplacingMergeTree",
+    "ReplicatedSummingMergeTree": "SummingMergeTree",
+    "ReplicatedAggregatingMergeTree": "AggregatingMergeTree",
+    "ReplicatedCollapsingMergeTree": "CollapsingMergeTree",
+    "ReplicatedVersionedCollapsingMergeTree": "VersionedCollapsingMergeTree",
+    "ReplicatedGraphiteMergeTree": "GraphiteMergeTree",
+}
 
 
 def recover_checksums_via_local(
@@ -28,7 +41,8 @@ def recover_checksums_via_local(
     disk_config: dict,
     create_table_ddl: str,
     ch_version: str,
-) -> None:
+    missing_files: Sequence[str],
+) -> List[str]:
     logging.debug(
         "recover_checksums_via_local: part_path={} part_name={} ch_version={}",
         detached_part_path,
@@ -36,8 +50,22 @@ def recover_checksums_via_local(
         ch_version,
     )
 
+    requested_checksums = [
+        filename
+        for filename in missing_files
+        if filename == _CHECKSUMS_FILENAME or is_projection_checksums(filename)
+    ]
+    if _CHECKSUMS_FILENAME not in requested_checksums:
+        requested_checksums.insert(0, _CHECKSUMS_FILENAME)
+
     with tempfile.TemporaryDirectory(prefix="chadmin-recovery-") as tmp_dir:
         tmp_path = Path(tmp_dir)
+        local_part_path = prepare_local_part_layout(
+            tmp_path=tmp_path,
+            detached_part_path=Path(detached_part_path),
+            part_name=part_name,
+            missing_checksums=requested_checksums,
+        )
         disk_config_path = _write_disk_config(tmp_path, disk_name, disk_config)
         sql = _build_recovery_sql(
             create_table_ddl=create_table_ddl,
@@ -51,62 +79,158 @@ def recover_checksums_via_local(
             ch_version=ch_version,
         )
 
+        restored_files = copy_recovered_checksums_back(
+            recovered_part_path=local_part_path,
+            detached_part_path=Path(detached_part_path),
+            requested_checksums=requested_checksums,
+        )
+
     logging.info(
-        "checksums_recovery_via_local: successfully regenerated checksums.txt "
+        "checksums_recovery_via_local: regenerated {} checksums file(s) "
         "for part '{}' (table {}.{})",
+        len(restored_files),
         part_name,
         database,
         table,
     )
+    return restored_files
 
 
 def build_recovery_ddl(
     original_ddl: str,
     disk_name: str,
 ) -> str:
-    ddl = original_ddl.strip()
-
-    ddl = re.sub(
-        r"CREATE TABLE\s+`[^`]+`\s*\.\s*`[^`]+`",
-        "CREATE TABLE recovery",
-        ddl,
-        count=1,
-    )
-    ddl = re.sub(
-        r"CREATE TABLE\s+\w+\s*\.\s*\w+",
-        "CREATE TABLE recovery",
-        ddl,
-        count=1,
-    )
-
-    ddl = re.sub(
-        r"\bReplicated(MergeTree|ReplacingMergeTree|AggregatingMergeTree"
-        r"|CollapsingMergeTree|SummingMergeTree|VersionedCollapsingMergeTree"
-        r"|GraphiteMergeTree)\s*\([^)]*\)",
-        r"\1()",
-        ddl,
-    )
-
-    if re.search(r"\bSETTINGS\b", ddl, re.IGNORECASE):
-        if re.search(r"\bdisk\s*=", ddl, re.IGNORECASE):
-            ddl = re.sub(
-                r"\bdisk\s*=\s*'[^']*'",
-                f"disk = '{disk_name}'",
-                ddl,
-            )
-        else:
-            ddl = re.sub(
-                r"(SETTINGS\b)",
-                rf"\1 disk = '{disk_name}',",
-                ddl,
-                count=1,
-                flags=re.IGNORECASE,
-            )
-    else:
-        ddl = ddl.rstrip(";").rstrip()
-        ddl += f"\nSETTINGS disk = '{disk_name}'"
-
+    ddl = original_ddl.strip().rstrip(";")
+    ddl = _replace_create_table_name(ddl, _RECOVERY_TABLE)
+    ddl = _rewrite_replicated_engine(ddl)
+    ddl = _set_disk_setting(ddl, disk_name)
     return ddl
+
+
+def prepare_local_part_layout(
+    *,
+    tmp_path: Path,
+    detached_part_path: Path,
+    part_name: str,
+    missing_checksums: Sequence[str],
+) -> Path:
+    detached_dir = tmp_path / "data" / _RECOVERY_DATABASE / _RECOVERY_TABLE / "detached"
+    detached_dir.mkdir(parents=True)
+    local_part_path = detached_dir / part_name
+    shutil.copytree(detached_part_path, local_part_path)
+
+    for filename in missing_checksums:
+        target = local_part_path / filename
+        if target.exists():
+            target.unlink()
+    return local_part_path
+
+
+def copy_recovered_checksums_back(
+    *,
+    recovered_part_path: Path,
+    detached_part_path: Path,
+    requested_checksums: Sequence[str],
+) -> List[str]:
+    restored: List[str] = []
+    seen = set()
+    for filename in requested_checksums:
+        if filename in seen:
+            continue
+        seen.add(filename)
+        source = recovered_part_path / filename
+        if not source.exists():
+            raise FileNotFoundError(f"Recovered checksums file not found: {source}")
+        destination = detached_part_path / filename
+        _atomic_copy(source, destination)
+        restored.append(filename)
+    return restored
+
+
+def is_projection_checksums(filename: str) -> bool:
+    parts = Path(filename).parts
+    return len(parts) >= 2 and parts[-1] == _CHECKSUMS_FILENAME and any(
+        part.endswith(".proj") for part in parts[:-1]
+    )
+
+
+def _atomic_copy(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp = destination.with_name(destination.name + ".chadmin-tmp")
+    tmp.write_bytes(source.read_bytes())
+    os.replace(tmp, destination)
+
+
+def _replace_create_table_name(ddl: str, table_name: str) -> str:
+    idx = _find_keyword(ddl, "CREATE", 0)
+    if idx < 0:
+        raise ValueError("CREATE keyword not found")
+    idx += len("CREATE")
+    idx = _skip_ws(ddl, idx)
+    if _keyword_at(ddl, idx, "OR"):
+        idx = _skip_ws(ddl, idx + len("OR"))
+        if not _keyword_at(ddl, idx, "REPLACE"):
+            raise ValueError("Expected REPLACE after CREATE OR")
+        idx = _skip_ws(ddl, idx + len("REPLACE"))
+    if not _keyword_at(ddl, idx, "TABLE"):
+        raise ValueError("TABLE keyword not found after CREATE")
+    idx = _skip_ws(ddl, idx + len("TABLE"))
+    if _keyword_at(ddl, idx, "IF"):
+        idx = _skip_ws(ddl, idx + len("IF"))
+        if not _keyword_at(ddl, idx, "NOT"):
+            raise ValueError("Expected NOT in IF NOT EXISTS")
+        idx = _skip_ws(ddl, idx + len("NOT"))
+        if not _keyword_at(ddl, idx, "EXISTS"):
+            raise ValueError("Expected EXISTS in IF NOT EXISTS")
+        idx = _skip_ws(ddl, idx + len("EXISTS"))
+
+    start, end = _read_table_identifier(ddl, idx)
+    return ddl[:start] + table_name + ddl[end:]
+
+
+def _rewrite_replicated_engine(ddl: str) -> str:
+    engine_idx = _find_keyword(ddl, "ENGINE", 0)
+    if engine_idx < 0:
+        raise ValueError("ENGINE clause not found")
+    idx = _skip_ws(ddl, engine_idx + len("ENGINE"))
+    if idx < len(ddl) and ddl[idx] == "=":
+        idx = _skip_ws(ddl, idx + 1)
+
+    name_start, name_end = _read_bare_identifier(ddl, idx)
+    engine_name = ddl[name_start:name_end]
+    if engine_name not in _ENGINE_MAP:
+        raise ValueError(f"Unsupported replicated engine: {engine_name!r}")
+
+    idx = _skip_ws(ddl, name_end)
+    args: List[str] = []
+    call_end = name_end
+    if idx < len(ddl) and ddl[idx] == "(":
+        args_text, call_end = _read_parenthesized(ddl, idx)
+        args = _split_top_level_args(args_text)
+
+    if len(args) < 2:
+        raise ValueError(f"Replicated engine {engine_name} must have at least 2 args")
+    plain_engine = _ENGINE_MAP[engine_name]
+    plain_args = args[2:]
+    replacement = f"{plain_engine}({', '.join(plain_args)})"
+    return ddl[:name_start] + replacement + ddl[call_end:]
+
+
+def _set_disk_setting(ddl: str, disk_name: str) -> str:
+    settings_idx = _find_keyword(ddl, "SETTINGS", 0)
+    if settings_idx < 0:
+        return f"{ddl.rstrip()}\nSETTINGS disk = '{disk_name}'"
+
+    disk_idx = _find_keyword(ddl, "disk", settings_idx + len("SETTINGS"))
+    if disk_idx >= 0:
+        idx = _skip_ws(ddl, disk_idx + len("disk"))
+        if idx < len(ddl) and ddl[idx] == "=":
+            value_start = _skip_ws(ddl, idx + 1)
+            value_end = _read_setting_value_end(ddl, value_start)
+            return ddl[:disk_idx] + f"disk = '{disk_name}'" + ddl[value_end:]
+
+    insert_at = settings_idx + len("SETTINGS")
+    return ddl[:insert_at] + f" disk = '{disk_name}'," + ddl[insert_at:]
 
 
 def _write_disk_config(tmp_path: Path, disk_name: str, disk_config: dict) -> Path:
@@ -132,8 +256,8 @@ def _build_recovery_sql(
     part_name: str,
 ) -> str:
     ddl = create_table_ddl.strip().rstrip(";") + ";"
-    attach = f"ALTER TABLE recovery ATTACH PART '{part_name}';"
-    detach = f"ALTER TABLE recovery DETACH PART '{part_name}';"
+    attach = f"ALTER TABLE {_RECOVERY_TABLE} ATTACH PART '{part_name}';"
+    detach = f"ALTER TABLE {_RECOVERY_TABLE} DETACH PART '{part_name}';"
     return "\n".join([ddl, attach, detach])
 
 
@@ -182,6 +306,178 @@ def _run_clickhouse_local(
             f"stderr: {stderr}\n"
             f"sql: {sql}"
         )
+
+
+def _find_keyword(sql: str, keyword: str, start: int) -> int:
+    keyword_upper = keyword.upper()
+    idx = start
+    while idx < len(sql):
+        char = sql[idx]
+        if char == "'":
+            idx = _skip_single_quoted(sql, idx)
+            continue
+        if char == "`":
+            idx = _skip_back_quoted(sql, idx)
+            continue
+        if sql.startswith("--", idx):
+            newline = sql.find("\n", idx + 2)
+            idx = len(sql) if newline < 0 else newline + 1
+            continue
+        if sql.startswith("/*", idx):
+            end = sql.find("*/", idx + 2)
+            idx = len(sql) if end < 0 else end + 2
+            continue
+        if sql[idx : idx + len(keyword)].upper() == keyword_upper and _is_boundary(
+            sql, idx - 1
+        ) and _is_boundary(sql, idx + len(keyword)):
+            return idx
+        idx += 1
+    return -1
+
+
+def _keyword_at(sql: str, idx: int, keyword: str) -> bool:
+    return (
+        sql[idx : idx + len(keyword)].upper() == keyword.upper()
+        and _is_boundary(sql, idx - 1)
+        and _is_boundary(sql, idx + len(keyword))
+    )
+
+
+def _is_boundary(sql: str, idx: int) -> bool:
+    if idx < 0 or idx >= len(sql):
+        return True
+    return not (sql[idx].isalnum() or sql[idx] == "_")
+
+
+def _skip_ws(sql: str, idx: int) -> int:
+    while idx < len(sql) and sql[idx].isspace():
+        idx += 1
+    return idx
+
+
+def _read_table_identifier(sql: str, idx: int) -> Tuple[int, int]:
+    start = idx
+    _, idx = _read_identifier(sql, idx)
+    idx = _skip_ws(sql, idx)
+    if idx < len(sql) and sql[idx] == ".":
+        idx = _skip_ws(sql, idx + 1)
+        _, idx = _read_identifier(sql, idx)
+    return start, idx
+
+
+def _read_identifier(sql: str, idx: int) -> Tuple[int, int]:
+    if idx < len(sql) and sql[idx] == "`":
+        end = _skip_back_quoted(sql, idx)
+        return idx, end
+    return _read_bare_identifier(sql, idx)
+
+
+def _read_bare_identifier(sql: str, idx: int) -> Tuple[int, int]:
+    if idx >= len(sql) or not (sql[idx].isalpha() or sql[idx] == "_"):
+        raise ValueError(f"Expected identifier at position {idx}")
+    start = idx
+    idx += 1
+    while idx < len(sql) and (sql[idx].isalnum() or sql[idx] == "_"):
+        idx += 1
+    return start, idx
+
+
+def _read_parenthesized(sql: str, idx: int) -> Tuple[str, int]:
+    if idx >= len(sql) or sql[idx] != "(":
+        raise ValueError(f"Expected '(' at position {idx}")
+    start = idx + 1
+    depth = 1
+    idx += 1
+    while idx < len(sql):
+        char = sql[idx]
+        if char == "'":
+            idx = _skip_single_quoted(sql, idx)
+            continue
+        if char == "`":
+            idx = _skip_back_quoted(sql, idx)
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[start:idx], idx + 1
+        idx += 1
+    raise ValueError("Unclosed parenthesized expression")
+
+
+def _split_top_level_args(args_text: str) -> List[str]:
+    args: List[str] = []
+    start = 0
+    idx = 0
+    depth = 0
+    while idx < len(args_text):
+        char = args_text[idx]
+        if char == "'":
+            idx = _skip_single_quoted(args_text, idx)
+            continue
+        if char == "`":
+            idx = _skip_back_quoted(args_text, idx)
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            args.append(args_text[start:idx].strip())
+            start = idx + 1
+        idx += 1
+    tail = args_text[start:].strip()
+    if tail:
+        args.append(tail)
+    return args
+
+
+def _read_setting_value_end(sql: str, idx: int) -> int:
+    depth = 0
+    while idx < len(sql):
+        char = sql[idx]
+        if char == "'":
+            idx = _skip_single_quoted(sql, idx)
+            continue
+        if char == "`":
+            idx = _skip_back_quoted(sql, idx)
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")" and depth > 0:
+            depth -= 1
+        elif char == "," and depth == 0:
+            return idx
+        idx += 1
+    return idx
+
+
+def _skip_single_quoted(sql: str, idx: int) -> int:
+    idx += 1
+    while idx < len(sql):
+        if sql[idx] == "\\":
+            idx += 2
+            continue
+        if sql[idx] == "'":
+            if idx + 1 < len(sql) and sql[idx + 1] == "'":
+                idx += 2
+                continue
+            return idx + 1
+        idx += 1
+    raise ValueError("Unclosed string literal")
+
+
+def _skip_back_quoted(sql: str, idx: int) -> int:
+    idx += 1
+    while idx < len(sql):
+        if sql[idx] == "\\":
+            idx += 2
+            continue
+        if sql[idx] == "`":
+            return idx + 1
+        idx += 1
+    raise ValueError("Unclosed quoted identifier")
 
 
 def get_show_create_table(

--- a/ch_tools/chadmin/internal/object_storage/part_file_classifier.py
+++ b/ch_tools/chadmin/internal/object_storage/part_file_classifier.py
@@ -1,0 +1,104 @@
+"""
+Classify a missing file inside a MergeTree part as one of:
+
+* ``recoverable``        — structural file CH can/we can regenerate
+                           (checksums.txt, columns.txt, count.txt, ...).
+* ``partially-recoverable`` — column data / skip-index / projection file;
+                           part can be kept by replacing the column with
+                           NULL or by dropping the index/projection.
+* ``unrecoverable``      — losing the file kills the whole part
+                           (primary.idx, Compact data.bin, *.bin of
+                           PARTITION/ORDER BY columns).
+
+Used by `chadmin data-store detect-broken-partitions` to decide what to
+do with each broken part.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Optional
+
+RECOVERABLE = "recoverable"
+PARTIALLY_RECOVERABLE = "partially-recoverable"
+UNRECOVERABLE = "unrecoverable"
+
+_STRUCTURAL_FILES = {
+    "checksums.txt",
+    "columns.txt",
+    "count.txt",
+    "partition.dat",
+    "default_compression_codec.txt",
+    "metadata_version.txt",
+    "ttl.txt",
+    "serialization.json",
+    "columns_substreams.txt",
+}
+_UNRECOVERABLE_FILES = {"primary.idx", "primary.cidx"}
+_COMPACT_DATA_FILES = {"data.bin", "data.cmrk2", "data.cmrk3", "data.mrk2", "data.mrk3"}
+
+_MINMAX_RE = re.compile(r"^minmax_.+\.idx$")
+_SKIP_INDEX_RE = re.compile(r"^skp_idx_.+\.(idx|idx2|cidx|mrk2|mrk3|cmrk2|cmrk3)$")
+_COLUMN_DATA_RE = re.compile(r"^(?P<col>.+)\.(?:bin|cmrk2|cmrk3|mrk2|mrk3|mrk|cmrk)$")
+_PROJECTION_RE = re.compile(r"(^|/)[^/]+\.proj/")
+
+_RANK = {RECOVERABLE: 0, PARTIALLY_RECOVERABLE: 1, UNRECOVERABLE: 2}
+
+
+def classify_file(
+    filename: str,
+    *,
+    part_type: Optional[str] = None,
+    critical_columns: Iterable[str] = (),
+) -> str:
+    """Return one of RECOVERABLE / PARTIALLY_RECOVERABLE / UNRECOVERABLE.
+
+    ``filename`` is the file path relative to the part directory
+    (forward slashes; projection sub-files look like ``foo.proj/bar``).
+    ``part_type`` is ``"Wide"`` / ``"Compact"`` / ``None``.
+    ``critical_columns`` — columns participating in PARTITION BY / ORDER BY;
+    losing their ``.bin`` is unrecoverable.
+    """
+    if _PROJECTION_RE.search("/" + filename):
+        # losing anything in a projection means dropping the projection
+        return PARTIALLY_RECOVERABLE
+
+    if filename in _STRUCTURAL_FILES or _MINMAX_RE.match(filename):
+        return RECOVERABLE
+
+    if filename in _UNRECOVERABLE_FILES:
+        return UNRECOVERABLE
+
+    if part_type == "Compact" and filename in _COMPACT_DATA_FILES:
+        return UNRECOVERABLE
+
+    if _SKIP_INDEX_RE.match(filename):
+        return PARTIALLY_RECOVERABLE
+
+    col_match = _COLUMN_DATA_RE.match(filename)
+    if col_match:
+        if col_match.group("col") in set(critical_columns):
+            return UNRECOVERABLE
+        return PARTIALLY_RECOVERABLE
+
+    # Unknown file kind — be conservative.
+    return UNRECOVERABLE
+
+
+def classify_part(
+    missing_files: Iterable[str],
+    *,
+    part_type: Optional[str] = None,
+    critical_columns: Iterable[str] = (),
+) -> str:
+    """Aggregate per-file statuses into a single part status (worst wins)."""
+    worst = RECOVERABLE
+    seen = False
+    for f in missing_files:
+        seen = True
+        status = classify_file(
+            f, part_type=part_type, critical_columns=critical_columns
+        )
+        if _RANK[status] > _RANK[worst]:
+            worst = status
+    return worst if seen else RECOVERABLE

--- a/ch_tools/chadmin/internal/object_storage/part_recovery.py
+++ b/ch_tools/chadmin/internal/object_storage/part_recovery.py
@@ -99,15 +99,11 @@ def get_part_recovery_context(
         "data"
     ][0]
 
-    tables_query = (
-        "SELECT engine, metadata_version FROM system.tables "
-        f"WHERE database = '{database}' AND name = '{table}' LIMIT 1"
-    )
-    tables_res = execute_query(ctx, tables_query, format_=OutputFormat.JSONCompact)
-    if not tables_res.get("data"):
+    table_info = _get_table_engine_and_metadata_version(ctx, database, table)
+    if table_info is None:
         logging.warning("Table {}.{} not found in system.tables", database, table)
         return None
-    engine, metadata_version = tables_res["data"][0]
+    engine, metadata_version = table_info
 
     columns_query = (
         "SELECT name, type FROM system.columns "
@@ -130,6 +126,38 @@ def get_part_recovery_context(
         is_replicated="Replicated" in (engine or ""),
         columns=columns,
     )
+
+
+def _get_table_engine_and_metadata_version(
+    ctx: Context, database: str, table: str
+) -> Optional[Tuple[Optional[str], int]]:
+    tables_query = (
+        "SELECT engine, metadata_version FROM system.tables "
+        f"WHERE database = '{database}' AND name = '{table}' LIMIT 1"
+    )
+    try:
+        tables_res = execute_query(ctx, tables_query, format_=OutputFormat.JSONCompact)
+    except Exception:
+        # ClickHouse 23.3 does not have system.tables.metadata_version.
+        tables_res = _get_table_engine_without_metadata_version(ctx, database, table)
+
+    if not tables_res.get("data"):
+        return None
+
+    row = tables_res["data"][0]
+    engine = row[0]
+    metadata_version = row[1] if len(row) > 1 and row[1] is not None else 0
+    return engine, int(metadata_version)
+
+
+def _get_table_engine_without_metadata_version(
+    ctx: Context, database: str, table: str
+) -> dict:
+    tables_query = (
+        "SELECT engine FROM system.tables "
+        f"WHERE database = '{database}' AND name = '{table}' LIMIT 1"
+    )
+    return execute_query(ctx, tables_query, format_=OutputFormat.JSONCompact)
 
 
 # ---------------------------------------------------------------------------

--- a/ch_tools/chadmin/internal/object_storage/part_recovery.py
+++ b/ch_tools/chadmin/internal/object_storage/part_recovery.py
@@ -8,6 +8,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from boto3 import client as Boto3Client
 from click import Context
 
+from ch_tools.chadmin.internal.object_storage.checksums_recovery_via_local import (
+    build_recovery_ddl,
+    get_show_create_table,
+    recover_checksums_via_local,
+)
 from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
     S3ObjectLocalInfo,
     S3ObjectLocalMetaData,
@@ -31,9 +36,9 @@ SIMPLE_RECOVERABLE_FILES = {
 }
 
 # Files whose recovery is recoverable in principle but is *not* part of
-# this PR — checksums.txt (needs clickhouse-local for Replicated, or local
-# unlink+ATTACH for non-Replicated, handled separately), and the various
-# binary structural files that need format-aware generators.
+# this PR — checksums.txt for Replicated is handled via clickhouse-local
+# (see checksums_recovery_via_local.py).  The binary structural files below
+# still need format-aware generators and are deferred.
 UNSUPPORTED_FILES = {
     "partition.dat",
     "ttl.txt",
@@ -264,6 +269,10 @@ def recover_part_files_locally(
     s3_client: Boto3Client,
     bucket: str,
     s3_prefix: str,
+    ctx: Optional[Context] = None,
+    disk_name: Optional[str] = None,
+    disk_config: Optional[dict] = None,
+    ch_version: Optional[str] = None,
 ) -> List[FileRecoveryResult]:
     """
     Walk ``missing_files`` and perform the per-file recovery action.
@@ -272,6 +281,8 @@ def recover_part_files_locally(
     function only touches files inside ``part_path`` (which by then lives
     under ``…/detached/…``) and S3 objects.
     """
+    checksums_recovered_via_local: bool = False
+
     results: List[FileRecoveryResult] = []
     for filename in missing_files:
         try:
@@ -283,6 +294,32 @@ def recover_part_files_locally(
                     target.unlink()
                 results.append(
                     FileRecoveryResult(filename, "unlinked", "non-replicated MergeTree")
+                )
+                continue
+
+            if filename == "checksums.txt" and recovery_ctx.is_replicated:
+                # ReplicatedMergeTree: use clickhouse-local to regenerate.
+                result = _recover_checksums_replicated(
+                    filename=filename,
+                    part_path=part_path,
+                    recovery_ctx=recovery_ctx,
+                    ctx=ctx,
+                    disk_name=disk_name,
+                    disk_config=disk_config,
+                    ch_version=ch_version,
+                )
+                results.append(result)
+                if result.status == "regenerated":
+                    checksums_recovered_via_local = True
+                continue
+
+            if checksums_recovered_via_local and _is_projection_checksums(filename):
+                results.append(
+                    FileRecoveryResult(
+                        filename,
+                        "regenerated",
+                        "covered by parent checksums.txt clickhouse-local run",
+                    )
                 )
                 continue
 
@@ -317,3 +354,73 @@ def recover_part_files_locally(
             )
             results.append(FileRecoveryResult(filename, "failed", repr(exc)))
     return results
+
+
+def _is_projection_checksums(filename: str) -> bool:
+    """Return True if *filename* is a ``checksums.txt`` inside a projection sub-dir."""
+    # Projection files look like ``<name>.proj/checksums.txt``.
+    return filename.endswith(".proj/checksums.txt") or (
+        "/" in filename and filename.rsplit("/", 1)[-1] == "checksums.txt"
+    )
+
+
+def _recover_checksums_replicated(
+    *,
+    filename: str,
+    part_path: str,
+    recovery_ctx: PartRecoveryContext,
+    ctx: Optional[Context],
+    disk_name: Optional[str],
+    disk_config: Optional[dict],
+    ch_version: Optional[str],
+) -> FileRecoveryResult:
+    """Attempt to regenerate ``checksums.txt`` for a Replicated part via
+    ``clickhouse-local``.  Returns a :class:`FileRecoveryResult`.
+    """
+    if ctx is None or disk_name is None or disk_config is None or ch_version is None:
+        return FileRecoveryResult(
+            filename,
+            "skipped",
+            "clickhouse-local recovery not available (missing ctx/disk_name/disk_config/ch_version)",
+        )
+
+    raw_ddl = get_show_create_table(ctx, recovery_ctx.database, recovery_ctx.table)
+    if raw_ddl is None:
+        return FileRecoveryResult(
+            filename,
+            "skipped",
+            f"SHOW CREATE TABLE failed for {recovery_ctx.quoted_table}",
+        )
+
+    try:
+        recovery_ddl = build_recovery_ddl(raw_ddl, disk_name)
+    except Exception as exc:
+        return FileRecoveryResult(
+            filename,
+            "failed",
+            f"build_recovery_ddl failed: {exc!r}",
+        )
+
+    try:
+        recover_checksums_via_local(
+            detached_part_path=part_path,
+            part_name=recovery_ctx.part_name,
+            database=recovery_ctx.database,
+            table=recovery_ctx.table,
+            disk_name=disk_name,
+            disk_config=disk_config,
+            create_table_ddl=recovery_ddl,
+            ch_version=ch_version,
+        )
+    except Exception as exc:
+        return FileRecoveryResult(
+            filename,
+            "failed",
+            f"clickhouse-local run failed: {exc!r}",
+        )
+
+    return FileRecoveryResult(
+        filename,
+        "regenerated",
+        "checksums.txt regenerated via clickhouse-local (covers projection parts)",
+    )

--- a/ch_tools/chadmin/internal/object_storage/part_recovery.py
+++ b/ch_tools/chadmin/internal/object_storage/part_recovery.py
@@ -11,6 +11,7 @@ from click import Context
 from ch_tools.chadmin.internal.object_storage.checksums_recovery_via_local import (
     build_recovery_ddl,
     get_show_create_table,
+    is_projection_checksums,
     recover_checksums_via_local,
 )
 from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
@@ -281,10 +282,25 @@ def recover_part_files_locally(
     function only touches files inside ``part_path`` (which by then lives
     under ``…/detached/…``) and S3 objects.
     """
-    checksums_recovered_via_local: bool = False
-
     results: List[FileRecoveryResult] = []
+    restored_checksums: List[str] = []
+    if recovery_ctx.is_replicated and "checksums.txt" in missing_files:
+        result, restored_checksums = _recover_checksums_replicated(
+            filename="checksums.txt",
+            part_path=part_path,
+            missing_files=missing_files,
+            recovery_ctx=recovery_ctx,
+            ctx=ctx,
+            disk_name=disk_name,
+            disk_config=disk_config,
+            ch_version=ch_version,
+        )
+        results.append(result)
+
+    restored_checksums_set = set(restored_checksums)
     for filename in missing_files:
+        if filename == "checksums.txt" and recovery_ctx.is_replicated:
+            continue
         try:
             if filename == "checksums.txt" and not recovery_ctx.is_replicated:
                 # Plain MergeTree: unlink local metadata so CH regenerates
@@ -297,28 +313,12 @@ def recover_part_files_locally(
                 )
                 continue
 
-            if filename == "checksums.txt" and recovery_ctx.is_replicated:
-                # ReplicatedMergeTree: use clickhouse-local to regenerate.
-                result = _recover_checksums_replicated(
-                    filename=filename,
-                    part_path=part_path,
-                    recovery_ctx=recovery_ctx,
-                    ctx=ctx,
-                    disk_name=disk_name,
-                    disk_config=disk_config,
-                    ch_version=ch_version,
-                )
-                results.append(result)
-                if result.status == "regenerated":
-                    checksums_recovered_via_local = True
-                continue
-
-            if checksums_recovered_via_local and _is_projection_checksums(filename):
+            if filename in restored_checksums_set and is_projection_checksums(filename):
                 results.append(
                     FileRecoveryResult(
                         filename,
                         "regenerated",
-                        "covered by parent checksums.txt clickhouse-local run",
+                        "checksums.txt regenerated via clickhouse-local",
                     )
                 )
                 continue
@@ -356,53 +356,55 @@ def recover_part_files_locally(
     return results
 
 
-def _is_projection_checksums(filename: str) -> bool:
-    """Return True if *filename* is a ``checksums.txt`` inside a projection sub-dir."""
-    # Projection files look like ``<name>.proj/checksums.txt``.
-    return filename.endswith(".proj/checksums.txt") or (
-        "/" in filename and filename.rsplit("/", 1)[-1] == "checksums.txt"
-    )
-
-
 def _recover_checksums_replicated(
     *,
     filename: str,
     part_path: str,
+    missing_files: List[str],
     recovery_ctx: PartRecoveryContext,
     ctx: Optional[Context],
     disk_name: Optional[str],
     disk_config: Optional[dict],
     ch_version: Optional[str],
-) -> FileRecoveryResult:
+) -> Tuple[FileRecoveryResult, List[str]]:
     """Attempt to regenerate ``checksums.txt`` for a Replicated part via
     ``clickhouse-local``.  Returns a :class:`FileRecoveryResult`.
     """
     if ctx is None or disk_name is None or disk_config is None or ch_version is None:
-        return FileRecoveryResult(
-            filename,
-            "skipped",
-            "clickhouse-local recovery not available (missing ctx/disk_name/disk_config/ch_version)",
+        return (
+            FileRecoveryResult(
+                filename,
+                "skipped",
+                "clickhouse-local recovery not available (missing ctx/disk_name/disk_config/ch_version)",
+            ),
+            [],
         )
 
     raw_ddl = get_show_create_table(ctx, recovery_ctx.database, recovery_ctx.table)
     if raw_ddl is None:
-        return FileRecoveryResult(
-            filename,
-            "skipped",
-            f"SHOW CREATE TABLE failed for {recovery_ctx.quoted_table}",
+        return (
+            FileRecoveryResult(
+                filename,
+                "skipped",
+                f"SHOW CREATE TABLE failed for {recovery_ctx.quoted_table}",
+            ),
+            [],
         )
 
     try:
         recovery_ddl = build_recovery_ddl(raw_ddl, disk_name)
     except Exception as exc:
-        return FileRecoveryResult(
-            filename,
-            "failed",
-            f"build_recovery_ddl failed: {exc!r}",
+        return (
+            FileRecoveryResult(
+                filename,
+                "failed",
+                f"build_recovery_ddl failed: {exc!r}",
+            ),
+            [],
         )
 
     try:
-        recover_checksums_via_local(
+        restored_files = recover_checksums_via_local(
             detached_part_path=part_path,
             part_name=recovery_ctx.part_name,
             database=recovery_ctx.database,
@@ -411,16 +413,23 @@ def _recover_checksums_replicated(
             disk_config=disk_config,
             create_table_ddl=recovery_ddl,
             ch_version=ch_version,
+            missing_files=missing_files,
         )
     except Exception as exc:
-        return FileRecoveryResult(
-            filename,
-            "failed",
-            f"clickhouse-local run failed: {exc!r}",
+        return (
+            FileRecoveryResult(
+                filename,
+                "failed",
+                f"clickhouse-local run failed: {exc!r}",
+            ),
+            [],
         )
 
-    return FileRecoveryResult(
-        filename,
-        "regenerated",
-        "checksums.txt regenerated via clickhouse-local (covers projection parts)",
+    return (
+        FileRecoveryResult(
+            filename,
+            "regenerated",
+            "checksums.txt regenerated via clickhouse-local",
+        ),
+        restored_files,
     )

--- a/ch_tools/chadmin/internal/object_storage/part_recovery.py
+++ b/ch_tools/chadmin/internal/object_storage/part_recovery.py
@@ -6,11 +6,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from boto3 import client as Boto3Client
-from click import Context
+from click import ClickException, Context
 
 from ch_tools.chadmin.internal.object_storage.checksums_recovery_via_local import (
     build_recovery_ddl,
-    get_show_create_table,
     is_projection_checksums,
     recover_checksums_via_local,
 )
@@ -24,6 +23,7 @@ from ch_tools.chadmin.internal.object_storage.structural_files import (
     generate_default_compression_codec,
     generate_metadata_version,
 )
+from ch_tools.chadmin.internal.table_schema_diff import get_schema_from_clickhouse
 from ch_tools.chadmin.internal.utils import execute_query
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.client import OutputFormat
@@ -408,7 +408,18 @@ def _recover_checksums_replicated(
             [],
         )
 
-    raw_ddl = get_show_create_table(ctx, recovery_ctx.database, recovery_ctx.table)
+    try:
+        raw_ddl = get_schema_from_clickhouse(
+            ctx, recovery_ctx.database, recovery_ctx.table
+        )
+    except ClickException as exc:
+        raw_ddl = None
+        logging.warning(
+            "SHOW CREATE TABLE `{}`.`{}` failed: {}",
+            recovery_ctx.database,
+            recovery_ctx.table,
+            exc,
+        )
     if raw_ddl is None:
         return (
             FileRecoveryResult(

--- a/ch_tools/chadmin/internal/object_storage/part_recovery.py
+++ b/ch_tools/chadmin/internal/object_storage/part_recovery.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from boto3 import client as Boto3Client
+from click import Context
+
+from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
+    S3ObjectLocalInfo,
+    S3ObjectLocalMetaData,
+)
+from ch_tools.chadmin.internal.object_storage.structural_files import (
+    generate_columns_txt,
+    generate_count_txt,
+    generate_default_compression_codec,
+    generate_metadata_version,
+)
+from ch_tools.chadmin.internal.utils import execute_query
+from ch_tools.common import logging
+from ch_tools.common.clickhouse.client import OutputFormat
+
+# Names of files we can rebuild from cheap ClickHouse metadata only.
+SIMPLE_RECOVERABLE_FILES = {
+    "columns.txt",
+    "count.txt",
+    "default_compression_codec.txt",
+    "metadata_version.txt",
+}
+
+# Files whose recovery is recoverable in principle but is *not* part of
+# this PR — checksums.txt (needs clickhouse-local for Replicated, or local
+# unlink+ATTACH for non-Replicated, handled separately), and the various
+# binary structural files that need format-aware generators.
+UNSUPPORTED_FILES = {
+    "partition.dat",
+    "ttl.txt",
+    "serialization.json",
+    "columns_substreams.txt",
+}
+
+
+@dataclass
+class PartRecoveryContext:
+    """Everything we need to regenerate the simple files of one part."""
+
+    database: str
+    table: str
+    part_name: str
+    part_type: Optional[str]
+    rows: int
+    metadata_version: int
+    default_codec: str
+    is_replicated: bool
+    columns: List[Tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def quoted_table(self) -> str:
+        return f"`{self.database}`.`{self.table}`"
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse metadata queries
+# ---------------------------------------------------------------------------
+
+
+def get_part_recovery_context(
+    ctx: Context, part_path: str
+) -> Optional[PartRecoveryContext]:
+    """Collect table + part metadata required for structural recovery.
+
+    Returns ``None`` if the part is not found in ``system.parts`` (e.g.
+    it has already been detached or merged away).
+    """
+    parts_query = (
+        "SELECT database, table, name, part_type, rows, default_compression_codec "
+        f"FROM system.parts WHERE path = '{part_path}/' AND active LIMIT 1"
+    )
+    parts_res = execute_query(ctx, parts_query, format_=OutputFormat.JSONCompact)
+    if not parts_res.get("data"):
+        logging.warning("Part not found in system.parts for path {}", part_path)
+        return None
+    (
+        database,
+        table,
+        part_name,
+        part_type,
+        rows,
+        default_codec,
+    ) = parts_res[
+        "data"
+    ][0]
+
+    tables_query = (
+        "SELECT engine, metadata_version FROM system.tables "
+        f"WHERE database = '{database}' AND name = '{table}' LIMIT 1"
+    )
+    tables_res = execute_query(ctx, tables_query, format_=OutputFormat.JSONCompact)
+    if not tables_res.get("data"):
+        logging.warning("Table {}.{} not found in system.tables", database, table)
+        return None
+    engine, metadata_version = tables_res["data"][0]
+
+    columns_query = (
+        "SELECT name, type FROM system.columns "
+        f"WHERE database = '{database}' AND table = '{table}' "
+        "ORDER BY position"
+    )
+    columns_res = execute_query(ctx, columns_query, format_=OutputFormat.JSONCompact)
+    columns: List[Tuple[str, str]] = [
+        (row[0], row[1]) for row in columns_res.get("data", [])
+    ]
+
+    return PartRecoveryContext(
+        database=database,
+        table=table,
+        part_name=part_name,
+        part_type=part_type,
+        rows=int(rows),
+        metadata_version=int(metadata_version) if metadata_version is not None else 0,
+        default_codec=default_codec or "CODEC(LZ4)",
+        is_replicated="Replicated" in (engine or ""),
+        columns=columns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# File content generation
+# ---------------------------------------------------------------------------
+
+
+def generate_simple_recoverable_file(
+    filename: str, recovery_ctx: PartRecoveryContext
+) -> bytes:
+    """Build the textual payload for one of :data:`SIMPLE_RECOVERABLE_FILES`."""
+    if filename == "columns.txt":
+        return generate_columns_txt(recovery_ctx.columns)
+    if filename == "count.txt":
+        return generate_count_txt(recovery_ctx.rows)
+    if filename == "default_compression_codec.txt":
+        return generate_default_compression_codec(recovery_ctx.default_codec)
+    if filename == "metadata_version.txt":
+        return generate_metadata_version(recovery_ctx.metadata_version)
+    raise ValueError(f"No simple generator for {filename!r}")
+
+
+# ---------------------------------------------------------------------------
+# S3 upload — always under a brand-new key
+# ---------------------------------------------------------------------------
+
+
+def upload_recovered_file_to_s3(
+    s3_client: Boto3Client,
+    bucket: str,
+    prefix: str,
+    content: bytes,
+) -> Tuple[str, int]:
+    """
+    Upload ``content`` to S3 under a freshly generated key and return
+    ``(key, size)`` that the caller will record in the local disk-metadata
+    file of the part.
+
+    The key is *never* the old one — that blob may still be referenced by
+    other replicas through ``remote_fs_zero_copy_path`` in ZooKeeper.
+    """
+    if not prefix.endswith("/"):
+        prefix = prefix + "/"
+    # Match ClickHouse's pattern: <prefix>/<xx>/<random uuid4 hex>.
+    rand = uuid.uuid4().hex
+    key = f"{prefix}{rand[:3]}/{rand}"
+    s3_client.put_object(Bucket=bucket, Key=key, Body=content)
+    return key, len(content)
+
+
+# ---------------------------------------------------------------------------
+# Local disk-metadata file rewriting
+# ---------------------------------------------------------------------------
+
+
+def rewrite_disk_metadata(
+    metadata_path: Path,
+    new_key: str,
+    new_size: int,
+) -> None:
+    """
+    Rewrite the local disk-metadata file at ``metadata_path`` so that it
+    points at exactly one new S3 object (``new_key``/``new_size``).
+
+    Used after a fresh blob has been uploaded for a regenerated file —
+    the old blob may still be referenced by zero-copy replicas, so we
+    *replace* the local pointer without touching the old key in S3.
+    """
+    if metadata_path.exists():
+        old = S3ObjectLocalMetaData.from_file(metadata_path)
+        version = old.version
+        key_is_full = old.has_full_object_key()
+        ref_counter = old.ref_counter
+        read_only = old.read_only
+    else:
+        # Pre-VERSION_FULL_OBJECT_KEY default — local keys (relative to the
+        # disk prefix).  We use it only for brand-new files; for the
+        # detect-broken-partitions flow the file always pre-exists.
+        version = 3
+        key_is_full = False
+        ref_counter = 0
+        read_only = False
+
+    new_meta = S3ObjectLocalMetaData(
+        version=version,
+        total_size=new_size,
+        objects=[
+            S3ObjectLocalInfo(key=new_key, size=new_size, key_is_full=key_is_full)
+        ],
+        ref_counter=ref_counter,
+        read_only=read_only,
+    )
+    new_meta.to_file(metadata_path)
+
+
+# ---------------------------------------------------------------------------
+# Recovery flow
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileRecoveryResult:
+    filename: str
+    status: str  # "regenerated" / "unlinked" / "skipped" / "failed"
+    detail: str = ""
+
+
+@dataclass
+class PartRecoveryResult:
+    part_path: str
+    part_name: Optional[str]
+    table: Optional[str]
+    files: List[FileRecoveryResult] = field(default_factory=list)
+    detached: bool = False
+    reattached: bool = False
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "part_path": self.part_path,
+            "part_name": self.part_name,
+            "table": self.table,
+            "files": [
+                {"filename": f.filename, "status": f.status, "detail": f.detail}
+                for f in self.files
+            ],
+            "detached": self.detached,
+            "reattached": self.reattached,
+            "error": self.error,
+        }
+
+
+def recover_part_files_locally(
+    *,
+    part_path: str,
+    missing_files: List[str],
+    recovery_ctx: PartRecoveryContext,
+    s3_client: Boto3Client,
+    bucket: str,
+    s3_prefix: str,
+) -> List[FileRecoveryResult]:
+    """
+    Walk ``missing_files`` and perform the per-file recovery action.
+
+    The part is expected to be *already detached* at this point — the
+    function only touches files inside ``part_path`` (which by then lives
+    under ``…/detached/…``) and S3 objects.
+    """
+    results: List[FileRecoveryResult] = []
+    for filename in missing_files:
+        try:
+            if filename == "checksums.txt" and not recovery_ctx.is_replicated:
+                # Plain MergeTree: unlink local metadata so CH regenerates
+                # the file on ATTACH via checkDataPart + writeChecksums.
+                target = Path(part_path) / filename
+                if target.exists():
+                    target.unlink()
+                results.append(
+                    FileRecoveryResult(filename, "unlinked", "non-replicated MergeTree")
+                )
+                continue
+
+            if filename in UNSUPPORTED_FILES:
+                results.append(
+                    FileRecoveryResult(filename, "skipped", "not yet implemented")
+                )
+                continue
+
+            if filename in SIMPLE_RECOVERABLE_FILES:
+                payload = generate_simple_recoverable_file(filename, recovery_ctx)
+                new_key, new_size = upload_recovered_file_to_s3(
+                    s3_client, bucket, s3_prefix, payload
+                )
+                rewrite_disk_metadata(Path(part_path) / filename, new_key, new_size)
+                results.append(
+                    FileRecoveryResult(
+                        filename, "regenerated", f"new s3 key {new_key} ({new_size} B)"
+                    )
+                )
+                continue
+
+            results.append(
+                FileRecoveryResult(filename, "skipped", "no recovery action available")
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.warning(
+                "Recovery of {} for part {} failed: {!r}",
+                filename,
+                part_path,
+                exc,
+            )
+            results.append(FileRecoveryResult(filename, "failed", repr(exc)))
+    return results

--- a/ch_tools/chadmin/internal/object_storage/s3_object_metadata.py
+++ b/ch_tools/chadmin/internal/object_storage/s3_object_metadata.py
@@ -1,3 +1,4 @@
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -109,3 +110,32 @@ class S3ObjectLocalMetaData:
         Whether key also contains object storage prefix or not.
         """
         return self._version_with_full_object_key(self.version)
+
+    def to_string(self) -> str:
+        """
+        Serialize the metadata back to the on-disk textual representation
+        used by ClickHouse object-storage disks.
+
+        Format (matches the parser above):
+
+            <version>
+            <object_count> <total_size>
+            <size> <key>
+            ...
+            <ref_counter>
+            <read_only>
+        """
+        lines = [str(self.version), f"{len(self.objects)} {self.total_size}"]
+        for obj in self.objects:
+            lines.append(f"{obj.size} {obj.key}")
+        lines.append(str(self.ref_counter))
+        lines.append("1" if self.read_only else "0")
+        # ClickHouse writes a trailing newline.
+        return "\n".join(lines) + "\n"
+
+    def to_file(self, path: Path) -> None:
+        """Atomically write the metadata representation to ``path``."""
+        tmp = path.with_suffix(path.suffix + ".chadmin-tmp")
+        with tmp.open("w", encoding="latin-1") as file:
+            file.write(self.to_string())
+        os.replace(tmp, path)

--- a/ch_tools/chadmin/internal/object_storage/s3_object_metadata.py
+++ b/ch_tools/chadmin/internal/object_storage/s3_object_metadata.py
@@ -1,8 +1,9 @@
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+
+from ch_tools.common.utils import atomic_write_file
 
 MAX_METADATA_FILE_SIZE = 10 * 1024
 VERSION_FULL_OBJECT_KEY = 5
@@ -135,7 +136,4 @@ class S3ObjectLocalMetaData:
 
     def to_file(self, path: Path) -> None:
         """Atomically write the metadata representation to ``path``."""
-        tmp = path.with_suffix(path.suffix + ".chadmin-tmp")
-        with tmp.open("w", encoding="latin-1") as file:
-            file.write(self.to_string())
-        os.replace(tmp, path)
+        atomic_write_file(path, self.to_string().encode("latin-1"))

--- a/ch_tools/chadmin/internal/object_storage/structural_files.py
+++ b/ch_tools/chadmin/internal/object_storage/structural_files.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+
+def _back_quote(name: str) -> str:
+    """Quote a column identifier the same way ClickHouse does."""
+    escaped = name.replace("\\", "\\\\").replace("`", "\\`")
+    return f"`{escaped}`"
+
+
+def generate_columns_txt(columns: Sequence[Tuple[str, str]]) -> bytes:
+    if not columns:
+        raise ValueError("columns.txt generation requires a non-empty column list")
+
+    lines: List[str] = [
+        "columns format version: 1",
+        f"{len(columns)} columns:",
+    ]
+    for name, type_ in columns:
+        lines.append(f"{_back_quote(name)} {type_}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def generate_count_txt(rows: int) -> bytes:
+    if rows < 0:
+        raise ValueError("count.txt: row count must be non-negative")
+    return f"{rows}\n".encode("ascii")
+
+
+def generate_default_compression_codec(codec: str = "CODEC(LZ4)") -> bytes:
+    codec = codec.strip()
+    if not codec:
+        raise ValueError("default_compression_codec.txt: codec must not be empty")
+    return (codec + "\n").encode("utf-8")
+
+
+def generate_metadata_version(metadata_version: int) -> bytes:
+    if metadata_version < 0:
+        raise ValueError("metadata_version.txt: version must be non-negative")
+    return f"{metadata_version}\n".encode("ascii")

--- a/ch_tools/common/utils.py
+++ b/ch_tools/common/utils.py
@@ -7,6 +7,16 @@ from typing import Any, Dict, List, Union
 from click import Context
 
 
+def atomic_write_file(path: Path, content: bytes) -> None:
+    """
+    Atomically write ``content`` to ``path`` using a temporary file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".chadmin-tmp")
+    tmp.write_bytes(content)
+    os.replace(tmp, path)
+
+
 def version_ge(version1: str, version2: str) -> bool:
     """
     Return True if version1 is greater or equal than version2.

--- a/tests/features/data_storage_group.feature
+++ b/tests/features/data_storage_group.feature
@@ -247,7 +247,7 @@ Feature: chadmin data-store commands
     """
     When we execute query on clickhouse01
     """
-    SELECT groupArray((a, b)) FROM test_db.mixed_recovery
+    SELECT arraySort(groupArray((a, b))) FROM test_db.mixed_recovery
     """
     Then we get response
     """

--- a/tests/features/data_storage_group.feature
+++ b/tests/features/data_storage_group.feature
@@ -89,6 +89,187 @@ Feature: chadmin data-store commands
       deleted: 'Yes'
     """
 
+  @require_version_23.3
+  Scenario: Detect broken object-storage part by missing structural file
+    When we execute queries on clickhouse01
+    """
+    SYSTEM STOP MERGES;
+
+    DROP DATABASE IF EXISTS test_db;
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.recoverable_plain (a UInt32, b UInt32)
+    ENGINE=MergeTree() ORDER BY a PARTITION BY b
+    SETTINGS storage_policy='object_storage';
+    INSERT INTO test_db.recoverable_plain SELECT number, number FROM numbers(3);
+    """
+    And we remove s3 objects for part files on clickhouse01
+    """
+    test_db:
+      recoverable_plain:
+        '0': ['columns.txt']
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions
+    """
+    Then we get response contains
+    """
+    - table: '`test_db`.`recoverable_plain`'
+      partition: '0'
+    """
+
+  @require_version_23.3
+  Scenario: Restore recoverable object-storage MergeTree part
+    When we execute queries on clickhouse01
+    """
+    SYSTEM STOP MERGES;
+
+    DROP DATABASE IF EXISTS test_db;
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.recoverable_plain (a UInt32, b UInt32)
+    ENGINE=MergeTree() ORDER BY a PARTITION BY b
+    SETTINGS storage_policy='object_storage';
+    INSERT INTO test_db.recoverable_plain SELECT number, number FROM numbers(3);
+    """
+    And we remove s3 objects for part files on clickhouse01
+    """
+    test_db:
+      recoverable_plain:
+        '0': ['columns.txt']
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions --restore-recoverable
+    """
+    Then we get response contains
+    """
+    - table: '`test_db`.`recoverable_plain`'
+      partition: '0'
+    """
+    When we execute query on clickhouse01
+    """
+    SELECT sum(a), sum(b) FROM test_db.recoverable_plain
+    """
+    Then we get response
+    """
+    3	3
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions
+    """
+    Then we get response contains
+    """
+    []
+    """
+
+  @require_version_23.3
+  Scenario: Restore ReplicatedMergeTree checksums via clickhouse-local
+    When we execute queries on clickhouse01
+    """
+    SYSTEM STOP MERGES;
+
+    DROP DATABASE IF EXISTS test_db;
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.replicated_checksums (a UInt32, b UInt32)
+    ENGINE=ReplicatedMergeTree('/clickhouse/test_db/replicated_checksums', '{replica}') ORDER BY a PARTITION BY b
+    SETTINGS storage_policy='object_storage';
+    INSERT INTO test_db.replicated_checksums SELECT number, number FROM numbers(3);
+    """
+    And we remove s3 objects for part files on clickhouse01
+    """
+    test_db:
+      replicated_checksums:
+        '0': ['checksums.txt']
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions --restore-recoverable
+    """
+    Then we get response contains
+    """
+    - table: '`test_db`.`replicated_checksums`'
+      partition: '0'
+    """
+    When we execute query on clickhouse01
+    """
+    SELECT sum(a), sum(b) FROM test_db.replicated_checksums
+    """
+    Then we get response
+    """
+    3	3
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions
+    """
+    Then we get response contains
+    """
+    []
+    """
+
+  @require_version_23.3
+  Scenario: Detach unrecoverable object-storage partition while restoring recoverable partitions
+    When we execute queries on clickhouse01
+    """
+    SYSTEM STOP MERGES;
+
+    DROP DATABASE IF EXISTS test_db;
+    CREATE DATABASE test_db;
+    CREATE TABLE test_db.mixed_recovery (a UInt32, b UInt32)
+    ENGINE=MergeTree() ORDER BY a PARTITION BY b
+    SETTINGS storage_policy='object_storage', min_bytes_for_wide_part=0;
+    INSERT INTO test_db.mixed_recovery VALUES (0, 0);
+    INSERT INTO test_db.mixed_recovery VALUES (1, 1);
+    CREATE TABLE test_db.unrecoverable_part (a UInt32, b UInt32)
+    ENGINE=MergeTree() ORDER BY a PARTITION BY b
+    SETTINGS storage_policy='object_storage', min_bytes_for_wide_part=0;
+    INSERT INTO test_db.unrecoverable_part VALUES (1, 1);
+    """
+    And we remove s3 objects for part files on clickhouse01
+    """
+    test_db:
+      mixed_recovery:
+        '0': ['checksums.txt']
+      unrecoverable_part:
+        '1': ['a.bin']
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions --restore-recoverable --detach
+    """
+    Then we get response contains
+    """
+    - table: '`test_db`.`mixed_recovery`'
+      partition: '0'
+    - table: '`test_db`.`unrecoverable_part`'
+      partition: '1'
+    """
+    When we execute query on clickhouse01
+    """
+    SELECT groupArray((a, b)) FROM test_db.mixed_recovery
+    """
+    Then we get response
+    """
+    [(0,0),(1,1)]
+    """
+    When we execute query on clickhouse01
+    """
+    SELECT count() FROM test_db.unrecoverable_part
+    """
+    Then we get response
+    """
+    0
+    """
+    When we execute command on clickhouse01
+    """
+    chadmin --format yaml data-store detect-broken-partitions
+    """
+    Then we get response contains
+    """
+    []
+    """
+
   # TODO: enable after detach partition fix
   @skip
   Scenario Outline: Reattach partitions with broken parts from zero copy

--- a/tests/steps/failure_mockers.py
+++ b/tests/steps/failure_mockers.py
@@ -24,21 +24,64 @@ def step_remove_keys_from_s3_for_partition(
     for database, database_info in data.items():
         for table, table_info in database_info.items():
             for partition in table_info:
-                get_parts_info_query = f"SELECT name, partition, path  FROM system.parts where database='{database}' and table='{table}' and partition='{partition}'"
-                # Get local path on disk to the single data part.
-                part_local_path = execute_query(
-                    context, node, get_parts_info_query, format_="JSONCompact"
-                )["data"][0][2]
-                # For this part, get the single object key in s3.
-                get_object_key_query = f"SELECT concat(path, local_path) AS full_path, remote_path from system.remote_data_paths  WHERE disk_name='object_storage'  and startsWith(full_path, '{os.path.join(part_local_path, 'columns.txt')}')"
-                data_object_key = execute_query(
-                    context, node, get_object_key_query, format_="JSONCompact"
-                )["data"][0][1]
-                keys_to_remove.append(data_object_key)
+                keys_to_remove.append(
+                    _get_part_file_s3_key(
+                        context, node, database, table, partition, "columns.txt"
+                    )
+                )
 
     s3_client = s3.S3Client(context)
     for key in keys_to_remove:
         s3_client.delete_data(key)
+
+
+@when("we remove s3 objects for part files on {node:w}")
+def step_remove_s3_objects_for_part_files(context: ContextT, node: str) -> None:
+    data = get_step_data(context)
+    keys_to_remove = []
+
+    for database, database_info in data.items():
+        for table, table_info in database_info.items():
+            for partition, files in table_info.items():
+                for filename in files:
+                    keys_to_remove.append(
+                        _get_part_file_s3_key(
+                            context, node, database, table, str(partition), filename
+                        )
+                    )
+
+    s3_client = s3.S3Client(context)
+    for key in keys_to_remove:
+        s3_client.delete_data(key)
+
+
+def _get_part_file_s3_key(
+    context: ContextT,
+    node: str,
+    database: str,
+    table: str,
+    partition: str,
+    filename: str,
+) -> str:
+    get_parts_info_query = (
+        "SELECT name, partition, path FROM system.parts "
+        f"WHERE database='{database}' AND table='{table}' "
+        f"AND partition='{partition}' AND active LIMIT 1"
+    )
+    part_local_path = execute_query(
+        context, node, get_parts_info_query, format_="JSONCompact"
+    )["data"][0][2]
+
+    file_local_path = os.path.join(part_local_path, filename)
+    container = get_container(context, node)
+    result = container.exec_run(
+        ["bash", "-c", f"sed -n '3p' {file_local_path} | awk '{{print $2}}'"],
+        user="root",
+    )
+    assert_that(result.exit_code, equal_to(0))
+    key = result.output.decode().strip()
+    assert key, f"S3 object metadata for {file_local_path} was not found"
+    return key
 
 
 @when("we move parts as broken_on_start for table {database}.{table} on {node:w}")

--- a/tests/steps/failure_mockers.py
+++ b/tests/steps/failure_mockers.py
@@ -12,6 +12,10 @@ from modules.docker import get_container
 from modules.steps import get_step_data
 from modules.typing import ContextT
 
+from ch_tools.chadmin.internal.object_storage.s3_object_metadata import (
+    S3ObjectLocalMetaData,
+)
+
 
 @when("we remove key from s3 for partitions database {database} on {node:w}")
 def step_remove_keys_from_s3_for_partition(
@@ -75,16 +79,17 @@ def _get_part_file_s3_key(
     file_local_path = os.path.join(part_local_path, filename)
     container = get_container(context, node)
     result = container.exec_run(
-        ["bash", "-c", f"sed -n '1p;3p' {file_local_path}"],
+        ["cat", file_local_path],
         user="root",
     )
     assert_that(result.exit_code, equal_to(0))
-    lines = result.output.decode().splitlines()
-    assert len(lines) == 2, f"S3 object metadata for {file_local_path} was not found"
 
-    version = int(lines[0])
-    key = lines[1].split(maxsplit=1)[1]
-    if version < 5:
+    metadata = S3ObjectLocalMetaData.from_string(result.output.decode())
+    assert metadata.objects, f"S3 object metadata for {file_local_path} was not found"
+
+    obj = metadata.objects[0]
+    key = obj.key
+    if not obj.key_is_full:
         key = f"data/cluster_id/shard_1/{key}"
     return key
 

--- a/tests/steps/failure_mockers.py
+++ b/tests/steps/failure_mockers.py
@@ -75,12 +75,17 @@ def _get_part_file_s3_key(
     file_local_path = os.path.join(part_local_path, filename)
     container = get_container(context, node)
     result = container.exec_run(
-        ["bash", "-c", f"sed -n '3p' {file_local_path} | awk '{{print $2}}'"],
+        ["bash", "-c", f"sed -n '1p;3p' {file_local_path}"],
         user="root",
     )
     assert_that(result.exit_code, equal_to(0))
-    key = result.output.decode().strip()
-    assert key, f"S3 object metadata for {file_local_path} was not found"
+    lines = result.output.decode().splitlines()
+    assert len(lines) == 2, f"S3 object metadata for {file_local_path} was not found"
+
+    version = int(lines[0])
+    key = lines[1].split(maxsplit=1)[1]
+    if version < 5:
+        key = f"data/cluster_id/shard_1/{key}"
     return key
 
 


### PR DESCRIPTION
## Summary by Sourcery

Extend broken part detection in object storage to classify and optionally repair parts, and add utilities to regenerate structural files for recoverable parts.

New Features:
- Add a --restore-recoverable flag to detect-broken-partitions to automatically detach, repair, and reattach recoverable parts while detaching unrecoverable ones.
- Introduce part file classification logic to categorize missing files by recoverability for MergeTree parts.
- Add utilities to regenerate simple structural files (e.g., columns.txt, count.txt, default_compression_codec.txt, metadata_version.txt) from ClickHouse metadata and rewrite corresponding S3 disk metadata.

Enhancements:
- Optimize S3 checks for part files by batching key existence lookups and reducing repeated queries to ClickHouse metadata.
- Improve logging and reporting for broken parts, including per-part recovery results and clearer debug output.