### PR TITLE
Optimize recursive ZooKeeper deletion for large trees

### DIFF
--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -5,6 +5,8 @@ from typing import Any, Generator, Optional
 from cloup import (
     Choice,
     Context,
+    FloatRange,
+    IntRange,
     argument,
     constraint,
     group,
@@ -26,6 +28,7 @@ from ch_tools.chadmin.internal.table_replica import (
 from ch_tools.chadmin.internal.utils import chunked
 from ch_tools.chadmin.internal.zero_copy import generate_zero_copy_lock_tasks
 from ch_tools.chadmin.internal.zookeeper import (
+    DEFAULT_DELETE_MAX_SWEEPS,
     check_zk_node,
     create_zk_nodes,
     delete_zk_nodes,
@@ -276,15 +279,38 @@ def update_command(
     type=StringParamType(),
     help="ZooKeeper node path. Can be specified multiple times.",
 )
+@option(
+    "--max-sweeps",
+    type=IntRange(min=0),
+    default=DEFAULT_DELETE_MAX_SWEEPS,
+    show_default=True,
+    help="Maximum deletion sweeps; 0 retries until completion.",
+)
+@option(
+    "--delete-timeout",
+    type=FloatRange(min=0.0, min_open=True),
+    help="Soft wall-clock deadline for deletion, in seconds.",
+)
 @pass_context
-def delete_command(ctx: Context, path: Optional[str], paths: tuple[str, ...]) -> None:
+def delete_command(
+    ctx: Context,
+    path: Optional[str],
+    paths: tuple[str, ...],
+    max_sweeps: int,
+    delete_timeout: Optional[float],
+) -> None:
     """Delete one or more ZooKeeper nodes.
 
     Node paths can be specified with ClickHouse macros (e.g. "/test_table/{shard}/replicas/{replica}").
     Use repeated --path options to delete multiple nodes.
     """
     paths_ = [path] if path is not None else list(paths)
-    delete_zk_nodes(ctx, paths_)
+    delete_zk_nodes(
+        ctx,
+        paths_,
+        max_sweeps=max_sweeps,
+        delete_timeout=delete_timeout,
+    )
 
 
 @zookeeper_group.command("get-table-metadata")

--- a/ch_tools/chadmin/cli/zookeeper_group.py
+++ b/ch_tools/chadmin/cli/zookeeper_group.py
@@ -28,7 +28,6 @@ from ch_tools.chadmin.internal.table_replica import (
 from ch_tools.chadmin.internal.utils import chunked
 from ch_tools.chadmin.internal.zero_copy import generate_zero_copy_lock_tasks
 from ch_tools.chadmin.internal.zookeeper import (
-    DEFAULT_DELETE_MAX_SWEEPS,
     check_zk_node,
     create_zk_nodes,
     delete_zk_nodes,
@@ -282,7 +281,7 @@ def update_command(
 @option(
     "--max-sweeps",
     type=IntRange(min=0),
-    default=DEFAULT_DELETE_MAX_SWEEPS,
+    default=3,
     show_default=True,
     help="Maximum deletion sweeps; 0 retries until completion.",
 )

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -11,7 +11,8 @@ import re
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from math import sqrt
+from enum import Enum, auto
+from time import monotonic
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Union
 
 from click import Context
@@ -20,43 +21,115 @@ from kazoo.exceptions import NodeExistsError, NoNodeError, NotEmptyError
 from kazoo.protocol.states import ZnodeStat
 from kazoo.retry import KazooRetry
 
-from ch_tools.chadmin.internal.utils import chunked, replace_macros
+from ch_tools.chadmin.internal.utils import replace_macros
 from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_clickhouse_config, get_macros
 from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 from ch_tools.common.utils import escape_for_file_name, unescape_for_file_name
 
-LARGE_RECURSIVE_DELETE_THRESHOLD = 10_000
-LARGE_RECURSIVE_DELETE_BATCH_SIZE = 1_000
-LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS = 3
 LARGE_RECURSIVE_DELETE_LOG_INTERVAL = 100_000
+MAX_MULTI_OPS = 1_000
+MAX_MULTI_BYTES = 512 * 1024
+DELETE_OP_OVERHEAD = 32
+DEFAULT_DELETE_MAX_SWEEPS = 3
 
 
 @dataclass
 class _DeleteProgress:
     deleted: int = 0
     already_absent: int = 0
+    not_empty: int = 0
+    sweeps: int = 0
+    retained_branches: int = 0
 
 
 @dataclass
-class _DeletionConvergence:
-    minimum_children: Optional[int] = None
-    stagnant_windows: int = 0
+class _ProbeResult:
+    postorder: Optional[List[str]]
+    children: Dict[str, List[str]]
+    deadline_reached: bool = False
 
-    def observe(self, path: str, remaining_children: int) -> None:
-        if self.minimum_children is None or remaining_children < self.minimum_children:
-            self.minimum_children = remaining_children
-            self.stagnant_windows = 0
-            return
 
-        self.stagnant_windows += 1
-        if self.stagnant_windows >= LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS:
-            raise RuntimeError(
-                f"Recursive deletion of {path} does not converge: "
-                f"{remaining_children} children remain after "
-                f"{self.stagnant_windows} non-decreasing windows. "
-                "Stop writers or increase deletion throughput."
-            )
+def _path_delete_size(path: str) -> int:
+    return len(path.encode("utf-8")) + DELETE_OP_OVERHEAD
+
+
+def _deadline_reached(deadline: Optional[float]) -> bool:
+    return deadline is not None and monotonic() >= deadline
+
+
+def _probe_subtree(
+    zk: KazooClient, root_path: str, deadline: Optional[float] = None
+) -> _ProbeResult:
+    estimated_bytes = _path_delete_size(root_path)
+    if estimated_bytes > MAX_MULTI_BYTES:
+        return _ProbeResult(None, {})
+
+    operation_count = 1
+    preorder = []
+    pending = [root_path]
+    cached_children: Dict[str, List[str]] = {}
+
+    while pending:
+        if _deadline_reached(deadline):
+            return _ProbeResult(None, cached_children, deadline_reached=True)
+        path = pending.pop()
+        preorder.append(path)
+        children = get_children(zk, path)
+        cached_children[path] = children
+        child_paths = []
+        for child in children:
+            child_path = os.path.join(path, child)
+            operation_count += 1
+            estimated_bytes += _path_delete_size(child_path)
+            if operation_count > MAX_MULTI_OPS or estimated_bytes > MAX_MULTI_BYTES:
+                return _ProbeResult(None, cached_children)
+            child_paths.append(child_path)
+        pending.extend(reversed(child_paths))
+
+    return _ProbeResult(list(reversed(preorder)), cached_children)
+
+
+class _DeleteOutcome(Enum):
+    DELETED = auto()
+    ABSENT = auto()
+    NOT_EMPTY = auto()
+
+
+def _delete_candidates(
+    zk: KazooClient, paths: List[str], progress: _DeleteProgress
+) -> List[_DeleteOutcome]:
+    if not paths:
+        return []
+
+    estimated_bytes = sum(_path_delete_size(path) for path in paths)
+    if len(paths) <= MAX_MULTI_OPS and estimated_bytes <= MAX_MULTI_BYTES:
+        transaction = zk.transaction()
+        for path in paths:
+            transaction.delete(path)
+        result = transaction.commit()
+        if len(result) == len(paths) and all(item is True for item in result):
+            progress.deleted += len(paths)
+            return [_DeleteOutcome.DELETED] * len(paths)
+
+        logging.info(
+            "Delete transaction failed; falling back to {} individual deletes",
+            len(paths),
+        )
+
+    outcomes = []
+    for path in paths:
+        try:
+            zk.delete(path)
+            progress.deleted += 1
+            outcomes.append(_DeleteOutcome.DELETED)
+        except NoNodeError:
+            progress.already_absent += 1
+            outcomes.append(_DeleteOutcome.ABSENT)
+        except NotEmptyError:
+            progress.not_empty += 1
+            outcomes.append(_DeleteOutcome.NOT_EMPTY)
+    return outcomes
 
 
 class ZKTransactionBuilder:
@@ -241,10 +314,22 @@ def delete_zk_node(ctx: Context, path: str, dry_run: bool = False) -> None:
     delete_zk_nodes(ctx, [path], dry_run)
 
 
-def delete_zk_nodes(ctx: Context, paths: List[str], dry_run: bool = False) -> None:
+def delete_zk_nodes(
+    ctx: Context,
+    paths: List[str],
+    dry_run: bool = False,
+    max_sweeps: int = DEFAULT_DELETE_MAX_SWEEPS,
+    delete_timeout: Optional[float] = None,
+) -> None:
     paths_formated = [format_path(ctx, path) for path in paths]
     with zk_client(ctx) as zk:
-        delete_recursive(zk, paths_formated, dry_run)
+        delete_recursive(
+            zk,
+            paths_formated,
+            dry_run,
+            max_sweeps=max_sweeps,
+            delete_timeout=delete_timeout,
+        )
 
 
 def format_path(ctx: Context, path: str) -> str:
@@ -328,60 +413,6 @@ def find_leafs_and_nodes(
     yield from _gen_matched_paths(root_path)
 
 
-def delete_nodes_transaction(
-    zk: KazooClient,
-    to_delete_in_trasaction: List[str],
-    progress: _DeleteProgress,
-) -> None:
-    """
-    Perform deletion for the list of nodes in a single transaction.
-    If the transaction fails, go through the list and delete the nodes one by one.
-    """
-    delete_transaction = zk.transaction()
-    for node in to_delete_in_trasaction:
-        delete_transaction.delete(node)
-    result = delete_transaction.commit()
-
-    if len(result) == len(to_delete_in_trasaction) and all(
-        item is True for item in result
-    ):
-        # Transaction completed successfully, exit.
-        progress.deleted += len(to_delete_in_trasaction)
-        return
-
-    logging.info(
-        "Delete transaction have failed. Fallthrough to single delete operations for zk_nodes : {}",
-        to_delete_in_trasaction,
-    )
-    for index, node in enumerate(to_delete_in_trasaction):
-        if index < len(result) and isinstance(result[index], NoNodeError):
-            progress.already_absent += 1
-            continue
-
-        stat = zk.exists(node)
-        if stat is None:
-            progress.already_absent += 1
-            continue
-
-        convergence = _DeletionConvergence()
-        while True:
-            try:
-                zk.delete(node, recursive=True)
-                progress.deleted += 1
-                break
-            except NoNodeError:
-                #  Someone deleted node before us. Do nothing.
-                logging.error("Node {} is already absent, skipped", node)
-                progress.already_absent += 1
-                break
-            except NotEmptyError:
-                stat = zk.exists(node)
-                if stat is None:
-                    progress.already_absent += 1
-                    break
-                convergence.observe(node, stat.children_count)
-
-
 def remove_subpaths(paths: List[str]) -> List[str]:
     """
     Removing from the list paths that are subpath of another.
@@ -409,7 +440,9 @@ class _DeleteFrame:
     path: str
     children: Optional[List[str]] = None
     next_child: int = 0
-    convergence: _DeletionConvergence = field(default_factory=_DeletionConvergence)
+    to_expand: List[str] = field(default_factory=list)
+    ready: List[str] = field(default_factory=list)
+    retained: bool = False
 
 
 def _collect_nodes_up_to(
@@ -431,120 +464,170 @@ def _collect_nodes_up_to(
     return nodes
 
 
-def _delete_leaf_candidates(
-    zk: KazooClient, paths: List[str], progress: _DeleteProgress
-) -> List[str]:
-    """Delete leaves and return candidates which still have children."""
-    if not paths:
-        return []
-
-    delete_transaction = zk.transaction()
-    for path in paths:
-        delete_transaction.delete(path)
-    result = delete_transaction.commit()
-
-    if len(result) == len(paths) and all(item is True for item in result):
-        progress.deleted += len(paths)
-        return []
-
-    if len(paths) > 1:
-        middle = len(paths) // 2
-        return _delete_leaf_candidates(
-            zk, paths[:middle], progress
-        ) + _delete_leaf_candidates(zk, paths[middle:], progress)
-
-    path = paths[0]
-    try:
-        zk.delete(path)
-        progress.deleted += 1
-        return []
-    except NoNodeError:
-        progress.already_absent += 1
-        return []
-    except NotEmptyError:
-        return paths
+def _take_child_batch(
+    parent: str, children: List[str], start: int
+) -> tuple[List[str], int]:
+    batch: List[str] = []
+    estimated_bytes = 0
+    index = start
+    while index < len(children) and len(batch) < MAX_MULTI_OPS:
+        path = os.path.join(parent, children[index])
+        path_size = _path_delete_size(path)
+        if batch and estimated_bytes + path_size > MAX_MULTI_BYTES:
+            break
+        batch.append(path)
+        estimated_bytes += path_size
+        index += 1
+        if estimated_bytes > MAX_MULTI_BYTES:
+            break
+    return batch, index
 
 
-def _delete_large_tree(
-    zk: KazooClient, root_path: str, progress: _DeleteProgress
-) -> None:
+def _record_ready_outcomes(frame: _DeleteFrame, outcomes: List[_DeleteOutcome]) -> int:
+    retained = sum(outcome is _DeleteOutcome.NOT_EMPTY for outcome in outcomes)
+    if retained:
+        frame.retained = True
+    return retained
+
+
+def _delete_candidates_with_progress_log(
+    zk: KazooClient,
+    root_path: str,
+    paths: List[str],
+    progress: _DeleteProgress,
+) -> List[_DeleteOutcome]:
+    deleted_before = progress.deleted
+    outcomes = _delete_candidates(zk, paths, progress)
+    if (
+        progress.deleted // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
+        > deleted_before // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
+    ):
+        logging.info(
+            "Large recursive ZooKeeper deletion of {} is in progress: "
+            "deleted={}, already_absent={}, not_empty={}",
+            root_path,
+            progress.deleted,
+            progress.already_absent,
+            progress.not_empty,
+        )
+    return outcomes
+
+
+def _delete_sweep(
+    zk: KazooClient,
+    root_path: str,
+    progress: _DeleteProgress,
+    cached_children: Dict[str, List[str]],
+    deadline: Optional[float] = None,
+) -> tuple[int, bool]:
+    """Run one finite sweep; return retained branch count and deadline state."""
     stack = [_DeleteFrame(root_path)]
+    retained_branches = 0
 
     while stack:
         frame = stack[-1]
-        if frame.children is None:
-            frame.children = get_children(zk, frame.path)
-            frame.next_child = 0
 
-        if frame.next_child < len(frame.children):
-            child_names = frame.children[
-                frame.next_child : frame.next_child + LARGE_RECURSIVE_DELETE_BATCH_SIZE
-            ]
-            frame.next_child += len(child_names)
-            child_paths = [os.path.join(frame.path, name) for name in child_names]
-            deleted_before = progress.deleted
-            nonempty_paths = _delete_leaf_candidates(zk, child_paths, progress)
-            if (
-                progress.deleted // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
-                > deleted_before // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
-            ):
-                logging.info(
-                    "Large recursive ZooKeeper deletion of {} is in progress: "
-                    "deleted={}, already_absent={}",
-                    root_path,
-                    progress.deleted,
-                    progress.already_absent,
-                )
-            stack.extend(_DeleteFrame(path) for path in reversed(nonempty_paths))
+        if frame.children is None:
+            try:
+                frame.children = cached_children.pop(frame.path)
+            except KeyError:
+                if _deadline_reached(deadline):
+                    return retained_branches, True
+                frame.children = get_children(zk, frame.path)
             continue
 
-        try:
-            zk.delete(frame.path)
-            progress.deleted += 1
-            stack.pop()
-        except NoNodeError:
-            progress.already_absent += 1
-            stack.pop()
-        except NotEmptyError:
-            stat = zk.exists(frame.path)
-            if stat is None:
-                progress.already_absent += 1
-                stack.pop()
-                continue
+        if frame.to_expand:
+            stack.append(_DeleteFrame(frame.to_expand.pop()))
+            continue
 
-            frame.convergence.observe(frame.path, stat.children_count)
-            frame.children = None
+        if frame.ready:
+            if _deadline_reached(deadline):
+                return retained_branches, True
+            outcomes = _delete_candidates_with_progress_log(
+                zk, root_path, frame.ready, progress
+            )
+            retained_branches += _record_ready_outcomes(frame, outcomes)
+            frame.ready = []
+            continue
+
+        if frame.next_child < len(frame.children):
+            if _deadline_reached(deadline):
+                return retained_branches, True
+            batch, frame.next_child = _take_child_batch(
+                frame.path, frame.children, frame.next_child
+            )
+            outcomes = _delete_candidates_with_progress_log(
+                zk, root_path, batch, progress
+            )
+            frame.to_expand.extend(
+                path
+                for path, outcome in zip(batch, outcomes)
+                if outcome is _DeleteOutcome.NOT_EMPTY
+            )
+            continue
+
+        stack.pop()
+        if frame.retained:
+            if stack:
+                stack[-1].retained = True
+            continue
+
+        if stack:
+            stack[-1].ready.append(frame.path)
+            continue
+
+        if _deadline_reached(deadline):
+            return retained_branches, True
+        outcomes = _delete_candidates_with_progress_log(
+            zk, root_path, [frame.path], progress
+        )
+        retained_branches += sum(
+            outcome is _DeleteOutcome.NOT_EMPTY for outcome in outcomes
+        )
+
+    return retained_branches, False
 
 
-def _delete_small_tree(
-    zk: KazooClient, nodes_to_delete: List[str], progress: _DeleteProgress
+def _delete_atomic(
+    zk: KazooClient, paths: List[str], progress: _DeleteProgress
+) -> bool:
+    transaction = zk.transaction()
+    for path in paths:
+        transaction.delete(path)
+    result = transaction.commit()
+    if len(result) != len(paths) or not all(item is True for item in result):
+        return False
+    progress.deleted += len(paths)
+    return True
+
+
+def _validate_delete_limits(max_sweeps: int, delete_timeout: Optional[float]) -> None:
+    if max_sweeps < 0:
+        raise ValueError("max_sweeps must be non-negative")
+    if delete_timeout is not None and delete_timeout <= 0:
+        raise ValueError("delete_timeout must be positive")
+
+
+def delete_recursive(
+    zk: KazooClient,
+    paths: List[str],
+    dry_run: bool = False,
+    max_sweeps: int = DEFAULT_DELETE_MAX_SWEEPS,
+    delete_timeout: Optional[float] = None,
 ) -> None:
-    operations_in_transaction = max(100, int(sqrt(len(nodes_to_delete))))
-    for transaction_operations in chunked(
-        reversed(nodes_to_delete), operations_in_transaction
-    ):
-        delete_nodes_transaction(zk, transaction_operations, progress)
-
-
-def delete_recursive(zk: KazooClient, paths: List[str], dry_run: bool = False) -> None:
     """
     Delete complete ZooKeeper subtrees.
 
-    Trees of at most 10,000 nodes use the original breadth-first discovery and
-    bottom-up transaction deletion. Larger trees use transactions of 1,000
-    optimistic leaf candidates; a failed transaction is bisected to identify
-    nonempty nodes, and only those nodes are traversed. The large-tree path keeps
-    only direct-child lists on the active traversal stack instead of every path.
-
-    The subtree is not deleted in one ZooKeeper transaction. Completion is reported
-    only after the root is deleted and a final exists request confirms its absence.
-    Three windows without a new minimum child count abort with an explicit partial
-    deletion error, so a writer with equal or greater throughput cannot make the
-    command retry forever. Writers should be stopped to guarantee completion.
+    Small observed trees use one children-first atomic transaction. Large trees use
+    bounded sibling batches and discover only candidates reported as nonempty.
+    Concurrently changed branches are retained for a later finite sweep.
     """
 
     if len(paths) == 0:
         return
+    _validate_delete_limits(max_sweeps, delete_timeout)
+
+    deadline = monotonic() + delete_timeout if delete_timeout is not None else None
 
     logging.debug("Node to recursive delete {}", paths)
     paths = remove_subpaths(paths)
@@ -557,56 +640,108 @@ def delete_recursive(zk: KazooClient, paths: List[str], dry_run: bool = False) -
         return
 
     for root_path in paths:
-        stat = zk.exists(root_path)
-        if stat is None:
+        if zk.exists(root_path) is None:
             logging.info(
                 "Recursive ZooKeeper deletion of {} completed: root already absent",
                 root_path,
             )
             continue
 
-        nodes_to_delete: Optional[List[str]] = None
-        if stat.children_count + 1 <= LARGE_RECURSIVE_DELETE_THRESHOLD:
-            nodes_to_delete = _collect_nodes_up_to(
-                zk, root_path, LARGE_RECURSIVE_DELETE_THRESHOLD
-            )
-
         progress = _DeleteProgress()
         try:
-            if nodes_to_delete is not None:
-                logging.info("Got {} nodes to remove.", len(nodes_to_delete))
-                _delete_small_tree(zk, nodes_to_delete, progress)
+            probe = _probe_subtree(zk, root_path, deadline)
+            if probe.deadline_reached:
+                raise RuntimeError(
+                    f"Recursive deletion of {root_path} is incomplete: "
+                    "delete deadline reached"
+                )
+            if probe.postorder is not None and not _deadline_reached(deadline):
+                logging.info(
+                    "Using atomic recursive ZooKeeper deletion for {}: nodes={}",
+                    root_path,
+                    len(probe.postorder),
+                )
+                if _delete_atomic(zk, probe.postorder, progress):
+                    if zk.exists(root_path) is not None:
+                        raise RuntimeError(
+                            f"Recursive deletion of {root_path} is incomplete: "
+                            "root still exists"
+                        )
+                    logging.info(
+                        "Recursive ZooKeeper deletion of {} completed: "
+                        "deleted={}, already_absent={}",
+                        root_path,
+                        progress.deleted,
+                        progress.already_absent,
+                    )
+                    continue
+                logging.info(
+                    "Atomic recursive ZooKeeper deletion of {} failed; "
+                    "switching to large mode",
+                    root_path,
+                )
             else:
                 logging.info(
                     "Using large recursive ZooKeeper deletion for {}: "
-                    "threshold={}, batch_size={}, max_stagnant_windows={}",
+                    "max_multi_ops={}, max_multi_bytes={}, max_sweeps={}",
                     root_path,
-                    LARGE_RECURSIVE_DELETE_THRESHOLD,
-                    LARGE_RECURSIVE_DELETE_BATCH_SIZE,
-                    LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS,
+                    MAX_MULTI_OPS,
+                    MAX_MULTI_BYTES,
+                    max_sweeps,
                 )
-                _delete_large_tree(zk, root_path, progress)
 
-            if zk.exists(root_path) is not None:
-                raise RuntimeError(
-                    f"Recursive deletion of {root_path} is incomplete: root still exists"
+            sweeps = 0
+            cached_children = probe.children
+            while True:
+                sweeps += 1
+                retained, deadline_reached = _delete_sweep(
+                    zk, root_path, progress, cached_children, deadline
                 )
+                progress.sweeps = sweeps
+                progress.retained_branches = retained
+                root_exists = zk.exists(root_path) is not None
+                logging.info(
+                    "Recursive ZooKeeper deletion sweep {} for {} completed: "
+                    "deleted={}, already_absent={}, not_empty={}, retained={}",
+                    sweeps,
+                    root_path,
+                    progress.deleted,
+                    progress.already_absent,
+                    progress.not_empty,
+                    retained,
+                )
+                if not root_exists:
+                    break
+                if deadline_reached or _deadline_reached(deadline):
+                    raise RuntimeError(
+                        f"Recursive deletion of {root_path} is incomplete: "
+                        "delete deadline reached"
+                    )
+                if max_sweeps and sweeps >= max_sweeps:
+                    raise RuntimeError(
+                        f"Recursive deletion of {root_path} is incomplete after "
+                        f"{sweeps} sweeps: root still exists"
+                    )
+                cached_children = {}
         except Exception:
             logging.error(
                 "Recursive ZooKeeper deletion of {} is incomplete: "
-                "deleted={}, already_absent={}",
+                "deleted={}, already_absent={}, not_empty={}",
                 root_path,
                 progress.deleted,
                 progress.already_absent,
+                progress.not_empty,
             )
             raise
 
         logging.info(
             "Recursive ZooKeeper deletion of {} completed: "
-            "deleted={}, already_absent={}",
+            "deleted={}, already_absent={}, not_empty={}, sweeps={}",
             root_path,
             progress.deleted,
             progress.already_absent,
+            progress.not_empty,
+            sweeps,
         )
 
 

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -10,6 +10,7 @@ import os
 import re
 from collections import deque
 from contextlib import contextmanager
+from dataclasses import dataclass
 from math import sqrt
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Union
 
@@ -24,6 +25,17 @@ from ch_tools.common import logging
 from ch_tools.common.clickhouse.config import get_clickhouse_config, get_macros
 from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 from ch_tools.common.utils import escape_for_file_name, unescape_for_file_name
+
+LARGE_RECURSIVE_DELETE_THRESHOLD = 10_000
+LARGE_RECURSIVE_DELETE_BATCH_SIZE = 1_000
+LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS = 3
+LARGE_RECURSIVE_DELETE_LOG_INTERVAL = 100_000
+
+
+@dataclass
+class _DeleteProgress:
+    deleted: int = 0
+    already_absent: int = 0
 
 
 class ZKTransactionBuilder:
@@ -296,19 +308,27 @@ def find_leafs_and_nodes(
 
 
 def delete_nodes_transaction(
-    zk: KazooClient, to_delete_in_trasaction: List[str]
+    zk: KazooClient,
+    to_delete_in_trasaction: List[str],
+    progress: Optional[_DeleteProgress] = None,
 ) -> None:
     """
     Perform deletion for the list of nodes in a single transaction.
     If the transaction fails, go through the list and delete the nodes one by one.
     """
+    if progress is None:
+        progress = _DeleteProgress()
+
     delete_transaction = zk.transaction()
     for node in to_delete_in_trasaction:
         delete_transaction.delete(node)
     result = delete_transaction.commit()
 
-    if result.count(True) == len(result):
+    if len(result) == len(to_delete_in_trasaction) and all(
+        item is True for item in result
+    ):
         # Transaction completed successfully, exit.
+        progress.deleted += len(to_delete_in_trasaction)
         return
 
     logging.info(
@@ -316,18 +336,25 @@ def delete_nodes_transaction(
         to_delete_in_trasaction,
     )
     for node in to_delete_in_trasaction:
-        successful_delete = False
-        while not successful_delete:
+        for _ in range(LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS):
             try:
                 zk.delete(node, recursive=True)
-                successful_delete = True
+                progress.deleted += 1
+                break
             except NoNodeError:
                 #  Someone deleted node before us. Do nothing.
                 logging.error("Node {} is already absent, skipped", node)
-                successful_delete = True
+                progress.already_absent += 1
+                break
             except NotEmptyError:
-                # Someone created a node while we deleting. Restart the operation.
-                pass
+                # Someone created a node while we were deleting. Retry the snapshot.
+                continue
+        else:
+            raise RuntimeError(
+                f"Recursive deletion of {node} does not converge after "
+                f"{LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS} attempts. "
+                "Stop writers or increase deletion throughput."
+            )
 
 
 def remove_subpaths(paths: List[str]) -> List[str]:
@@ -352,13 +379,161 @@ def remove_subpaths(paths: List[str]) -> List[str]:
     return ["/".join(path) for path in normalized_paths]
 
 
+@dataclass
+class _DeleteFrame:
+    path: str
+    children: Optional[List[str]] = None
+    next_child: int = 0
+    minimum_remaining_children: Optional[int] = None
+    stagnant_windows: int = 0
+
+
+def _collect_nodes_up_to(
+    zk: KazooClient, root_path: str, limit: Optional[int] = None
+) -> Optional[List[str]]:
+    nodes = []
+    queue = deque([root_path])
+
+    while queue:
+        path = queue.popleft()
+        nodes.append(path)
+        if limit is not None and len(nodes) > limit:
+            return None
+        children = get_children(zk, path)
+        if limit is not None and len(nodes) + len(queue) + len(children) > limit:
+            return None
+        queue.extend(os.path.join(path, child_node) for child_node in children)
+
+    return nodes
+
+
+def _delete_leaf_candidates(
+    zk: KazooClient, paths: List[str], progress: _DeleteProgress
+) -> List[str]:
+    """Delete leaves and return candidates which still have children."""
+    if not paths:
+        return []
+
+    delete_transaction = zk.transaction()
+    for path in paths:
+        delete_transaction.delete(path)
+    result = delete_transaction.commit()
+
+    if len(result) == len(paths) and all(item is True for item in result):
+        progress.deleted += len(paths)
+        return []
+
+    if len(paths) > 1:
+        middle = len(paths) // 2
+        return _delete_leaf_candidates(
+            zk, paths[:middle], progress
+        ) + _delete_leaf_candidates(zk, paths[middle:], progress)
+
+    path = paths[0]
+    try:
+        zk.delete(path)
+        progress.deleted += 1
+        return []
+    except NoNodeError:
+        progress.already_absent += 1
+        return []
+    except NotEmptyError:
+        return paths
+
+
+def _delete_large_tree(
+    zk: KazooClient, root_path: str, progress: _DeleteProgress
+) -> None:
+    stack = [_DeleteFrame(root_path)]
+
+    while stack:
+        frame = stack[-1]
+        if frame.children is None:
+            frame.children = get_children(zk, frame.path)
+            frame.next_child = 0
+
+        if frame.next_child < len(frame.children):
+            child_names = frame.children[
+                frame.next_child : frame.next_child + LARGE_RECURSIVE_DELETE_BATCH_SIZE
+            ]
+            frame.next_child += len(child_names)
+            child_paths = [os.path.join(frame.path, name) for name in child_names]
+            deleted_before = progress.deleted
+            nonempty_paths = _delete_leaf_candidates(zk, child_paths, progress)
+            if (
+                progress.deleted // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
+                > deleted_before // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
+            ):
+                logging.info(
+                    "Large recursive ZooKeeper deletion of {} is in progress: "
+                    "deleted={}, already_absent={}",
+                    root_path,
+                    progress.deleted,
+                    progress.already_absent,
+                )
+            stack.extend(_DeleteFrame(path) for path in reversed(nonempty_paths))
+            continue
+
+        try:
+            zk.delete(frame.path)
+            progress.deleted += 1
+            stack.pop()
+        except NoNodeError:
+            progress.already_absent += 1
+            stack.pop()
+        except NotEmptyError:
+            stat = zk.exists(frame.path)
+            if stat is None:
+                progress.already_absent += 1
+                stack.pop()
+                continue
+
+            remaining_children = stat.children_count
+            if (
+                frame.minimum_remaining_children is None
+                or remaining_children < frame.minimum_remaining_children
+            ):
+                frame.minimum_remaining_children = remaining_children
+                frame.stagnant_windows = 0
+            else:
+                frame.stagnant_windows += 1
+
+            if frame.stagnant_windows >= LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS:
+                raise RuntimeError(
+                    f"Recursive deletion of {frame.path} does not converge: "
+                    f"{remaining_children} children remain after "
+                    f"{frame.stagnant_windows} non-decreasing windows. "
+                    "Stop writers or increase deletion throughput."
+                )
+
+            frame.children = None
+
+
+def _delete_small_tree(
+    zk: KazooClient, nodes_to_delete: List[str], progress: _DeleteProgress
+) -> None:
+    operations_in_transaction = max(100, int(sqrt(len(nodes_to_delete))))
+    for transaction_operations in chunked(
+        reversed(nodes_to_delete), operations_in_transaction
+    ):
+        delete_nodes_transaction(zk, transaction_operations, progress)
+
+
 def delete_recursive(zk: KazooClient, paths: List[str], dry_run: bool = False) -> None:
     """
-    Kazoo already has the ability to recursively delete nodes, but the implementation is quite naive
-    and has poor performance with a large number of nodes being deleted.
+    Delete complete ZooKeeper subtrees.
 
-    In this implementation we unite the nodes to delete in transactions to do single operation for batch of nodes.
-    To delete in correct order first of all we perform topological sort using bfs approach.
+    Trees of at most 10,000 nodes use the original breadth-first discovery and
+    bottom-up transaction deletion. Larger trees use transactions of 1,000
+    optimistic leaf candidates; a failed transaction is bisected to identify
+    nonempty nodes, and only those nodes are traversed. The large-tree path keeps
+    only direct-child lists on the active traversal stack instead of every path.
+
+    The subtree is not deleted in one ZooKeeper transaction. Completion is reported
+    only after the root is deleted and a final exists request confirms its absence.
+    Three windows without a new minimum child count abort with an explicit partial
+    deletion error, so a writer with equal or greater throughput cannot make the
+    command retry forever. Writers should be stopped to guarantee completion.
     """
 
     if len(paths) == 0:
@@ -366,27 +541,66 @@ def delete_recursive(zk: KazooClient, paths: List[str], dry_run: bool = False) -
 
     logging.debug("Node to recursive delete {}", paths)
     paths = remove_subpaths(paths)
-    nodes_to_delete = []
-    queue = deque(paths)
-
-    while queue:
-        path = queue.popleft()
-        nodes_to_delete.append(path)
-        for child_node in get_children(zk, path):
-            queue.append(os.path.join(path, child_node))
-
-    logging.info("Got {} nodes to remove.", len(nodes_to_delete))
     if dry_run:
-        logging.info("Would delete nodes: {}", nodes_to_delete)
+        dry_run_nodes = []
+        for path in paths:
+            dry_run_nodes.extend(_collect_nodes_up_to(zk, path) or [])
+        logging.info("Got {} nodes to remove.", len(dry_run_nodes))
+        logging.info("Would delete nodes: {}", dry_run_nodes)
         return
 
-    # When number of nodes to delete is large preferable to use greater transaction size.
-    operations_in_transaction = max(100, int(sqrt(len(nodes_to_delete))))
+    for root_path in paths:
+        stat = zk.exists(root_path)
+        if stat is None:
+            logging.info(
+                "Recursive ZooKeeper deletion of {} completed: root already absent",
+                root_path,
+            )
+            continue
 
-    for transaction_orerations in chunked(
-        reversed(nodes_to_delete), operations_in_transaction
-    ):
-        delete_nodes_transaction(zk, transaction_orerations)
+        nodes_to_delete: Optional[List[str]] = None
+        if stat.children_count + 1 <= LARGE_RECURSIVE_DELETE_THRESHOLD:
+            nodes_to_delete = _collect_nodes_up_to(
+                zk, root_path, LARGE_RECURSIVE_DELETE_THRESHOLD
+            )
+
+        progress = _DeleteProgress()
+        try:
+            if nodes_to_delete is not None:
+                logging.info("Got {} nodes to remove.", len(nodes_to_delete))
+                _delete_small_tree(zk, nodes_to_delete, progress)
+            else:
+                logging.info(
+                    "Using large recursive ZooKeeper deletion for {}: "
+                    "threshold={}, batch_size={}, max_stagnant_windows={}",
+                    root_path,
+                    LARGE_RECURSIVE_DELETE_THRESHOLD,
+                    LARGE_RECURSIVE_DELETE_BATCH_SIZE,
+                    LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS,
+                )
+                _delete_large_tree(zk, root_path, progress)
+
+            if zk.exists(root_path) is not None:
+                raise RuntimeError(
+                    f"Recursive deletion of {root_path} is incomplete: root still exists"
+                )
+        except Exception:
+            logging.error(
+                "Recursive ZooKeeper deletion of {} is incomplete: "
+                "deleted={}, already_absent={}",
+                root_path,
+                progress.deleted,
+                progress.already_absent,
+            )
+            raise
+
+        logging.info(
+            "Recursive ZooKeeper deletion of {} completed: "
+            "deleted={}, already_absent={}",
+            root_path,
+            progress.deleted,
+            progress.already_absent,
+        )
 
 
 def escape_for_zookeeper(s: str) -> str:

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -10,7 +10,7 @@ import os
 import re
 from collections import deque
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import sqrt
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Union
 
@@ -36,6 +36,27 @@ LARGE_RECURSIVE_DELETE_LOG_INTERVAL = 100_000
 class _DeleteProgress:
     deleted: int = 0
     already_absent: int = 0
+
+
+@dataclass
+class _DeletionConvergence:
+    minimum_children: Optional[int] = None
+    stagnant_windows: int = 0
+
+    def observe(self, path: str, remaining_children: int) -> None:
+        if self.minimum_children is None or remaining_children < self.minimum_children:
+            self.minimum_children = remaining_children
+            self.stagnant_windows = 0
+            return
+
+        self.stagnant_windows += 1
+        if self.stagnant_windows >= LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS:
+            raise RuntimeError(
+                f"Recursive deletion of {path} does not converge: "
+                f"{remaining_children} children remain after "
+                f"{self.stagnant_windows} non-decreasing windows. "
+                "Stop writers or increase deletion throughput."
+            )
 
 
 class ZKTransactionBuilder:
@@ -310,15 +331,12 @@ def find_leafs_and_nodes(
 def delete_nodes_transaction(
     zk: KazooClient,
     to_delete_in_trasaction: List[str],
-    progress: Optional[_DeleteProgress] = None,
+    progress: _DeleteProgress,
 ) -> None:
     """
     Perform deletion for the list of nodes in a single transaction.
     If the transaction fails, go through the list and delete the nodes one by one.
     """
-    if progress is None:
-        progress = _DeleteProgress()
-
     delete_transaction = zk.transaction()
     for node in to_delete_in_trasaction:
         delete_transaction.delete(node)
@@ -335,8 +353,18 @@ def delete_nodes_transaction(
         "Delete transaction have failed. Fallthrough to single delete operations for zk_nodes : {}",
         to_delete_in_trasaction,
     )
-    for node in to_delete_in_trasaction:
-        for _ in range(LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS):
+    for index, node in enumerate(to_delete_in_trasaction):
+        if index < len(result) and isinstance(result[index], NoNodeError):
+            progress.already_absent += 1
+            continue
+
+        stat = zk.exists(node)
+        if stat is None:
+            progress.already_absent += 1
+            continue
+
+        convergence = _DeletionConvergence()
+        while True:
             try:
                 zk.delete(node, recursive=True)
                 progress.deleted += 1
@@ -347,14 +375,11 @@ def delete_nodes_transaction(
                 progress.already_absent += 1
                 break
             except NotEmptyError:
-                # Someone created a node while we were deleting. Retry the snapshot.
-                continue
-        else:
-            raise RuntimeError(
-                f"Recursive deletion of {node} does not converge after "
-                f"{LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS} attempts. "
-                "Stop writers or increase deletion throughput."
-            )
+                stat = zk.exists(node)
+                if stat is None:
+                    progress.already_absent += 1
+                    break
+                convergence.observe(node, stat.children_count)
 
 
 def remove_subpaths(paths: List[str]) -> List[str]:
@@ -384,8 +409,7 @@ class _DeleteFrame:
     path: str
     children: Optional[List[str]] = None
     next_child: int = 0
-    minimum_remaining_children: Optional[int] = None
-    stagnant_windows: int = 0
+    convergence: _DeletionConvergence = field(default_factory=_DeletionConvergence)
 
 
 def _collect_nodes_up_to(
@@ -488,24 +512,7 @@ def _delete_large_tree(
                 stack.pop()
                 continue
 
-            remaining_children = stat.children_count
-            if (
-                frame.minimum_remaining_children is None
-                or remaining_children < frame.minimum_remaining_children
-            ):
-                frame.minimum_remaining_children = remaining_children
-                frame.stagnant_windows = 0
-            else:
-                frame.stagnant_windows += 1
-
-            if frame.stagnant_windows >= LARGE_RECURSIVE_DELETE_MAX_STAGNANT_WINDOWS:
-                raise RuntimeError(
-                    f"Recursive deletion of {frame.path} does not converge: "
-                    f"{remaining_children} children remain after "
-                    f"{frame.stagnant_windows} non-decreasing windows. "
-                    "Stop writers or increase deletion throughput."
-                )
-
+            frame.convergence.observe(frame.path, stat.children_count)
             frame.children = None
 
 

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -433,10 +433,14 @@ def remove_subpaths(paths: List[str]) -> List[str]:
 
 @dataclass
 class _DeleteFrame:
+    """Discovery state for one node; pending work belongs to one sibling batch."""
+
     path: str
     children: Optional[List[str]] = None
     next_child: int = 0
+    # Children that rejected deletion and still need their descendants visited.
     to_expand: List[str] = field(default_factory=list)
+    # Visited children awaiting another deletion attempt, grouped at their parent.
     ready: List[str] = field(default_factory=list)
     retained: bool = False
 
@@ -465,6 +469,11 @@ def _walk_subtree_depth_first(
 def _take_child_batch(
     parent: str, children: List[str], start: int
 ) -> tuple[List[str], int]:
+    """Build a sibling batch and return the next unread child index.
+
+    A path exceeding the byte limit is emitted alone so traversal can advance;
+    _delete_candidates handles it with an individual delete instead of multi.
+    """
     batch: List[str] = []
     estimated_bytes = 0
     index = start
@@ -513,7 +522,11 @@ def _delete_sweep(
     progress: _DeleteProgress,
     deadline: Optional[float] = None,
 ) -> tuple[int, bool]:
-    """Run one finite sweep; return retained branch count and deadline state."""
+    """Run one depth-first sweep; return retained branch count and deadline state.
+
+    Count final NOT_EMPTY results, including the root, rather than all surviving
+    nodes or skipped ancestors. Update progress for every completed deletion.
+    """
     stack = [_DeleteFrame(root_path)]
     retained_branches = 0
 
@@ -524,6 +537,8 @@ def _delete_sweep(
         frame = stack[-1]
 
         if frame.children is None:
+            # ZooKeeper returns the complete child list; batch limits cannot
+            # bound this allocation.
             frame.children = get_children(zk, frame.path)
             continue
 
@@ -532,6 +547,8 @@ def _delete_sweep(
             continue
 
         if frame.ready:
+            # Writers may have added children since discovery. Defer another
+            # discovery to the next sweep so this retry cannot loop forever.
             not_empty_indices = _delete_candidates_with_progress_log(
                 zk, root_path, frame.ready, progress
             )
@@ -542,6 +559,7 @@ def _delete_sweep(
             continue
 
         if frame.next_child < len(frame.children):
+            # Optimistically delete leaves without a get_children call per leaf.
             batch, frame.next_child = _take_child_batch(
                 frame.path, frame.children, frame.next_child
             )
@@ -553,6 +571,8 @@ def _delete_sweep(
 
         stack.pop()
         if frame.retained:
+            # A surviving descendant prevents deletion of this node and all
+            # its ancestors. Propagate that fact, not a skip of sibling work.
             if stack:
                 stack[-1].retained = True
             continue
@@ -580,6 +600,28 @@ def _delete_atomic(
         return False
     progress.counts.deleted += len(paths)
     return True
+
+
+def _dry_run_delete_recursive(zk: KazooClient, paths: List[str]) -> None:
+    node_count = 0
+    dry_run_nodes: Optional[List[str]] = []
+    for path in paths:
+        for node in _walk_subtree_depth_first(zk, path):
+            node_count += 1
+            if dry_run_nodes is not None:
+                if len(dry_run_nodes) < RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS:
+                    dry_run_nodes.append(node)
+                else:
+                    dry_run_nodes = None
+    logging.info("Got {} nodes to remove.", node_count)
+    if dry_run_nodes is None:
+        logging.info(
+            "Would delete {} nodes; path list omitted because it exceeds " "{} entries",
+            node_count,
+            RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS,
+        )
+    else:
+        logging.info("Would delete nodes: {}", dry_run_nodes)
 
 
 def delete_recursive(
@@ -610,26 +652,7 @@ def delete_recursive(
     logging.debug("Node to recursive delete {}", paths)
     paths = remove_subpaths(paths)
     if dry_run:
-        node_count = 0
-        dry_run_nodes: Optional[List[str]] = []
-        for path in paths:
-            for node in _walk_subtree_depth_first(zk, path):
-                node_count += 1
-                if dry_run_nodes is not None:
-                    if len(dry_run_nodes) < RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS:
-                        dry_run_nodes.append(node)
-                    else:
-                        dry_run_nodes = None
-        logging.info("Got {} nodes to remove.", node_count)
-        if dry_run_nodes is None:
-            logging.info(
-                "Would delete {} nodes; path list omitted because it exceeds "
-                "{} entries",
-                node_count,
-                RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS,
-            )
-        else:
-            logging.info("Would delete nodes: {}", dry_run_nodes)
+        _dry_run_delete_recursive(zk, paths)
         return
 
     for root_path in paths:

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -11,7 +11,6 @@ import re
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from enum import Enum, auto
 from time import monotonic
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Union
 
@@ -35,10 +34,15 @@ RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS = 1_000
 
 
 @dataclass
-class _DeleteProgress:
+class _DeleteCounts:
     deleted: int = 0
     already_absent: int = 0
     not_empty: int = 0
+
+
+@dataclass
+class _DeleteProgress:
+    counts: _DeleteCounts = field(default_factory=_DeleteCounts)
     sweeps: int = 0
     retained_branches: int = 0
 
@@ -86,15 +90,10 @@ def _probe_subtree(
     return _ProbeResult(list(reversed(preorder)))
 
 
-class _DeleteOutcome(Enum):
-    DELETED = auto()
-    ABSENT = auto()
-    NOT_EMPTY = auto()
-
-
 def _delete_candidates(
-    zk: KazooClient, paths: List[str], progress: _DeleteProgress
-) -> List[_DeleteOutcome]:
+    zk: KazooClient, paths: List[str], counts: _DeleteCounts
+) -> List[int]:
+    """Update counts and return input indices of nonempty nodes."""
     if not paths:
         return []
 
@@ -108,27 +107,25 @@ def _delete_candidates(
             transaction.delete(path)
         result = transaction.commit()
         if len(result) == len(paths) and all(item is True for item in result):
-            progress.deleted += len(paths)
-            return [_DeleteOutcome.DELETED] * len(paths)
+            counts.deleted += len(paths)
+            return []
 
         logging.info(
             "Delete transaction failed; falling back to {} individual deletes",
             len(paths),
         )
 
-    outcomes = []
-    for path in paths:
+    not_empty_indices = []
+    for index, path in enumerate(paths):
         try:
             zk.delete(path)
-            progress.deleted += 1
-            outcomes.append(_DeleteOutcome.DELETED)
+            counts.deleted += 1
         except NoNodeError:
-            progress.already_absent += 1
-            outcomes.append(_DeleteOutcome.ABSENT)
+            counts.already_absent += 1
         except NotEmptyError:
-            progress.not_empty += 1
-            outcomes.append(_DeleteOutcome.NOT_EMPTY)
-    return outcomes
+            counts.not_empty += 1
+            not_empty_indices.append(index)
+    return not_empty_indices
 
 
 class ZKTransactionBuilder:
@@ -487,34 +484,27 @@ def _take_child_batch(
     return batch, index
 
 
-def _record_ready_outcomes(frame: _DeleteFrame, outcomes: List[_DeleteOutcome]) -> int:
-    retained = sum(outcome is _DeleteOutcome.NOT_EMPTY for outcome in outcomes)
-    if retained:
-        frame.retained = True
-    return retained
-
-
 def _delete_candidates_with_progress_log(
     zk: KazooClient,
     root_path: str,
     paths: List[str],
     progress: _DeleteProgress,
-) -> List[_DeleteOutcome]:
-    deleted_before = progress.deleted
-    outcomes = _delete_candidates(zk, paths, progress)
+) -> List[int]:
+    deleted_before = progress.counts.deleted
+    not_empty_indices = _delete_candidates(zk, paths, progress.counts)
     if (
-        progress.deleted // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
+        progress.counts.deleted // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
         > deleted_before // LARGE_RECURSIVE_DELETE_LOG_INTERVAL
     ):
         logging.info(
             "Large recursive ZooKeeper deletion of {} is in progress: "
             "deleted={}, already_absent={}, not_empty={}",
             root_path,
-            progress.deleted,
-            progress.already_absent,
-            progress.not_empty,
+            progress.counts.deleted,
+            progress.counts.already_absent,
+            progress.counts.not_empty,
         )
-    return outcomes
+    return not_empty_indices
 
 
 def _delete_sweep(
@@ -542,10 +532,12 @@ def _delete_sweep(
             continue
 
         if frame.ready:
-            outcomes = _delete_candidates_with_progress_log(
+            not_empty_indices = _delete_candidates_with_progress_log(
                 zk, root_path, frame.ready, progress
             )
-            retained_branches += _record_ready_outcomes(frame, outcomes)
+            if not_empty_indices:
+                frame.retained = True
+            retained_branches += len(not_empty_indices)
             frame.ready = []
             continue
 
@@ -553,14 +545,10 @@ def _delete_sweep(
             batch, frame.next_child = _take_child_batch(
                 frame.path, frame.children, frame.next_child
             )
-            outcomes = _delete_candidates_with_progress_log(
+            not_empty_indices = _delete_candidates_with_progress_log(
                 zk, root_path, batch, progress
             )
-            frame.to_expand.extend(
-                path
-                for path, outcome in zip(batch, outcomes)
-                if outcome is _DeleteOutcome.NOT_EMPTY
-            )
+            frame.to_expand.extend(batch[index] for index in not_empty_indices)
             continue
 
         stack.pop()
@@ -573,12 +561,10 @@ def _delete_sweep(
             stack[-1].ready.append(frame.path)
             continue
 
-        outcomes = _delete_candidates_with_progress_log(
+        not_empty_indices = _delete_candidates_with_progress_log(
             zk, root_path, [frame.path], progress
         )
-        retained_branches += sum(
-            outcome is _DeleteOutcome.NOT_EMPTY for outcome in outcomes
-        )
+        retained_branches += len(not_empty_indices)
 
     return retained_branches, False
 
@@ -592,7 +578,7 @@ def _delete_atomic(
     result = transaction.commit()
     if len(result) != len(paths) or not all(item is True for item in result):
         return False
-    progress.deleted += len(paths)
+    progress.counts.deleted += len(paths)
     return True
 
 
@@ -687,8 +673,8 @@ def delete_recursive(
                         "Recursive ZooKeeper deletion of {} completed: "
                         "deleted={}, already_absent={}",
                         root_path,
-                        progress.deleted,
-                        progress.already_absent,
+                        progress.counts.deleted,
+                        progress.counts.already_absent,
                     )
                     continue
                 logging.info(
@@ -720,9 +706,9 @@ def delete_recursive(
                     "deleted={}, already_absent={}, not_empty={}, retained={}",
                     sweeps,
                     root_path,
-                    progress.deleted,
-                    progress.already_absent,
-                    progress.not_empty,
+                    progress.counts.deleted,
+                    progress.counts.already_absent,
+                    progress.counts.not_empty,
                     retained,
                 )
                 if not root_exists:
@@ -744,9 +730,9 @@ def delete_recursive(
                 "Recursive ZooKeeper deletion of {} is incomplete: "
                 "deleted={}, already_absent={}, not_empty={}",
                 root_path,
-                progress.deleted,
-                progress.already_absent,
-                progress.not_empty,
+                progress.counts.deleted,
+                progress.counts.already_absent,
+                progress.counts.not_empty,
             )
             raise
 
@@ -754,9 +740,9 @@ def delete_recursive(
             "Recursive ZooKeeper deletion of {} completed: "
             "deleted={}, already_absent={}, not_empty={}, sweeps={}",
             root_path,
-            progress.deleted,
-            progress.already_absent,
-            progress.not_empty,
+            progress.counts.deleted,
+            progress.counts.already_absent,
+            progress.counts.not_empty,
             sweeps,
         )
 

--- a/ch_tools/chadmin/internal/zookeeper.py
+++ b/ch_tools/chadmin/internal/zookeeper.py
@@ -28,10 +28,10 @@ from ch_tools.common.clickhouse.config.clickhouse import ClickhouseConfig
 from ch_tools.common.utils import escape_for_file_name, unescape_for_file_name
 
 LARGE_RECURSIVE_DELETE_LOG_INTERVAL = 100_000
-MAX_MULTI_OPS = 1_000
-MAX_MULTI_BYTES = 512 * 1024
-DELETE_OP_OVERHEAD = 32
-DEFAULT_DELETE_MAX_SWEEPS = 3
+RECURSIVE_DELETE_TRANSACTION_MAX_OPS = 1_000
+RECURSIVE_DELETE_TRANSACTION_MAX_BYTES = 512 * 1024
+RECURSIVE_DELETE_OPERATION_OVERHEAD = 32
+RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS = 1_000
 
 
 @dataclass
@@ -46,48 +46,44 @@ class _DeleteProgress:
 @dataclass
 class _ProbeResult:
     postorder: Optional[List[str]]
-    children: Dict[str, List[str]]
     deadline_reached: bool = False
 
 
 def _path_delete_size(path: str) -> int:
-    return len(path.encode("utf-8")) + DELETE_OP_OVERHEAD
-
-
-def _deadline_reached(deadline: Optional[float]) -> bool:
-    return deadline is not None and monotonic() >= deadline
+    return len(path.encode("utf-8")) + RECURSIVE_DELETE_OPERATION_OVERHEAD
 
 
 def _probe_subtree(
     zk: KazooClient, root_path: str, deadline: Optional[float] = None
 ) -> _ProbeResult:
     estimated_bytes = _path_delete_size(root_path)
-    if estimated_bytes > MAX_MULTI_BYTES:
-        return _ProbeResult(None, {})
+    if estimated_bytes > RECURSIVE_DELETE_TRANSACTION_MAX_BYTES:
+        return _ProbeResult(None)
 
     operation_count = 1
     preorder = []
     pending = [root_path]
-    cached_children: Dict[str, List[str]] = {}
 
     while pending:
-        if _deadline_reached(deadline):
-            return _ProbeResult(None, cached_children, deadline_reached=True)
+        if deadline is not None and monotonic() >= deadline:
+            return _ProbeResult(None, deadline_reached=True)
         path = pending.pop()
         preorder.append(path)
         children = get_children(zk, path)
-        cached_children[path] = children
         child_paths = []
         for child in children:
             child_path = os.path.join(path, child)
             operation_count += 1
             estimated_bytes += _path_delete_size(child_path)
-            if operation_count > MAX_MULTI_OPS or estimated_bytes > MAX_MULTI_BYTES:
-                return _ProbeResult(None, cached_children)
+            if (
+                operation_count > RECURSIVE_DELETE_TRANSACTION_MAX_OPS
+                or estimated_bytes > RECURSIVE_DELETE_TRANSACTION_MAX_BYTES
+            ):
+                return _ProbeResult(None)
             child_paths.append(child_path)
         pending.extend(reversed(child_paths))
 
-    return _ProbeResult(list(reversed(preorder)), cached_children)
+    return _ProbeResult(list(reversed(preorder)))
 
 
 class _DeleteOutcome(Enum):
@@ -103,7 +99,10 @@ def _delete_candidates(
         return []
 
     estimated_bytes = sum(_path_delete_size(path) for path in paths)
-    if len(paths) <= MAX_MULTI_OPS and estimated_bytes <= MAX_MULTI_BYTES:
+    if (
+        len(paths) <= RECURSIVE_DELETE_TRANSACTION_MAX_OPS
+        and estimated_bytes <= RECURSIVE_DELETE_TRANSACTION_MAX_BYTES
+    ):
         transaction = zk.transaction()
         for path in paths:
             transaction.delete(path)
@@ -318,7 +317,7 @@ def delete_zk_nodes(
     ctx: Context,
     paths: List[str],
     dry_run: bool = False,
-    max_sweeps: int = DEFAULT_DELETE_MAX_SWEEPS,
+    max_sweeps: int = 3,
     delete_timeout: Optional[float] = None,
 ) -> None:
     paths_formated = [format_path(ctx, path) for path in paths]
@@ -445,23 +444,25 @@ class _DeleteFrame:
     retained: bool = False
 
 
-def _collect_nodes_up_to(
-    zk: KazooClient, root_path: str, limit: Optional[int] = None
-) -> Optional[List[str]]:
-    nodes = []
-    queue = deque([root_path])
+def _walk_subtree_depth_first(
+    zk: KazooClient, root_path: str
+) -> Generator[str, None, None]:
+    """Yield paths without retaining every full path in a wide subtree."""
+    yield root_path
+    stack = [(root_path, get_children(zk, root_path), 0)]
 
-    while queue:
-        path = queue.popleft()
-        nodes.append(path)
-        if limit is not None and len(nodes) > limit:
-            return None
-        children = get_children(zk, path)
-        if limit is not None and len(nodes) + len(queue) + len(children) > limit:
-            return None
-        queue.extend(os.path.join(path, child_node) for child_node in children)
+    while stack:
+        parent, children, index = stack[-1]
+        if index == len(children):
+            stack.pop()
+            continue
 
-    return nodes
+        child_path = os.path.join(parent, children[index])
+        stack[-1] = (parent, children, index + 1)
+        yield child_path
+        child_nodes = get_children(zk, child_path)
+        if child_nodes:
+            stack.append((child_path, child_nodes, 0))
 
 
 def _take_child_batch(
@@ -470,15 +471,18 @@ def _take_child_batch(
     batch: List[str] = []
     estimated_bytes = 0
     index = start
-    while index < len(children) and len(batch) < MAX_MULTI_OPS:
+    while index < len(children) and len(batch) < RECURSIVE_DELETE_TRANSACTION_MAX_OPS:
         path = os.path.join(parent, children[index])
         path_size = _path_delete_size(path)
-        if batch and estimated_bytes + path_size > MAX_MULTI_BYTES:
+        if (
+            batch
+            and estimated_bytes + path_size > RECURSIVE_DELETE_TRANSACTION_MAX_BYTES
+        ):
             break
         batch.append(path)
         estimated_bytes += path_size
         index += 1
-        if estimated_bytes > MAX_MULTI_BYTES:
+        if estimated_bytes > RECURSIVE_DELETE_TRANSACTION_MAX_BYTES:
             break
     return batch, index
 
@@ -517,7 +521,6 @@ def _delete_sweep(
     zk: KazooClient,
     root_path: str,
     progress: _DeleteProgress,
-    cached_children: Dict[str, List[str]],
     deadline: Optional[float] = None,
 ) -> tuple[int, bool]:
     """Run one finite sweep; return retained branch count and deadline state."""
@@ -525,15 +528,13 @@ def _delete_sweep(
     retained_branches = 0
 
     while stack:
+        if deadline is not None and monotonic() >= deadline:
+            return retained_branches, True
+
         frame = stack[-1]
 
         if frame.children is None:
-            try:
-                frame.children = cached_children.pop(frame.path)
-            except KeyError:
-                if _deadline_reached(deadline):
-                    return retained_branches, True
-                frame.children = get_children(zk, frame.path)
+            frame.children = get_children(zk, frame.path)
             continue
 
         if frame.to_expand:
@@ -541,8 +542,6 @@ def _delete_sweep(
             continue
 
         if frame.ready:
-            if _deadline_reached(deadline):
-                return retained_branches, True
             outcomes = _delete_candidates_with_progress_log(
                 zk, root_path, frame.ready, progress
             )
@@ -551,8 +550,6 @@ def _delete_sweep(
             continue
 
         if frame.next_child < len(frame.children):
-            if _deadline_reached(deadline):
-                return retained_branches, True
             batch, frame.next_child = _take_child_batch(
                 frame.path, frame.children, frame.next_child
             )
@@ -576,8 +573,6 @@ def _delete_sweep(
             stack[-1].ready.append(frame.path)
             continue
 
-        if _deadline_reached(deadline):
-            return retained_branches, True
         outcomes = _delete_candidates_with_progress_log(
             zk, root_path, [frame.path], progress
         )
@@ -601,18 +596,11 @@ def _delete_atomic(
     return True
 
 
-def _validate_delete_limits(max_sweeps: int, delete_timeout: Optional[float]) -> None:
-    if max_sweeps < 0:
-        raise ValueError("max_sweeps must be non-negative")
-    if delete_timeout is not None and delete_timeout <= 0:
-        raise ValueError("delete_timeout must be positive")
-
-
 def delete_recursive(
     zk: KazooClient,
     paths: List[str],
     dry_run: bool = False,
-    max_sweeps: int = DEFAULT_DELETE_MAX_SWEEPS,
+    max_sweeps: int = 3,
     delete_timeout: Optional[float] = None,
 ) -> None:
     """
@@ -622,25 +610,45 @@ def delete_recursive(
     bounded sibling batches and discover only candidates reported as nonempty.
     Concurrently changed branches are retained for a later finite sweep.
     """
+    # pylint: disable=too-many-branches
 
     if len(paths) == 0:
         return
-    _validate_delete_limits(max_sweeps, delete_timeout)
+    if max_sweeps < 0:
+        raise ValueError("max_sweeps must be non-negative")
+    if delete_timeout is not None and delete_timeout <= 0:
+        raise ValueError("delete_timeout must be positive")
 
     deadline = monotonic() + delete_timeout if delete_timeout is not None else None
 
     logging.debug("Node to recursive delete {}", paths)
     paths = remove_subpaths(paths)
     if dry_run:
-        dry_run_nodes = []
+        node_count = 0
+        dry_run_nodes: Optional[List[str]] = []
         for path in paths:
-            dry_run_nodes.extend(_collect_nodes_up_to(zk, path) or [])
-        logging.info("Got {} nodes to remove.", len(dry_run_nodes))
-        logging.info("Would delete nodes: {}", dry_run_nodes)
+            for node in _walk_subtree_depth_first(zk, path):
+                node_count += 1
+                if dry_run_nodes is not None:
+                    if len(dry_run_nodes) < RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS:
+                        dry_run_nodes.append(node)
+                    else:
+                        dry_run_nodes = None
+        logging.info("Got {} nodes to remove.", node_count)
+        if dry_run_nodes is None:
+            logging.info(
+                "Would delete {} nodes; path list omitted because it exceeds "
+                "{} entries",
+                node_count,
+                RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS,
+            )
+        else:
+            logging.info("Would delete nodes: {}", dry_run_nodes)
         return
 
     for root_path in paths:
-        if zk.exists(root_path) is None:
+        root_stat = zk.exists(root_path)
+        if root_stat is None:
             logging.info(
                 "Recursive ZooKeeper deletion of {} completed: root already absent",
                 root_path,
@@ -649,13 +657,21 @@ def delete_recursive(
 
         progress = _DeleteProgress()
         try:
-            probe = _probe_subtree(zk, root_path, deadline)
+            if root_stat.children_count >= RECURSIVE_DELETE_TRANSACTION_MAX_OPS:
+                probe = _ProbeResult(None)
+            else:
+                probe = _probe_subtree(zk, root_path, deadline)
             if probe.deadline_reached:
                 raise RuntimeError(
                     f"Recursive deletion of {root_path} is incomplete: "
                     "delete deadline reached"
                 )
-            if probe.postorder is not None and not _deadline_reached(deadline):
+            if deadline is not None and monotonic() >= deadline:
+                raise RuntimeError(
+                    f"Recursive deletion of {root_path} is incomplete: "
+                    "delete deadline reached"
+                )
+            if probe.postorder is not None:
                 logging.info(
                     "Using atomic recursive ZooKeeper deletion for {}: nodes={}",
                     root_path,
@@ -680,22 +696,21 @@ def delete_recursive(
                     "switching to large mode",
                     root_path,
                 )
-            else:
-                logging.info(
-                    "Using large recursive ZooKeeper deletion for {}: "
-                    "max_multi_ops={}, max_multi_bytes={}, max_sweeps={}",
-                    root_path,
-                    MAX_MULTI_OPS,
-                    MAX_MULTI_BYTES,
-                    max_sweeps,
-                )
+
+            logging.info(
+                "Using large recursive ZooKeeper deletion for {}: "
+                "transaction_max_ops={}, transaction_max_bytes={}, max_sweeps={}",
+                root_path,
+                RECURSIVE_DELETE_TRANSACTION_MAX_OPS,
+                RECURSIVE_DELETE_TRANSACTION_MAX_BYTES,
+                max_sweeps,
+            )
 
             sweeps = 0
-            cached_children = probe.children
             while True:
                 sweeps += 1
                 retained, deadline_reached = _delete_sweep(
-                    zk, root_path, progress, cached_children, deadline
+                    zk, root_path, progress, deadline
                 )
                 progress.sweeps = sweeps
                 progress.retained_branches = retained
@@ -712,7 +727,9 @@ def delete_recursive(
                 )
                 if not root_exists:
                     break
-                if deadline_reached or _deadline_reached(deadline):
+                if deadline_reached or (
+                    deadline is not None and monotonic() >= deadline
+                ):
                     raise RuntimeError(
                         f"Recursive deletion of {root_path} is incomplete: "
                         "delete deadline reached"
@@ -722,7 +739,6 @@ def delete_recursive(
                         f"Recursive deletion of {root_path} is incomplete after "
                         f"{sweeps} sweeps: root still exists"
                     )
-                cached_children = {}
         except Exception:
             logging.error(
                 "Recursive ZooKeeper deletion of {} is incomplete: "

--- a/tests/features/chadmin_zookeeper.feature
+++ b/tests/features/chadmin_zookeeper.feature
@@ -404,6 +404,16 @@ Feature: chadmin zookeeper commands.
     And we delete zookeepers nodes /test/a on clickhouse01
     Then the list of children on clickhouse01 for zk node /test is empty
 
+  Scenario: Zookeeper recursive delete spans multiple sibling batches
+    Given a ZooKeeper tree at /test/wide with 1 branches and 2001 leaves per branch
+    When we delete zookeepers nodes /test/wide on clickhouse01
+    Then ZooKeeper node /test/wide is absent
+
+  Scenario: Zookeeper recursive delete discovers nonempty branches across batches
+    Given a ZooKeeper tree at /test/branched with 1001 branches and 2 leaves per branch
+    When we delete zookeepers nodes /test/branched on clickhouse01
+    Then ZooKeeper node /test/branched is absent
+
   Scenario: Zookeeper delete parent and child nodes
     When we execute chadmin create zk nodes on clickhouse01
     """

--- a/tests/images/clickhouse/config/config.xml
+++ b/tests/images/clickhouse/config/config.xml
@@ -5,7 +5,7 @@
 
     <listen_host>0.0.0.0</listen_host>
     <https_port>8443</https_port>
-    <tcp_ssl_port>9440</tcp_ssl_port>
+    <tcp_port_secure>9440</tcp_port_secure>
 
     <openSSL>
         <server>

--- a/tests/steps/zookeeper.py
+++ b/tests/steps/zookeeper.py
@@ -14,6 +14,40 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from ch_tools.common import logging
 
 
+@given(
+    "a ZooKeeper tree at {root} with {branches:d} branches and {leaves:d} leaves per branch"
+)
+def step_create_tree(context: Context, root: str, branches: int, leaves: int) -> None:
+    client = _zk_client(context)
+    try:
+        client.start()
+        client.create(root, makepath=True)
+        for branch in range(branches):
+            parent = f"{root}/branch-{branch}"
+            client.create(parent)
+            for start in range(0, leaves, 500):
+                transaction = client.transaction()
+                for leaf in range(start, min(start + 500, leaves)):
+                    transaction.create(f"{parent}/leaf-{leaf}")
+                results = transaction.commit()
+                assert len(results) == min(500, leaves - start)
+                assert all(isinstance(result, str) for result in results), results
+    finally:
+        client.stop()
+        client.close()
+
+
+@then("ZooKeeper node {path} is absent")
+def step_node_absent(context: Context, path: str) -> None:
+    client = _zk_client(context)
+    try:
+        client.start()
+        assert client.exists(path) is None
+    finally:
+        client.stop()
+        client.close()
+
+
 @given("a working zookeeper")
 @retry(wait=wait_fixed(0.5), stop=stop_after_attempt(40))
 def step_wait_for_zookeeper_alive(context: Context) -> None:

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,0 +1,20 @@
+# Local deletion stress test
+
+Requires Docker and the project's `.venv`. Run from the repository root; excluded from CI.
+
+```sh
+bash tests/stress/run_zookeeper_delete.sh --leaves 100000
+bash tests/stress/run_zookeeper_delete.sh --leaves 25000000 --timeout 7200
+```
+
+Creates direct children in temporary Keeper, reports deletion time and test-process
+peak RSS (including seeding), verifies root absence,
+then removes the container and test data. Failure exits nonzero.
+
+Keeper defaults: 4 CPUs, 16 GiB RAM, no swap; client needs additional RAM.
+Override `STRESS_KEEPER_MEMORY` / `STRESS_KEEPER_IMAGE` as needed.
+Uses test configuration with `force_sync=false`.
+Requires GNU `timeout`; `STRESS_WALL_TIMEOUT` caps the whole run (default: 3h).
+
+For an existing disposable server, use `zookeeper_delete.py --hosts host:port`
+with `PYTHONPATH=.`; failed runs leave their generated root for manual cleanup.

--- a/tests/stress/run_zookeeper_delete.sh
+++ b/tests/stress/run_zookeeper_delete.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+keeper_image=${STRESS_KEEPER_IMAGE:-clickhouse/clickhouse-keeper:26.3.12.3}
+keeper_memory=${STRESS_KEEPER_MEMORY:-16g}
+container_id=
+
+cleanup() {
+    status=$?
+    trap - EXIT
+    if [[ -n "$container_id" ]]; then
+        if (( status != 0 )); then
+            docker logs --tail 60 "$container_id" >&2 || true
+        fi
+        docker rm -fv "$container_id" >/dev/null || true
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+container_id=$(docker run -d --hostname zookeeper01 \
+    --memory "$keeper_memory" --memory-swap "$keeper_memory" --cpus 4 \
+    --publish 127.0.0.1::2181 \
+    --mount "type=bind,src=$repo_dir/tests/images/zookeeper/config/config.xml,dst=/etc/clickhouse-keeper/stress.xml,readonly" \
+    --entrypoint clickhouse-keeper "$keeper_image" \
+    --config-file=/etc/clickhouse-keeper/stress.xml)
+echo "Disposable Keeper: $container_id (memory limit: $keeper_memory)"
+keeper_address=$(docker port "$container_id" 2181/tcp)
+
+cd "$repo_dir"
+PYTHONPATH="$repo_dir${PYTHONPATH:+:$PYTHONPATH}" \
+    timeout -k 5s "${STRESS_WALL_TIMEOUT:-3h}" \
+    .venv/bin/python tests/stress/zookeeper_delete.py --hosts "$keeper_address" "$@"

--- a/tests/stress/zookeeper_delete.py
+++ b/tests/stress/zookeeper_delete.py
@@ -1,0 +1,62 @@
+"""Create N direct children on a test server, delete their root, verify absence."""
+
+import argparse
+import resource
+import sys
+from time import monotonic
+from uuid import uuid4
+
+from kazoo.client import KazooClient
+
+from ch_tools.chadmin.internal.zookeeper import delete_recursive
+from ch_tools.common import logging
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hosts", required=True)
+    parser.add_argument("--leaves", type=int, default=100_000)
+    parser.add_argument(
+        "--timeout", type=float, default=600, help="Soft deletion deadline, seconds"
+    )
+    args = parser.parse_args()
+    if args.leaves < 1 or args.timeout <= 0:
+        parser.error("leaves and timeout must be positive")
+
+    logging.configure({"handlers": {}}, "zookeeper-stress")
+    root = f"/chadmin-delete-stress-{uuid4()}"
+    print(f"Test root: {root}", flush=True)
+    client = KazooClient(hosts=args.hosts)
+    try:
+        client.start(timeout=10)
+        started = monotonic()
+        client.create(root)
+        for start in range(0, args.leaves, 500):
+            end = min(start + 500, args.leaves)
+            transaction = client.transaction()
+            for leaf in range(start, end):
+                transaction.create(f"{root}/leaf-{leaf}")
+            results = transaction.commit()
+            assert len(results) == end - start and all(
+                isinstance(result, str) for result in results
+            ), f"Seeding failed: {results}"
+            if end % 100_000 == 0 or end == args.leaves:
+                print(f"Created {end}/{args.leaves} children", flush=True)
+        print(f"Seed seconds: {monotonic() - started:.2f}", flush=True)
+
+        started = monotonic()
+        delete_recursive(client, [root], delete_timeout=args.timeout)
+        assert client.exists(root) is None, f"Root survived: {root}"
+        print(f"Delete seconds: {monotonic() - started:.2f}", flush=True)
+    finally:
+        client.stop()
+        client.close()
+        peak_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        peak_bytes = peak_rss if sys.platform == "darwin" else peak_rss * 1024
+        print(
+            f"Test process peak RSS bytes (including seeding): {peak_bytes}", flush=True
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -1,12 +1,284 @@
+import os
+from types import SimpleNamespace
 from typing import Any, Optional
 from unittest.mock import ANY, patch
 
 import pytest
 from click.testing import CliRunner
+from kazoo.exceptions import NoNodeError, NotEmptyError
 
 from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
+from ch_tools.chadmin.internal.zookeeper import delete_recursive
 
 PATH = "/clickhouse/task_queue/ddl/query/shards/replica1:9440,replica2:9440/executed"
+
+
+class FakeTransaction:
+    def __init__(self, zk: "FakeZooKeeper") -> None:
+        self.zk = zk
+        self.paths: list[str] = []
+
+    def delete(self, path: str) -> None:
+        self.paths.append(path)
+
+    def commit(self) -> list[Any]:
+        self.zk.transaction_sizes.append(len(self.paths))
+        for path in self.paths:
+            if path not in self.zk.children:
+                return [NoNodeError() for _ in self.paths]
+            if self.zk.children[path]:
+                return [NotEmptyError() for _ in self.paths]
+
+        for path in self.paths:
+            self.zk.remove_leaf(path)
+        return [True for _ in self.paths]
+
+
+class FakeZooKeeper:
+    def __init__(self, children: dict[str, set[str]]) -> None:
+        self.children = {path: set(names) for path, names in children.items()}
+        self.get_children_calls: list[str] = []
+        self.transaction_sizes: list[int] = []
+
+    def exists(self, path: str) -> Any:
+        if path not in self.children:
+            return None
+        return SimpleNamespace(children_count=len(self.children[path]))
+
+    def get_children(self, path: str) -> list[str]:
+        self.get_children_calls.append(path)
+        if path not in self.children:
+            raise NoNodeError
+        return sorted(self.children[path])
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction(self)
+
+    def delete(self, path: str, recursive: bool = False) -> None:
+        if path not in self.children:
+            raise NoNodeError
+        if self.children[path] and not recursive:
+            raise NotEmptyError
+        if recursive:
+            for child in list(self.children[path]):
+                self.delete(os.path.join(path, child), recursive=True)
+        self.remove_leaf(path)
+
+    def remove_leaf(self, path: str) -> None:
+        parent = os.path.dirname(path)
+        if parent in self.children:
+            self.children[parent].discard(os.path.basename(path))
+        del self.children[path]
+
+
+def test_large_delete_does_not_read_each_leaf() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+    zk = FakeZooKeeper(
+        {
+            "/root": leaf_names,
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        }
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == ["/root"]
+    assert max(zk.transaction_sizes) <= 1_000
+
+
+def test_large_delete_descends_only_into_nonempty_candidates() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+    zk = FakeZooKeeper(
+        {
+            "/root": leaf_names | {"branch"},
+            "/root/branch": {"grandchild"},
+            "/root/branch/grandchild": set(),
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        }
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == ["/root", "/root/branch"]
+
+
+def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"branch"},
+            "/root/branch": {"leaf-0", "leaf-1", "leaf-2"},
+            "/root/branch/leaf-0": set(),
+            "/root/branch/leaf-1": set(),
+            "/root/branch/leaf-2": set(),
+        }
+    )
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging"),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_THRESHOLD",
+            3,
+        ),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_BATCH_SIZE",
+            2,
+        ),
+    ):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == [
+        "/root",
+        "/root/branch",
+        "/root",
+        "/root/branch",
+    ]
+
+
+class RacingZooKeeper(FakeZooKeeper):
+    def __init__(self, children: dict[str, set[str]], continuous: bool) -> None:
+        super().__init__(children)
+        self.continuous = continuous
+        self.created = 0
+
+    def delete(self, path: str, recursive: bool = False) -> None:
+        should_race = path == "/root" and not self.children[path]
+        if should_race and (self.continuous or self.created == 0):
+            child = f"late-{self.created}"
+            self.created += 1
+            self.children[path].add(child)
+            self.children[f"{path}/{child}"] = set()
+            raise NotEmptyError
+        super().delete(path, recursive)
+
+
+def test_large_delete_retries_a_finite_creation_race() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+    zk = RacingZooKeeper(
+        {
+            "/root": leaf_names,
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        },
+        continuous=False,
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.created == 1
+    assert zk.get_children_calls == ["/root", "/root"]
+
+
+def test_large_delete_aborts_after_three_stagnant_windows() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+    zk = RacingZooKeeper(
+        {
+            "/root": leaf_names,
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        },
+        continuous=True,
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        with pytest.raises(RuntimeError, match="does not converge"):
+            delete_recursive(zk, ["/root"])
+
+    assert zk.created == 4
+    mock_logging.error.assert_called_once()
+
+
+def test_small_delete_does_not_select_large_algorithm() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"leaf"},
+            "/root/leaf": set(),
+        }
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == ["/root", "/root/leaf"]
+    assert not any(
+        "Using large recursive" in call.args[0]
+        for call in mock_logging.info.call_args_list
+    )
+
+
+class AlwaysBusyRootZooKeeper(FakeZooKeeper):
+    def __init__(self, children: dict[str, set[str]]) -> None:
+        super().__init__(children)
+        self.root_delete_attempts = 0
+
+    def delete(self, path: str, recursive: bool = False) -> None:
+        if path == "/root":
+            self.root_delete_attempts += 1
+            raise NotEmptyError
+        super().delete(path, recursive)
+
+
+def test_small_delete_does_not_retry_forever_with_a_busy_writer() -> None:
+    zk = AlwaysBusyRootZooKeeper(
+        {
+            "/root": {"leaf"},
+            "/root/leaf": set(),
+        }
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        with pytest.raises(RuntimeError, match="does not converge"):
+            delete_recursive(zk, ["/root"])
+
+    assert zk.root_delete_attempts == 3
+
+
+def test_large_delete_logs_algorithm_selection_and_completion() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+    zk = FakeZooKeeper(
+        {
+            "/root": leaf_names,
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        }
+    )
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        delete_recursive(zk, ["/root"])
+
+    messages = [call.args[0] for call in mock_logging.info.call_args_list]
+    assert any("Using large recursive" in message for message in messages)
+    assert any("completed" in message for message in messages)
+
+
+class UnconfirmedDeletionZooKeeper(FakeZooKeeper):
+    def __init__(self, children: dict[str, set[str]]) -> None:
+        super().__init__(children)
+        self.root_deleted = False
+
+    def exists(self, path: str) -> Any:
+        if path == "/root" and self.root_deleted:
+            return SimpleNamespace(children_count=0)
+        return super().exists(path)
+
+    def remove_leaf(self, path: str) -> None:
+        super().remove_leaf(path)
+        if path == "/root":
+            self.root_deleted = True
+
+
+def test_delete_reports_error_if_root_absence_is_not_confirmed() -> None:
+    zk = UnconfirmedDeletionZooKeeper({"/root": set()})
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        with pytest.raises(RuntimeError, match="root still exists"):
+            delete_recursive(zk, ["/root"])
+
+    mock_logging.error.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -110,11 +110,13 @@ def test_probe_returns_complete_child_first_small_tree() -> None:
 def test_probe_stops_when_delete_bytes_exceed_limit() -> None:
     zk = FakeZooKeeper({"/root": {"long-child-name"}, "/root/long-child-name": set()})
 
-    with patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 40):
+    with patch(
+        "ch_tools.chadmin.internal.zookeeper." "RECURSIVE_DELETE_TRANSACTION_MAX_BYTES",
+        40,
+    ):
         result = _probe_subtree(zk, "/root")
 
     assert result.postorder is None
-    assert result.children["/root"] == ["long-child-name"]
     assert zk.get_children_calls == ["/root"]
 
 
@@ -167,7 +169,10 @@ def test_delete_candidates_skips_multi_for_oversized_singleton() -> None:
     zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
     progress = _DeleteProgress()
 
-    with patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 1):
+    with patch(
+        "ch_tools.chadmin.internal.zookeeper." "RECURSIVE_DELETE_TRANSACTION_MAX_BYTES",
+        1,
+    ):
         outcomes = _delete_candidates(zk, ["/root/leaf"], progress)
 
     assert outcomes == [_DeleteOutcome.DELETED]
@@ -190,6 +195,32 @@ def test_large_delete_does_not_read_each_leaf() -> None:
     assert zk.children == {}
     assert zk.get_children_calls == ["/root"]
     assert max(zk.transaction_sizes) <= 1_000
+
+
+def test_direct_child_count_skips_small_tree_probe() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"first", "second"},
+            "/root/first": set(),
+            "/root/second": set(),
+        }
+    )
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging"),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
+            2,
+        ),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper._probe_subtree"
+        ) as mock_probe_subtree,
+    ):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    mock_probe_subtree.assert_not_called()
 
 
 def test_large_delete_descends_only_into_nonempty_candidates() -> None:
@@ -233,8 +264,16 @@ def test_large_delete_batches_are_parent_local_and_bounded() -> None:
 
     with (
         patch("ch_tools.chadmin.internal.zookeeper.logging"),
-        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
-        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 100),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
+            2,
+        ),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_BYTES",
+            100,
+        ),
     ):
         delete_recursive(zk, ["/root"])
 
@@ -264,7 +303,8 @@ def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
     with (
         patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
-            "ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS",
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
             3,
         ),
     ):
@@ -272,6 +312,8 @@ def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
 
     assert zk.children == {}
     assert zk.get_children_calls == [
+        "/root",
+        "/root/branch",
         "/root",
         "/root/branch",
     ]
@@ -349,7 +391,7 @@ def test_small_delete_does_not_select_large_algorithm() -> None:
     )
 
 
-def test_failed_small_transaction_reuses_probe_in_large_mode() -> None:
+def test_failed_small_transaction_rereads_children_in_large_mode() -> None:
     zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
     zk.fail_transactions = 1
 
@@ -357,14 +399,14 @@ def test_failed_small_transaction_reuses_probe_in_large_mode() -> None:
         delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
-    assert zk.get_children_calls == ["/root", "/root/leaf"]
+    assert zk.get_children_calls == ["/root", "/root/leaf", "/root"]
     assert any(
         "switching to large" in call.args[0]
         for call in mock_logging.info.call_args_list
     )
 
 
-def test_failed_atomic_leaf_reuses_cached_empty_children() -> None:
+def test_failed_atomic_leaf_rereads_children_in_large_mode() -> None:
     zk = FakeZooKeeper({"/root": set()})
     zk.fail_transactions = 1
 
@@ -372,7 +414,7 @@ def test_failed_atomic_leaf_reuses_cached_empty_children() -> None:
         delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
-    assert zk.get_children_calls == ["/root"]
+    assert zk.get_children_calls == ["/root", "/root"]
 
 
 def test_delete_timeout_stops_before_next_batch_and_checks_root() -> None:
@@ -387,10 +429,14 @@ def test_delete_timeout_stops_before_next_batch_and_checks_root() -> None:
 
     with (
         patch("ch_tools.chadmin.internal.zookeeper.logging"),
-        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
+            2,
+        ),
         patch(
             "ch_tools.chadmin.internal.zookeeper.monotonic",
-            side_effect=[0.0, 0.0, 0.0, 2.0],
+            side_effect=[0.0, 0.0, 0.0, 0.0, 2.0],
         ),
         pytest.raises(RuntimeError, match="deadline"),
     ):
@@ -432,7 +478,11 @@ def test_large_delete_logs_aggregate_progress_without_candidate_names() -> None:
 
     with (
         patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging,
-        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
+            2,
+        ),
         patch(
             "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_LOG_INTERVAL", 2
         ),
@@ -442,6 +492,44 @@ def test_large_delete_logs_aggregate_progress_without_candidate_names() -> None:
     messages = str(mock_logging.method_calls)
     assert "in progress" in messages
     assert "sweep" in messages
+    assert "private-leaf" not in messages
+
+
+def test_small_dry_run_logs_all_paths() -> None:
+    zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        delete_recursive(zk, ["/root"], dry_run=True)
+
+    assert zk.children == {"/root": {"leaf"}, "/root/leaf": set()}
+    mock_logging.info.assert_any_call("Got {} nodes to remove.", 2)
+    mock_logging.info.assert_any_call("Would delete nodes: {}", ["/root", "/root/leaf"])
+
+
+def test_large_dry_run_counts_all_nodes_without_logging_paths() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"private-leaf-0", "private-leaf-1", "private-leaf-2"},
+            "/root/private-leaf-0": set(),
+            "/root/private-leaf-1": set(),
+            "/root/private-leaf-2": set(),
+        }
+    )
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging,
+        patch(
+            "ch_tools.chadmin.internal.zookeeper."
+            "RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS",
+            2,
+        ),
+    ):
+        delete_recursive(zk, ["/root"], dry_run=True)
+
+    assert len(zk.children) == 4
+    mock_logging.info.assert_any_call("Got {} nodes to remove.", 4)
+    messages = str(mock_logging.info.call_args_list)
+    assert "path list omitted" in messages
     assert "private-leaf" not in messages
 
 

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -9,8 +9,11 @@ from kazoo.exceptions import NoNodeError, NotEmptyError
 
 from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
 from ch_tools.chadmin.internal.zookeeper import (
+    _delete_candidates,
+    _DeleteOutcome,
     _DeleteProgress,
-    delete_nodes_transaction,
+    _path_delete_size,
+    _probe_subtree,
     delete_recursive,
 )
 
@@ -27,11 +30,24 @@ class FakeTransaction:
 
     def commit(self) -> list[Any]:
         self.zk.transaction_sizes.append(len(self.paths))
+        self.zk.transaction_paths.append(list(self.paths))
+        self.zk.before_transaction(self.paths)
+        if self.zk.fail_transactions:
+            self.zk.fail_transactions -= 1
+            return [NotEmptyError() for _ in self.paths]
+        staged_children = {
+            path: set(children) for path, children in self.zk.children.items()
+        }
         for path in self.paths:
-            if path not in self.zk.children:
+            if path not in staged_children:
                 return [NoNodeError() for _ in self.paths]
-            if self.zk.children[path]:
+            if staged_children[path]:
                 return [NotEmptyError() for _ in self.paths]
+
+            parent = os.path.dirname(path)
+            if parent in staged_children:
+                staged_children[parent].discard(os.path.basename(path))
+            del staged_children[path]
 
         for path in self.paths:
             self.zk.remove_leaf(path)
@@ -41,10 +57,17 @@ class FakeTransaction:
 class FakeZooKeeper:
     def __init__(self, children: dict[str, set[str]]) -> None:
         self.children = {path: set(names) for path, names in children.items()}
+        self.exists_calls: list[str] = []
         self.get_children_calls: list[str] = []
         self.transaction_sizes: list[int] = []
+        self.transaction_paths: list[list[str]] = []
+        self.fail_transactions = 0
+
+    def before_transaction(self, paths: list[str]) -> None:
+        pass
 
     def exists(self, path: str) -> Any:
+        self.exists_calls.append(path)
         if path not in self.children:
             return None
         return SimpleNamespace(children_count=len(self.children[path]))
@@ -75,64 +98,81 @@ class FakeZooKeeper:
         del self.children[path]
 
 
-class FixedResultTransaction:
-    def __init__(self, result: list[Any]) -> None:
-        self.result = result
+def test_probe_returns_complete_child_first_small_tree() -> None:
+    zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
 
-    def delete(self, path: str) -> None:
-        pass
+    result = _probe_subtree(zk, "/root")
 
-    def commit(self) -> list[Any]:
-        return self.result
+    assert result.postorder == ["/root/leaf", "/root"]
+    assert zk.get_children_calls == ["/root", "/root/leaf"]
 
 
-class ShrinkingRecursiveDeleteZooKeeper:
-    def __init__(self) -> None:
-        self.delete_attempts = 0
+def test_probe_stops_when_delete_bytes_exceed_limit() -> None:
+    zk = FakeZooKeeper({"/root": {"long-child-name"}, "/root/long-child-name": set()})
 
-    def transaction(self) -> FixedResultTransaction:
-        return FixedResultTransaction([NotEmptyError()])
+    with patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 40):
+        result = _probe_subtree(zk, "/root")
 
-    def exists(self, path: str) -> Any:
-        return SimpleNamespace(children_count=4 - self.delete_attempts)
-
-    def delete(self, path: str, recursive: bool = False) -> None:
-        self.delete_attempts += 1
-        if self.delete_attempts <= 3:
-            raise NotEmptyError
+    assert result.postorder is None
+    assert result.children["/root"] == ["long-child-name"]
+    assert zk.get_children_calls == ["/root"]
 
 
-def test_small_fallback_resets_stagnation_when_child_count_decreases() -> None:
-    zk = ShrinkingRecursiveDeleteZooKeeper()
+def test_delete_candidates_reports_successful_transaction() -> None:
+    zk = FakeZooKeeper(
+        {"/root": {"first", "second"}, "/root/first": set(), "/root/second": set()}
+    )
+    progress = _DeleteProgress()
+
+    outcomes = _delete_candidates(zk, ["/root/first", "/root/second"], progress)
+
+    assert outcomes == [_DeleteOutcome.DELETED, _DeleteOutcome.DELETED]
+    assert progress == _DeleteProgress(deleted=2)
+    assert zk.transaction_sizes == [2]
+
+
+def test_delete_candidates_falls_back_to_individual_outcomes() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"branch", "leaf"},
+            "/root/branch": {"grandchild"},
+            "/root/branch/grandchild": set(),
+            "/root/leaf": set(),
+        }
+    )
+    progress = _DeleteProgress()
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        outcomes = _delete_candidates(zk, ["/root/leaf", "/root/branch"], progress)
+
+    assert outcomes == [_DeleteOutcome.DELETED, _DeleteOutcome.NOT_EMPTY]
+    assert progress == _DeleteProgress(deleted=1, not_empty=1)
+    assert zk.transaction_sizes == [2]
+    assert "/root/leaf" not in str(mock_logging.method_calls)
+    assert "/root/branch" not in str(mock_logging.method_calls)
+
+
+def test_delete_candidates_reports_absent_member() -> None:
+    zk = FakeZooKeeper({"/root": set()})
     progress = _DeleteProgress()
 
     with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_nodes_transaction(zk, ["/root"], progress)
+        outcomes = _delete_candidates(zk, ["/root/missing"], progress)
 
-    assert zk.delete_attempts == 4
-    assert progress == _DeleteProgress(deleted=1)
-
-
-class MissingRecursiveDeleteZooKeeper:
-    def __init__(self) -> None:
-        self.delete_attempts = 0
-
-    def transaction(self) -> FixedResultTransaction:
-        return FixedResultTransaction([NoNodeError()])
-
-    def delete(self, path: str, recursive: bool = False) -> None:
-        self.delete_attempts += 1
-
-
-def test_small_fallback_counts_missing_transaction_target_as_absent() -> None:
-    zk = MissingRecursiveDeleteZooKeeper()
-    progress = _DeleteProgress()
-
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_nodes_transaction(zk, ["/missing"], progress)
-
-    assert zk.delete_attempts == 0
+    assert outcomes == [_DeleteOutcome.ABSENT]
     assert progress == _DeleteProgress(already_absent=1)
+
+
+def test_delete_candidates_skips_multi_for_oversized_singleton() -> None:
+    zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
+    progress = _DeleteProgress()
+
+    with patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 1):
+        outcomes = _delete_candidates(zk, ["/root/leaf"], progress)
+
+    assert outcomes == [_DeleteOutcome.DELETED]
+    assert progress == _DeleteProgress(deleted=1)
+    assert zk.transaction_sizes == []
 
 
 def test_large_delete_does_not_read_each_leaf() -> None:
@@ -168,6 +208,46 @@ def test_large_delete_descends_only_into_nonempty_candidates() -> None:
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root/branch"]
+    branch_attempts = [
+        index
+        for index, paths in enumerate(zk.transaction_paths)
+        if "/root/branch" in paths
+    ]
+    grandchild_attempt = next(
+        index
+        for index, paths in enumerate(zk.transaction_paths)
+        if "/root/branch/grandchild" in paths
+    )
+    assert len(branch_attempts) == 2
+    assert branch_attempts[0] < grandchild_attempt < branch_attempts[1]
+
+
+def test_large_delete_batches_are_parent_local_and_bounded() -> None:
+    leaf_names = {f"leaf-{index}" for index in range(6)}
+    zk = FakeZooKeeper(
+        {
+            "/root": leaf_names,
+            **{f"/root/{leaf}": set() for leaf in leaf_names},
+        }
+    )
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging"),
+        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
+        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_BYTES", 100),
+    ):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert all(len(paths) <= 2 for paths in zk.transaction_paths)
+    assert all(
+        len({os.path.dirname(path) for path in paths}) == 1
+        for paths in zk.transaction_paths
+    )
+    assert all(
+        sum(_path_delete_size(path) for path in paths) <= 100
+        for paths in zk.transaction_paths
+    )
 
 
 def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
@@ -184,20 +264,14 @@ def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
     with (
         patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
-            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_THRESHOLD",
+            "ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS",
             3,
-        ),
-        patch(
-            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_BATCH_SIZE",
-            2,
         ),
     ):
         delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == [
-        "/root",
-        "/root/branch",
         "/root",
         "/root/branch",
     ]
@@ -209,15 +283,13 @@ class RacingZooKeeper(FakeZooKeeper):
         self.continuous = continuous
         self.created = 0
 
-    def delete(self, path: str, recursive: bool = False) -> None:
-        should_race = path == "/root" and not self.children[path]
+    def before_transaction(self, paths: list[str]) -> None:
+        should_race = paths == ["/root"] and not self.children["/root"]
         if should_race and (self.continuous or self.created == 0):
             child = f"late-{self.created}"
             self.created += 1
-            self.children[path].add(child)
-            self.children[f"{path}/{child}"] = set()
-            raise NotEmptyError
-        super().delete(path, recursive)
+            self.children["/root"].add(child)
+            self.children[f"/root/{child}"] = set()
 
 
 def test_large_delete_retries_a_finite_creation_race() -> None:
@@ -238,7 +310,7 @@ def test_large_delete_retries_a_finite_creation_race() -> None:
     assert zk.get_children_calls == ["/root", "/root"]
 
 
-def test_large_delete_aborts_after_three_stagnant_windows() -> None:
+def test_large_delete_aborts_after_three_sweeps_with_continuous_writer() -> None:
     leaf_names = {f"leaf-{index}" for index in range(10_001)}
     zk = RacingZooKeeper(
         {
@@ -249,10 +321,11 @@ def test_large_delete_aborts_after_three_stagnant_windows() -> None:
     )
 
     with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        with pytest.raises(RuntimeError, match="does not converge"):
-            delete_recursive(zk, ["/root"])
+        with pytest.raises(RuntimeError, match="after 3 sweeps"):
+            delete_recursive(zk, ["/root"], max_sweeps=3)
 
-    assert zk.created == 4
+    assert zk.created == 3
+    assert zk.get_children_calls == ["/root", "/root", "/root"]
     mock_logging.error.assert_called_once()
 
 
@@ -269,38 +342,65 @@ def test_small_delete_does_not_select_large_algorithm() -> None:
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root/leaf"]
+    assert zk.transaction_paths == [["/root/leaf", "/root"]]
     assert not any(
         "Using large recursive" in call.args[0]
         for call in mock_logging.info.call_args_list
     )
 
 
-class AlwaysBusyRootZooKeeper(FakeZooKeeper):
-    def __init__(self, children: dict[str, set[str]]) -> None:
-        super().__init__(children)
-        self.root_delete_attempts = 0
+def test_failed_small_transaction_reuses_probe_in_large_mode() -> None:
+    zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
+    zk.fail_transactions = 1
 
-    def delete(self, path: str, recursive: bool = False) -> None:
-        if path == "/root":
-            self.root_delete_attempts += 1
-            raise NotEmptyError
-        super().delete(path, recursive)
+    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == ["/root", "/root/leaf"]
+    assert any(
+        "switching to large" in call.args[0]
+        for call in mock_logging.info.call_args_list
+    )
 
 
-def test_small_delete_does_not_retry_forever_with_a_busy_writer() -> None:
-    zk = AlwaysBusyRootZooKeeper(
+def test_failed_atomic_leaf_reuses_cached_empty_children() -> None:
+    zk = FakeZooKeeper({"/root": set()})
+    zk.fail_transactions = 1
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_recursive(zk, ["/root"])
+
+    assert zk.children == {}
+    assert zk.get_children_calls == ["/root"]
+
+
+def test_delete_timeout_stops_before_next_batch_and_checks_root() -> None:
+    zk = FakeZooKeeper(
         {
-            "/root": {"leaf"},
+            "/root": {"branch", "leaf"},
+            "/root/branch": {"grandchild"},
+            "/root/branch/grandchild": set(),
             "/root/leaf": set(),
         }
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        with pytest.raises(RuntimeError, match="does not converge"):
-            delete_recursive(zk, ["/root"])
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging"),
+        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper.monotonic",
+            side_effect=[0.0, 0.0, 0.0, 2.0],
+        ),
+        pytest.raises(RuntimeError, match="deadline"),
+    ):
+        delete_recursive(zk, ["/root"], max_sweeps=0, delete_timeout=1.0)
 
-    # First failure establishes the baseline; next three stagnant windows abort.
-    assert zk.root_delete_attempts == 4
+    assert "/root/leaf" not in zk.children
+    assert "/root/branch" in zk.children
+    assert zk.get_children_calls == ["/root"]
+    assert zk.transaction_paths == [["/root/branch", "/root/leaf"]]
+    assert zk.exists_calls[-1] == "/root"
 
 
 def test_large_delete_logs_algorithm_selection_and_completion() -> None:
@@ -318,6 +418,31 @@ def test_large_delete_logs_algorithm_selection_and_completion() -> None:
     messages = [call.args[0] for call in mock_logging.info.call_args_list]
     assert any("Using large recursive" in message for message in messages)
     assert any("completed" in message for message in messages)
+
+
+def test_large_delete_logs_aggregate_progress_without_candidate_names() -> None:
+    zk = FakeZooKeeper(
+        {
+            "/root": {"private-leaf-0", "private-leaf-1", "private-leaf-2"},
+            "/root/private-leaf-0": set(),
+            "/root/private-leaf-1": set(),
+            "/root/private-leaf-2": set(),
+        }
+    )
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging,
+        patch("ch_tools.chadmin.internal.zookeeper.MAX_MULTI_OPS", 2),
+        patch(
+            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_LOG_INTERVAL", 2
+        ),
+    ):
+        delete_recursive(zk, ["/root"])
+
+    messages = str(mock_logging.method_calls)
+    assert "in progress" in messages
+    assert "sweep" in messages
+    assert "private-leaf" not in messages
 
 
 class UnconfirmedDeletionZooKeeper(FakeZooKeeper):
@@ -417,7 +542,7 @@ PATHS = [PATH, "/clickhouse/task_queue/ddl/query/shards/replica3/executed"]
             ["delete", "--path", PATHS[0], "--path", PATHS[1]],
             "delete_zk_nodes",
             (PATHS,),
-            {},
+            {"max_sweeps": 3, "delete_timeout": None},
             id="delete",
         ),
     ],
@@ -448,3 +573,44 @@ def test_delete_command_rejects_multiple_paths() -> None:
 
     assert result.exit_code != 0
     assert "Got unexpected extra argument" in result.output
+
+
+def test_delete_command_forwards_sweep_and_deadline_options() -> None:
+    with patch(
+        "ch_tools.chadmin.cli.zookeeper_group.delete_zk_nodes"
+    ) as mock_delete_zk_nodes:
+        result = CliRunner().invoke(
+            zookeeper_group,
+            [
+                "delete",
+                "--max-sweeps",
+                "0",
+                "--delete-timeout",
+                "12.5",
+                PATH,
+            ],
+            obj={"config": {"loguru": {"handlers": {}}}},
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_delete_zk_nodes.assert_called_once_with(
+        ANY, [PATH], max_sweeps=0, delete_timeout=12.5
+    )
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        pytest.param(["--max-sweeps", "-1"], id="negative-sweeps"),
+        pytest.param(["--delete-timeout", "0"], id="zero-timeout"),
+        pytest.param(["--delete-timeout", "-1"], id="negative-timeout"),
+    ],
+)
+def test_delete_command_rejects_invalid_limits(option: list[str]) -> None:
+    result = CliRunner().invoke(
+        zookeeper_group,
+        ["delete", *option, PATH],
+        obj={"config": {"loguru": {"handlers": {}}}},
+    )
+
+    assert result.exit_code != 0

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -1,6 +1,6 @@
 import os
 from types import SimpleNamespace
-from typing import Any, Optional
+from typing import Any, Generator, Optional
 from unittest.mock import ANY, patch
 
 import pytest
@@ -10,13 +10,21 @@ from kazoo.exceptions import NoNodeError, NotEmptyError
 from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
 from ch_tools.chadmin.internal.zookeeper import (
     _delete_candidates,
+    _delete_sweep,
     _DeleteCounts,
+    _DeleteProgress,
     _path_delete_size,
     _probe_subtree,
     delete_recursive,
 )
 
 PATH = "/clickhouse/task_queue/ddl/query/shards/replica1:9440,replica2:9440/executed"
+
+
+@pytest.fixture(autouse=True)
+def silence_logging() -> Generator[None, None, None]:
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        yield
 
 
 class FakeTransaction:
@@ -58,6 +66,7 @@ class FakeZooKeeper:
         self.children = {path: set(names) for path, names in children.items()}
         self.exists_calls: list[str] = []
         self.get_children_calls: list[str] = []
+        self.delete_calls: list[str] = []
         self.transaction_sizes: list[int] = []
         self.transaction_paths: list[list[str]] = []
         self.fail_transactions = 0
@@ -81,6 +90,7 @@ class FakeZooKeeper:
         return FakeTransaction(self)
 
     def delete(self, path: str, recursive: bool = False) -> None:
+        self.delete_calls.append(path)
         if path not in self.children:
             raise NoNodeError
         if self.children[path] and not recursive:
@@ -145,16 +155,11 @@ def test_delete_candidates_falls_back_to_individual_outcomes() -> None:
     )
     progress = _DeleteCounts()
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        not_empty_indices = _delete_candidates(
-            zk, ["/root/leaf", "/root/branch"], progress
-        )
+    not_empty_indices = _delete_candidates(zk, ["/root/leaf", "/root/branch"], progress)
 
     assert not_empty_indices == [1]
     assert progress == _DeleteCounts(deleted=1, not_empty=1)
     assert zk.transaction_sizes == [2]
-    assert "/root/leaf" not in str(mock_logging.method_calls)
-    assert "/root/branch" not in str(mock_logging.method_calls)
 
 
 def test_delete_candidates_preserves_counts_on_unexpected_failure() -> None:
@@ -163,7 +168,6 @@ def test_delete_candidates_preserves_counts_on_unexpected_failure() -> None:
     zk.fail_transactions = 1
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch.object(zk, "delete", side_effect=[None, RuntimeError("connection lost")]),
         pytest.raises(RuntimeError, match="connection lost"),
     ):
@@ -176,8 +180,7 @@ def test_delete_candidates_reports_absent_member() -> None:
     zk = FakeZooKeeper({"/root": set()})
     progress = _DeleteCounts()
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        not_empty_indices = _delete_candidates(zk, ["/root/missing"], progress)
+    not_empty_indices = _delete_candidates(zk, ["/root/missing"], progress)
 
     assert not_empty_indices == []
     assert progress == _DeleteCounts(already_absent=1)
@@ -207,8 +210,7 @@ def test_large_delete_does_not_read_each_leaf() -> None:
         }
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root"]
@@ -225,7 +227,6 @@ def test_direct_child_count_skips_small_tree_probe() -> None:
     )
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
             "ch_tools.chadmin.internal.zookeeper."
             "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
@@ -252,8 +253,7 @@ def test_large_delete_descends_only_into_nonempty_candidates() -> None:
         }
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root/branch"]
@@ -281,7 +281,6 @@ def test_large_delete_batches_are_parent_local_and_bounded() -> None:
     )
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
             "ch_tools.chadmin.internal.zookeeper."
             "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
@@ -319,7 +318,6 @@ def test_bounded_scan_does_not_queue_a_large_nested_directory() -> None:
     )
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
             "ch_tools.chadmin.internal.zookeeper."
             "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
@@ -362,8 +360,7 @@ def test_large_delete_retries_a_finite_creation_race() -> None:
         continuous=False,
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.created == 1
@@ -380,13 +377,11 @@ def test_large_delete_aborts_after_three_sweeps_with_continuous_writer() -> None
         continuous=True,
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        with pytest.raises(RuntimeError, match="after 3 sweeps"):
-            delete_recursive(zk, ["/root"], max_sweeps=3)
+    with pytest.raises(RuntimeError, match="after 3 sweeps"):
+        delete_recursive(zk, ["/root"], max_sweeps=3)
 
     assert zk.created == 3
     assert zk.get_children_calls == ["/root", "/root", "/root"]
-    mock_logging.error.assert_called_once()
 
 
 def test_small_delete_does_not_select_large_algorithm() -> None:
@@ -397,39 +392,28 @@ def test_small_delete_does_not_select_large_algorithm() -> None:
         }
     )
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root/leaf"]
     assert zk.transaction_paths == [["/root/leaf", "/root"]]
-    assert not any(
-        "Using large recursive" in call.args[0]
-        for call in mock_logging.info.call_args_list
-    )
 
 
 def test_failed_small_transaction_rereads_children_in_large_mode() -> None:
     zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
     zk.fail_transactions = 1
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root/leaf", "/root"]
-    assert any(
-        "switching to large" in call.args[0]
-        for call in mock_logging.info.call_args_list
-    )
 
 
 def test_failed_atomic_leaf_rereads_children_in_large_mode() -> None:
     zk = FakeZooKeeper({"/root": set()})
     zk.fail_transactions = 1
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        delete_recursive(zk, ["/root"])
+    delete_recursive(zk, ["/root"])
 
     assert zk.children == {}
     assert zk.get_children_calls == ["/root", "/root"]
@@ -446,7 +430,6 @@ def test_delete_timeout_stops_before_next_batch_and_checks_root() -> None:
     )
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging"),
         patch(
             "ch_tools.chadmin.internal.zookeeper."
             "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
@@ -467,64 +450,40 @@ def test_delete_timeout_stops_before_next_batch_and_checks_root() -> None:
     assert zk.exists_calls[-1] == "/root"
 
 
-def test_large_delete_logs_algorithm_selection_and_completion() -> None:
-    leaf_names = {f"leaf-{index}" for index in range(10_001)}
+def test_sweep_accumulates_counts_across_batches() -> None:
     zk = FakeZooKeeper(
         {
-            "/root": leaf_names,
-            **{f"/root/{leaf}": set() for leaf in leaf_names},
+            "/root": {"first", "second", "third"},
+            "/root/first": set(),
+            "/root/second": set(),
+            "/root/third": set(),
         }
     )
-
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        delete_recursive(zk, ["/root"])
-
-    messages = [call.args[0] for call in mock_logging.info.call_args_list]
-    assert any("Using large recursive" in message for message in messages)
-    assert any("completed" in message for message in messages)
-
-
-def test_large_delete_logs_aggregate_progress_without_candidate_names() -> None:
-    zk = FakeZooKeeper(
-        {
-            "/root": {"private-leaf-0", "private-leaf-1", "private-leaf-2"},
-            "/root/private-leaf-0": set(),
-            "/root/private-leaf-1": set(),
-            "/root/private-leaf-2": set(),
-        }
-    )
-
-    with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging,
-        patch(
-            "ch_tools.chadmin.internal.zookeeper."
-            "RECURSIVE_DELETE_TRANSACTION_MAX_OPS",
-            2,
-        ),
-        patch(
-            "ch_tools.chadmin.internal.zookeeper.LARGE_RECURSIVE_DELETE_LOG_INTERVAL", 2
-        ),
+    progress = _DeleteProgress()
+    with patch(
+        "ch_tools.chadmin.internal.zookeeper.RECURSIVE_DELETE_TRANSACTION_MAX_OPS", 2
     ):
-        delete_recursive(zk, ["/root"])
+        retained, deadline_reached = _delete_sweep(zk, "/root", progress)
 
-    messages = str(mock_logging.method_calls)
-    assert "in progress" in messages
-    assert "sweep" in messages
-    assert "private-leaf" not in messages
+    assert zk.children == {}
+    assert progress.counts == _DeleteCounts(deleted=4)
+    assert retained == 0
+    assert not deadline_reached
+    assert zk.transaction_sizes == [2, 1, 1]
 
 
-def test_small_dry_run_logs_all_paths() -> None:
+def test_small_dry_run_visits_tree_without_deleting() -> None:
     zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        delete_recursive(zk, ["/root"], dry_run=True)
+    delete_recursive(zk, ["/root"], dry_run=True)
 
     assert zk.children == {"/root": {"leaf"}, "/root/leaf": set()}
-    mock_logging.info.assert_any_call("Got {} nodes to remove.", 2)
-    mock_logging.info.assert_any_call("Would delete nodes: {}", ["/root", "/root/leaf"])
+    assert zk.transaction_paths == []
+    assert zk.delete_calls == []
+    assert zk.get_children_calls == ["/root", "/root/leaf"]
 
 
-def test_large_dry_run_counts_all_nodes_without_logging_paths() -> None:
+def test_dry_run_visits_all_nodes_beyond_preview_limit() -> None:
     zk = FakeZooKeeper(
         {
             "/root": {"private-leaf-0", "private-leaf-1", "private-leaf-2"},
@@ -535,7 +494,6 @@ def test_large_dry_run_counts_all_nodes_without_logging_paths() -> None:
     )
 
     with (
-        patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging,
         patch(
             "ch_tools.chadmin.internal.zookeeper."
             "RECURSIVE_DELETE_DRY_RUN_MAX_LISTED_PATHS",
@@ -545,10 +503,10 @@ def test_large_dry_run_counts_all_nodes_without_logging_paths() -> None:
         delete_recursive(zk, ["/root"], dry_run=True)
 
     assert len(zk.children) == 4
-    mock_logging.info.assert_any_call("Got {} nodes to remove.", 4)
-    messages = str(mock_logging.info.call_args_list)
-    assert "path list omitted" in messages
-    assert "private-leaf" not in messages
+    assert zk.transaction_paths == []
+    assert zk.delete_calls == []
+    assert set(zk.get_children_calls) == set(zk.children)
+    assert len(zk.get_children_calls) == len(zk.children)
 
 
 class UnconfirmedDeletionZooKeeper(FakeZooKeeper):
@@ -570,11 +528,8 @@ class UnconfirmedDeletionZooKeeper(FakeZooKeeper):
 def test_delete_reports_error_if_root_absence_is_not_confirmed() -> None:
     zk = UnconfirmedDeletionZooKeeper({"/root": set()})
 
-    with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        with pytest.raises(RuntimeError, match="root still exists"):
-            delete_recursive(zk, ["/root"])
-
-    mock_logging.error.assert_called_once()
+    with pytest.raises(RuntimeError, match="root still exists"):
+        delete_recursive(zk, ["/root"])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -8,7 +8,11 @@ from click.testing import CliRunner
 from kazoo.exceptions import NoNodeError, NotEmptyError
 
 from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
-from ch_tools.chadmin.internal.zookeeper import delete_recursive
+from ch_tools.chadmin.internal.zookeeper import (
+    _DeleteProgress,
+    delete_nodes_transaction,
+    delete_recursive,
+)
 
 PATH = "/clickhouse/task_queue/ddl/query/shards/replica1:9440,replica2:9440/executed"
 
@@ -69,6 +73,66 @@ class FakeZooKeeper:
         if parent in self.children:
             self.children[parent].discard(os.path.basename(path))
         del self.children[path]
+
+
+class FixedResultTransaction:
+    def __init__(self, result: list[Any]) -> None:
+        self.result = result
+
+    def delete(self, path: str) -> None:
+        pass
+
+    def commit(self) -> list[Any]:
+        return self.result
+
+
+class ShrinkingRecursiveDeleteZooKeeper:
+    def __init__(self) -> None:
+        self.delete_attempts = 0
+
+    def transaction(self) -> FixedResultTransaction:
+        return FixedResultTransaction([NotEmptyError()])
+
+    def exists(self, path: str) -> Any:
+        return SimpleNamespace(children_count=4 - self.delete_attempts)
+
+    def delete(self, path: str, recursive: bool = False) -> None:
+        self.delete_attempts += 1
+        if self.delete_attempts <= 3:
+            raise NotEmptyError
+
+
+def test_small_fallback_resets_stagnation_when_child_count_decreases() -> None:
+    zk = ShrinkingRecursiveDeleteZooKeeper()
+    progress = _DeleteProgress()
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_nodes_transaction(zk, ["/root"], progress)
+
+    assert zk.delete_attempts == 4
+    assert progress == _DeleteProgress(deleted=1)
+
+
+class MissingRecursiveDeleteZooKeeper:
+    def __init__(self) -> None:
+        self.delete_attempts = 0
+
+    def transaction(self) -> FixedResultTransaction:
+        return FixedResultTransaction([NoNodeError()])
+
+    def delete(self, path: str, recursive: bool = False) -> None:
+        self.delete_attempts += 1
+
+
+def test_small_fallback_counts_missing_transaction_target_as_absent() -> None:
+    zk = MissingRecursiveDeleteZooKeeper()
+    progress = _DeleteProgress()
+
+    with patch("ch_tools.chadmin.internal.zookeeper.logging"):
+        delete_nodes_transaction(zk, ["/missing"], progress)
+
+    assert zk.delete_attempts == 0
+    assert progress == _DeleteProgress(already_absent=1)
 
 
 def test_large_delete_does_not_read_each_leaf() -> None:
@@ -235,7 +299,8 @@ def test_small_delete_does_not_retry_forever_with_a_busy_writer() -> None:
         with pytest.raises(RuntimeError, match="does not converge"):
             delete_recursive(zk, ["/root"])
 
-    assert zk.root_delete_attempts == 3
+    # First failure establishes the baseline; next three stagnant windows abort.
+    assert zk.root_delete_attempts == 4
 
 
 def test_large_delete_logs_algorithm_selection_and_completion() -> None:

--- a/tests/unit/chadmin/test_zookeeper.py
+++ b/tests/unit/chadmin/test_zookeeper.py
@@ -10,8 +10,7 @@ from kazoo.exceptions import NoNodeError, NotEmptyError
 from ch_tools.chadmin.cli.zookeeper_group import zookeeper_group
 from ch_tools.chadmin.internal.zookeeper import (
     _delete_candidates,
-    _DeleteOutcome,
-    _DeleteProgress,
+    _DeleteCounts,
     _path_delete_size,
     _probe_subtree,
     delete_recursive,
@@ -124,12 +123,14 @@ def test_delete_candidates_reports_successful_transaction() -> None:
     zk = FakeZooKeeper(
         {"/root": {"first", "second"}, "/root/first": set(), "/root/second": set()}
     )
-    progress = _DeleteProgress()
+    progress = _DeleteCounts()
 
-    outcomes = _delete_candidates(zk, ["/root/first", "/root/second"], progress)
+    not_empty_indices = _delete_candidates(
+        zk, ["/root/first", "/root/second"], progress
+    )
 
-    assert outcomes == [_DeleteOutcome.DELETED, _DeleteOutcome.DELETED]
-    assert progress == _DeleteProgress(deleted=2)
+    assert not_empty_indices == []
+    assert progress == _DeleteCounts(deleted=2)
     assert zk.transaction_sizes == [2]
 
 
@@ -142,41 +143,58 @@ def test_delete_candidates_falls_back_to_individual_outcomes() -> None:
             "/root/leaf": set(),
         }
     )
-    progress = _DeleteProgress()
+    progress = _DeleteCounts()
 
     with patch("ch_tools.chadmin.internal.zookeeper.logging") as mock_logging:
-        outcomes = _delete_candidates(zk, ["/root/leaf", "/root/branch"], progress)
+        not_empty_indices = _delete_candidates(
+            zk, ["/root/leaf", "/root/branch"], progress
+        )
 
-    assert outcomes == [_DeleteOutcome.DELETED, _DeleteOutcome.NOT_EMPTY]
-    assert progress == _DeleteProgress(deleted=1, not_empty=1)
+    assert not_empty_indices == [1]
+    assert progress == _DeleteCounts(deleted=1, not_empty=1)
     assert zk.transaction_sizes == [2]
     assert "/root/leaf" not in str(mock_logging.method_calls)
     assert "/root/branch" not in str(mock_logging.method_calls)
 
 
+def test_delete_candidates_preserves_counts_on_unexpected_failure() -> None:
+    zk = FakeZooKeeper({"/root": set()})
+    counts = _DeleteCounts()
+    zk.fail_transactions = 1
+
+    with (
+        patch("ch_tools.chadmin.internal.zookeeper.logging"),
+        patch.object(zk, "delete", side_effect=[None, RuntimeError("connection lost")]),
+        pytest.raises(RuntimeError, match="connection lost"),
+    ):
+        _delete_candidates(zk, ["/root/first", "/root/second"], counts)
+
+    assert counts == _DeleteCounts(deleted=1)
+
+
 def test_delete_candidates_reports_absent_member() -> None:
     zk = FakeZooKeeper({"/root": set()})
-    progress = _DeleteProgress()
+    progress = _DeleteCounts()
 
     with patch("ch_tools.chadmin.internal.zookeeper.logging"):
-        outcomes = _delete_candidates(zk, ["/root/missing"], progress)
+        not_empty_indices = _delete_candidates(zk, ["/root/missing"], progress)
 
-    assert outcomes == [_DeleteOutcome.ABSENT]
-    assert progress == _DeleteProgress(already_absent=1)
+    assert not_empty_indices == []
+    assert progress == _DeleteCounts(already_absent=1)
 
 
 def test_delete_candidates_skips_multi_for_oversized_singleton() -> None:
     zk = FakeZooKeeper({"/root": {"leaf"}, "/root/leaf": set()})
-    progress = _DeleteProgress()
+    progress = _DeleteCounts()
 
     with patch(
         "ch_tools.chadmin.internal.zookeeper." "RECURSIVE_DELETE_TRANSACTION_MAX_BYTES",
         1,
     ):
-        outcomes = _delete_candidates(zk, ["/root/leaf"], progress)
+        not_empty_indices = _delete_candidates(zk, ["/root/leaf"], progress)
 
-    assert outcomes == [_DeleteOutcome.DELETED]
-    assert progress == _DeleteProgress(deleted=1)
+    assert not_empty_indices == []
+    assert progress == _DeleteCounts(deleted=1)
     assert zk.transaction_sizes == []
 
 


### PR DESCRIPTION
Recursive deletion stalled on a tree with ~25 million nodes.

Small trees use one children-first transaction (up to 1,000 operations / estimated 512 KiB). Larger trees use bounded sibling batches and descend into nonempty nodes; failed transactions fall back to individual deletes. Surviving branches are retried in later sweeps. Success requires root absence.

`--max-sweeps` defaults to 3 (0 = unlimited); `--delete-timeout` sets a soft deadline. Dry-run limits listed paths to 1,000. `get_children` still allocates the complete direct-child list.

Tests: 252 unit tests passed. Added Behave cases for 2,001 leaves and 1,001 nonempty branches; full execution left to CI. Optional local Docker stress test:

```sh
bash tests/stress/run_zookeeper_delete.sh --leaves 25000000 --timeout 7200
```

Verified 25 million direct children plus root deleted in one sweep: **613.88 s**, deletion-client peak RSS **2.88 GiB**, root absence confirmed. Seeding took 353.15 s. Server: Keeper 26.3.12.3, 4 CPUs / 16 GiB, `force_sync=false`. RSS was measured with the earlier separate-worker runner; the simplified runner reports whole-process RSS.

Also replaces `tcp_ssl_port` with `tcp_port_secure` in test configuration: ClickHouse 26.8 rejects the old key, breaking the `latest` CI matrix.
